### PR TITLE
feat(security): gate API GET reads on Origin allowlist + v2 API-keys design doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Exempt by design (no `Origin` header reaches them):
 
 Server-side build-time fetchers (SSGs that read comments at deploy time)
 will now get 403s. Workaround: consume `GET /feed/:slug` (Atom, ungated)
-until the planned API-keys system ships.
+until the planned API-keys system ships — design lives in
+[`docs/api-keys-design.md`](docs/api-keys-design.md) (not implemented in
+v1).
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ your local archive.
 - **Re-render**: bumping the markdown sanitizer? Run
   `npm run rerender` to re-render stored comments in place.
 
+## Access control
+
+Your instance is gated by `ALLOWED_ORIGINS` (set in `wrangler.toml`,
+comma-separated, no wildcards). Every request under `/api/*` — including
+plain GET reads of comment trees, counts, and config — must carry an
+`Origin` header matching the allowlist. Browser fetches from your own
+sites send `Origin` automatically and continue to work; direct curl /
+scraper hits to `/api/v1/*` now return `403 err.origin.forbidden`.
+
+Exempt by design (no `Origin` header reaches them):
+
+- `GET /api/v1/health` — uptime probes
+- `GET /api/v1/auth/:provider/{start,callback}` — OAuth top-level navigation
+- `GET /feed/:slug`, `GET /c/:id`, `GET /embed/:slug`, `GET /embed.js` —
+  outside the `/api/*` gate; intentionally public
+
+Server-side build-time fetchers (SSGs that read comments at deploy time)
+will now get 403s. Workaround: consume `GET /feed/:slug` (Atom, ungated)
+until the planned API-keys system ships.
+
 ## Privacy
 
 Garrul stores:

--- a/docs/api-keys-design.md
+++ b/docs/api-keys-design.md
@@ -1,0 +1,215 @@
+# API keys — v2 design (not implemented)
+
+This is a **forward-looking design** for a server-issued API-key system.
+**No code in v1 implements it.** v1's security boundary is the
+`ALLOWED_ORIGINS` allowlist enforced on every method under `/api/*` by
+`src/lib/cors.ts` — that already handles the "stop random sites from
+embedding my widget" threat for browser-loaded clients.
+
+API keys earn their keep only when one of the following is in play:
+
+1. **Programmatic / non-browser clients** that legitimately need
+   access (e.g., an SSG that pulls comments at build time, a backup
+   script, an importer).
+2. **Multi-tenant SaaS.** If Garrul ever runs as a hosted offering,
+   per-tenant keys are the natural authorization boundary.
+3. **Per-site quotas / accounting.** Rate-limit and bill against a
+   key, not a hashed IP.
+
+If none of those motivations apply to your deployment, you do not
+need this system. Origin gating is enough.
+
+---
+
+## Non-goals (do NOT design these in)
+
+- **Securing the browser widget.** Any key embedded in `embed.js` is
+  publicly readable. Origin enforcement is the actual lever there.
+- **End-user authentication.** Sessions cover that
+  (`src/lib/session.ts`).
+- **Replacing `ALLOWED_ORIGINS`.** Keys are additive — a request can
+  satisfy *either* (a) Origin allowlist or (b) a valid key. The key
+  path exists for non-browser consumers; the Origin path stays the
+  default for the widget.
+
+---
+
+## Wire format
+
+```
+Authorization: Bearer grl_<32-hex>
+```
+
+- Prefix `grl_` so leaked keys are visually identifiable in logs and
+  scrub-able by GitHub secret scanning (apply for a partner token
+  prefix registration when this ships).
+- 32-hex (16 bytes) random body. Generate with `crypto.getRandomValues`.
+- No other auth schemes accepted on `/api/*`. Basic / cookie / etc.
+  are not API keys and must not be interpreted as such.
+
+The raw key is shown **once** at issue time and never persisted in
+plaintext — we store only `key_hash`.
+
+---
+
+## Schema
+
+New table, separate migration (`src/db/migrations/NNNN_api_keys.sql`):
+
+```sql
+CREATE TABLE api_keys (
+  id          TEXT PRIMARY KEY,                  -- ULID
+  key_hash    TEXT NOT NULL UNIQUE,              -- sha256(raw_key)
+  label       TEXT NOT NULL,                     -- human label, e.g. "ssg-builder"
+  origin_bound TEXT,                             -- nullable; if set, request Origin must match
+  scopes      TEXT NOT NULL,                     -- comma-separated, e.g. "read:comments,read:counts"
+  created_at  INTEGER NOT NULL,                  -- unix ms
+  last_used_at INTEGER,                          -- unix ms, updated on each successful auth
+  revoked_at  INTEGER                            -- nullable; non-null = revoked
+);
+
+CREATE INDEX api_keys_revoked_at ON api_keys (revoked_at);
+```
+
+**Hashing.** Use SHA-256 of the raw key, no salt. Keys are 128 bits of
+random already — salting buys nothing and breaks the lookup index. (We
+hash, not store plaintext, so a DB leak doesn't grant access.)
+
+**No `tenant_id` in v1 of keys.** Add it when the multi-tenant
+migration lands; design the column nullable for back-compat.
+
+---
+
+## Scopes
+
+Comma-separated string column for simplicity. Initial vocabulary:
+
+| Scope | Grants |
+|---|---|
+| `read:comments` | GET `/api/v1/comments`, `/counts` |
+| `write:comments` | POST/PATCH/DELETE `/api/v1/comments` |
+| `read:config` | GET `/api/v1/config` |
+| `admin` | All admin routes (rarely issued; prefer session-based admin) |
+
+The middleware checks `scopes.includes(required_scope)` per route.
+Per-route required scopes are declared via Hono route metadata when
+the keys feature ships.
+
+---
+
+## Middleware ordering
+
+The key check sits **alongside** the Origin check, not in place of it.
+Both run in `src/lib/cors.ts` (or a new `apiAuth` middleware in front
+of it — TBD during build):
+
+```
+1. OPTIONS preflight → handle, return 204.
+2. If a carve-out path (health, OAuth) → next().
+3. If Authorization: Bearer grl_* is present:
+     a. Look up by sha256(key); 401 if missing or revoked.
+     b. If origin_bound is set and request Origin differs → 403.
+     c. Check required_scope; 403 if missing.
+     d. Update last_used_at (best-effort, KV-cached to avoid D1 write per req).
+     e. next().  // Origin check skipped; key was the authorization.
+4. Else fall back to current Origin-allowlist behavior.
+```
+
+**Key takes precedence over Origin.** A valid key authorizes the
+request regardless of Origin. If a holder wants Origin-binding for
+defense-in-depth (e.g., they only ever use the key from one server),
+they set `origin_bound` at issue time and the middleware enforces it.
+
+---
+
+## Admin UI
+
+New route group `/admin/api-keys` (reuses the admin session gate from
+`src/routes/admin.ts`):
+
+- `GET /admin/api-keys` — list (label, scopes, origin_bound, last_used_at, revoked_at).
+- `POST /admin/api-keys` — create. Returns raw key in the response **once**, with a banner: "Copy this now; it will not be shown again."
+- `POST /admin/api-keys/:id/revoke` — soft-delete (`revoked_at = now`).
+- No rotation primitive in v1 of keys — revoke + reissue is the workflow.
+
+---
+
+## Rate-limit integration
+
+`src/lib/ratelimit.ts` currently keys buckets on hashed IP. With
+keys present, key on `api_key_id` instead — this lets you cut off
+a single misbehaving consumer without throttling everyone behind
+their NAT.
+
+```
+const bucketKey = apiKeyId ?? ipHash;
+```
+
+Make the per-bucket limit configurable per key in v2 of keys (a
+`rate_limit_rpm` column or similar) — out of scope for the first
+build.
+
+---
+
+## Logging & telemetry
+
+- Log the key `id` (never the raw key, never the hash) on each request
+  that authenticates via key.
+- Emit an Analytics Engine event `apikey.used` with `{id, scope, path,
+  status}` — the same channel already used for `comment.posted`,
+  `ratelimit.hit`, etc.
+- Revocations log a single `apikey.revoked` line.
+
+---
+
+## Migration path from v1 → v2 of keys
+
+Designed-in extension points for SaaS:
+
+1. **`tenant_id` column.** Add to `api_keys`, `posts`, `comments`,
+   `subscriptions`. Existing single-tenant rows get a default tenant.
+2. **Tenant-scoped origin allowlists.** Move `ALLOWED_ORIGINS` from
+   env var to a per-tenant config row, keyed by `tenant_id`. The
+   middleware now resolves tenant from the key (or, for browser
+   requests, from the Origin → tenant map).
+3. **Per-tenant rate limits.** Already enabled by the `apiKeyId`
+   bucket key above.
+
+None of this is in v1 of keys — but the column shapes above don't
+preclude it.
+
+---
+
+## Open questions to resolve before building
+
+- **One key per consumer, or many?** Likely many (e.g., dev vs prod
+  keys for the same SSG). The label field is enough; no per-consumer
+  uniqueness constraint.
+- **Should self-hosters be able to opt out of keys entirely?** Yes —
+  keys are additive. If you never issue one, the middleware never
+  exercises the key path. No config flag needed.
+- **RSS feeds (`/feed/:slug`) — gate behind keys?** Probably not.
+  RSS is universally consumed by non-browser readers that don't
+  send any auth. Keep RSS ungated; if you want to lock the feed,
+  use Cloudflare WAF.
+- **Key in query string for downloads?** Some clients can't set
+  Authorization headers (e.g., browser-initiated downloads). Punt
+  to v3 of keys; for now, `Authorization` header only.
+- **Audit log for admin key actions?** Probably yes — small append-only
+  table or just Analytics Engine. Decide when building.
+
+---
+
+## What this design explicitly does NOT include
+
+- Key rotation primitives (revoke + reissue is the workflow).
+- OAuth2 client-credentials flow (overkill; we want a static bearer).
+- Per-key IP allowlists (origin_bound is the equivalent; IP allowlists
+  are operationally painful with Workers' edge network anyway).
+- A separate "service account" concept on top of keys (the key *is*
+  the service identity).
+
+---
+
+**Status:** design only. When building, start by spiking the migration
+and middleware on a branch; the admin UI can lag the protocol.

--- a/docs/api-keys-design.md
+++ b/docs/api-keys-design.md
@@ -62,7 +62,7 @@ CREATE TABLE api_keys (
   key_hash    TEXT NOT NULL UNIQUE,              -- sha256(raw_key)
   label       TEXT NOT NULL,                     -- human label, e.g. "ssg-builder"
   origin_bound TEXT,                             -- nullable; if set, request Origin must match
-  scopes      TEXT NOT NULL,                     -- comma-separated, e.g. "read:comments,read:counts"
+  scopes      TEXT NOT NULL,                     -- comma-separated, e.g. "read:comments,write:comments"
   created_at  INTEGER NOT NULL,                  -- unix ms
   last_used_at INTEGER,                          -- unix ms, updated on each successful auth
   revoked_at  INTEGER                            -- nullable; non-null = revoked
@@ -91,7 +91,21 @@ Comma-separated string column for simplicity. Initial vocabulary:
 | `read:config` | GET `/api/v1/config` |
 | `admin` | All admin routes (rarely issued; prefer session-based admin) |
 
-The middleware checks `scopes.includes(required_scope)` per route.
+**Scope check semantics.** Parse the column into a token set first,
+then check exact membership — never substring-match the raw string.
+Otherwise a future narrow scope like `read:comments_private` would
+silently grant `read:comments`.
+
+```ts
+// Right:
+const granted = new Set(row.scopes.split(",").map((s) => s.trim()));
+if (!granted.has(requiredScope)) return 403;
+
+// Wrong: substring match — a token "read:comments_extra" would satisfy
+// the check for "read:comments".
+if (!row.scopes.includes(requiredScope)) return 403;
+```
+
 Per-route required scopes are declared via Hono route metadata when
 the keys feature ships.
 

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -38,8 +38,8 @@ const matches = (origin: string, allowed: Set<string>): boolean => {
 	return allowed.has(origin);
 };
 
-const isCarveOut = (path: string): boolean =>
-	CARVE_OUT_PATHS.some((re) => re.test(path));
+const isCarveOut = (method: string, path: string): boolean =>
+	method === "GET" && CARVE_OUT_PATHS.some((re) => re.test(path));
 
 export const corsAndCsrf = (): MiddlewareHandler => {
 	return async (c, next) => {
@@ -70,9 +70,12 @@ export const corsAndCsrf = (): MiddlewareHandler => {
 
 		// Origin allowlist applies to ALL methods under /api/*, including GET.
 		// Carve-outs (health, OAuth start/callback) bypass because they
-		// legitimately receive no Origin header. Dev mode bypasses entirely
-		// so curl + local clients work without juggling Origin headers.
-		if (!isCarveOut(path) && !isDev) {
+		// legitimately receive no Origin header — but only for GET, the
+		// method they're actually invoked with. A future POST/PATCH on a
+		// carve-out path must NOT silently bypass the gate. Dev mode
+		// bypasses entirely so curl + local clients work without juggling
+		// Origin headers.
+		if (!isCarveOut(c.req.method, path) && !isDev) {
 			if (!origin || !matches(origin, allowed)) {
 				return c.json({ error: "err.origin.forbidden" }, 403);
 			}

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -4,15 +4,25 @@
  * ALLOWED_ORIGINS is a comma-separated list of origins permitted to embed
  * the widget. Used for both:
  *   - CORS preflight responses (Access-Control-Allow-* headers)
- *   - Origin-header check on state-changing requests (CSRF defense, since
- *     SameSite=None cookies opt out of the browser's default CSRF protection)
+ *   - Origin-header check on all requests under /api/* (CSRF defense, since
+ *     SameSite=None cookies opt out of the browser's default CSRF protection,
+ *     and a hard gate on Origin doubles as the lever that stops random sites
+ *     from using this instance — including for plain GET reads).
  *
  * Wildcards (*) are NOT supported — the spec disallows `*` together with
  * `credentials: include`, and we always want credentials.
+ *
+ * Carve-outs (CARVE_OUT_PATHS) bypass the Origin check entirely — used for
+ * routes that legitimately receive no Origin header (uptime probes, OAuth
+ * top-level browser navigation).
  */
 import type { MiddlewareHandler } from "hono";
 
-const STATE_CHANGING = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+const CARVE_OUT_PATHS: readonly RegExp[] = [
+	/^\/api\/v1\/health(\/|$)/,
+	/^\/api\/v1\/auth\/[^/]+\/start(\/|$)/,
+	/^\/api\/v1\/auth\/[^/]+\/callback(\/|$)/,
+];
 
 const parseAllowed = (raw: string | undefined): Set<string> => {
 	if (!raw) return new Set();
@@ -28,15 +38,16 @@ const matches = (origin: string, allowed: Set<string>): boolean => {
 	return allowed.has(origin);
 };
 
+const isCarveOut = (path: string): boolean =>
+	CARVE_OUT_PATHS.some((re) => re.test(path));
+
 export const corsAndCsrf = (): MiddlewareHandler => {
 	return async (c, next) => {
 		const origin = c.req.header("origin");
-		// `ALLOWED_ORIGINS` is declared on Bindings and is always a string.
-		// In dev we may also accept the special token "*dev*" to allow any
-		// origin, but that requires ENV=dev too.
 		const env = c.env as Record<string, string | undefined>;
 		const allowed = parseAllowed(env.ALLOWED_ORIGINS);
 		const isDev = env.ENV === "dev";
+		const path = c.req.path;
 
 		// CORS preflight.
 		if (c.req.method === "OPTIONS") {
@@ -57,10 +68,12 @@ export const corsAndCsrf = (): MiddlewareHandler => {
 			return c.body(null, 204);
 		}
 
-		// CSRF: state-changing requests must have a same-origin or allowlisted
-		// Origin. GET / HEAD / OPTIONS are exempt.
-		if (STATE_CHANGING.has(c.req.method)) {
-			if (!origin || (!matches(origin, allowed) && !isDev)) {
+		// Origin allowlist applies to ALL methods under /api/*, including GET.
+		// Carve-outs (health, OAuth start/callback) bypass because they
+		// legitimately receive no Origin header. Dev mode bypasses entirely
+		// so curl + local clients work without juggling Origin headers.
+		if (!isCarveOut(path) && !isDev) {
+			if (!origin || !matches(origin, allowed)) {
 				return c.json({ error: "err.origin.forbidden" }, 403);
 			}
 		}

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -18,10 +18,15 @@
  */
 import type { MiddlewareHandler } from "hono";
 
+// Anchored at both ends — an optional trailing slash is allowed for
+// path-normalization tolerance, but sub-paths like
+// `/api/v1/auth/github/start/admin` must NOT silently bypass the
+// Origin gate (defense-in-depth against future routes accidentally
+// inheriting carve-out behavior).
 const CARVE_OUT_PATHS: readonly RegExp[] = [
-	/^\/api\/v1\/health(\/|$)/,
-	/^\/api\/v1\/auth\/[^/]+\/start(\/|$)/,
-	/^\/api\/v1\/auth\/[^/]+\/callback(\/|$)/,
+	/^\/api\/v1\/health\/?$/,
+	/^\/api\/v1\/auth\/[^/]+\/start\/?$/,
+	/^\/api\/v1\/auth\/[^/]+\/callback\/?$/,
 ];
 
 const parseAllowed = (raw: string | undefined): Set<string> => {

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Origin-allowlist + CSRF middleware (src/lib/cors.ts).
+ *
+ * Same stub-Hono-context approach as session.test.ts — no Miniflare needed,
+ * the middleware only touches c.req.{header,method,path}, c.env, c.header,
+ * c.body, and c.json.
+ */
+import { describe, it, expect } from "vitest";
+import type { MiddlewareHandler } from "hono";
+import { corsAndCsrf } from "../src/lib/cors";
+
+type Outcome =
+	| { kind: "blocked"; status: number; body: unknown }
+	| { kind: "preflight"; status: number; headers: Record<string, string> }
+	| { kind: "passed"; headers: Record<string, string> };
+
+const runMiddleware = async (
+	mw: MiddlewareHandler,
+	opts: {
+		method: string;
+		path: string;
+		origin?: string;
+		env?: Record<string, string | undefined>;
+	},
+): Promise<Outcome> => {
+	const headers: Record<string, string> = {};
+	let nextCalled = false;
+	let earlyResponse:
+		| { kind: "blocked"; status: number; body: unknown }
+		| { kind: "preflight"; status: number }
+		| null = null;
+
+	const ctx = {
+		env: opts.env ?? { ALLOWED_ORIGINS: "https://blog.example.com" },
+		req: {
+			header: (name: string) =>
+				name.toLowerCase() === "origin" ? opts.origin : undefined,
+			method: opts.method,
+			path: opts.path,
+		},
+		header: (name: string, value: string) => {
+			headers[name] = value;
+		},
+		body: (_b: unknown, status: number) => {
+			earlyResponse = { kind: "preflight", status };
+			return undefined as unknown as Response;
+		},
+		json: (body: unknown, status: number) => {
+			earlyResponse = { kind: "blocked", status, body };
+			return undefined as unknown as Response;
+		},
+	};
+
+	const next = async (): Promise<void> => {
+		nextCalled = true;
+	};
+
+	// Hono's middleware signature is (c, next) => Promise<void | Response>.
+	// Our stub matches its surface area for the parts cors.ts uses.
+	await (mw as unknown as (c: typeof ctx, n: typeof next) => Promise<void>)(
+		ctx,
+		next,
+	);
+
+	if (earlyResponse?.kind === "blocked") return earlyResponse;
+	if (earlyResponse?.kind === "preflight") {
+		return { kind: "preflight", status: earlyResponse.status, headers };
+	}
+	if (!nextCalled) {
+		throw new Error("middleware neither blocked nor called next()");
+	}
+	return { kind: "passed", headers };
+};
+
+describe("corsAndCsrf — Origin allowlist on /api/*", () => {
+	const mw = corsAndCsrf();
+
+	describe("GET reads now require Origin (hardening)", () => {
+		it("GET /api/v1/comments with no Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/comments",
+			});
+			expect(r.kind).toBe("blocked");
+			if (r.kind !== "blocked") return;
+			expect(r.status).toBe(403);
+			expect(r.body).toEqual({ error: "err.origin.forbidden" });
+		});
+
+		it("GET /api/v1/comments with disallowed Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/comments",
+				origin: "https://evil.example.com",
+			});
+			expect(r.kind).toBe("blocked");
+			if (r.kind !== "blocked") return;
+			expect(r.status).toBe(403);
+		});
+
+		it("GET /api/v1/comments with allowed Origin → passes, CORS headers echoed", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/comments",
+				origin: "https://blog.example.com",
+			});
+			expect(r.kind).toBe("passed");
+			if (r.kind !== "passed") return;
+			expect(r.headers["Access-Control-Allow-Origin"]).toBe(
+				"https://blog.example.com",
+			);
+			expect(r.headers["Access-Control-Allow-Credentials"]).toBe("true");
+			expect(r.headers.Vary).toBe("Origin");
+		});
+
+		it("GET /api/v1/counts with no Origin → 403 (also gated)", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/counts",
+			});
+			expect(r.kind).toBe("blocked");
+		});
+
+		it("GET /api/v1/config with no Origin → 403 (also gated)", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/config",
+			});
+			expect(r.kind).toBe("blocked");
+		});
+	});
+
+	describe("State-changing methods still gated (existing behavior)", () => {
+		it("POST /api/v1/comments with no Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "POST",
+				path: "/api/v1/comments",
+			});
+			expect(r.kind).toBe("blocked");
+			if (r.kind !== "blocked") return;
+			expect(r.status).toBe(403);
+		});
+
+		it("POST /api/v1/comments with allowed Origin → passes", async () => {
+			const r = await runMiddleware(mw, {
+				method: "POST",
+				path: "/api/v1/comments",
+				origin: "https://blog.example.com",
+			});
+			expect(r.kind).toBe("passed");
+		});
+
+		it("DELETE /api/v1/comments/abc with disallowed Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "DELETE",
+				path: "/api/v1/comments/abc",
+				origin: "https://evil.example.com",
+			});
+			expect(r.kind).toBe("blocked");
+		});
+	});
+
+	describe("Carve-outs bypass the Origin check", () => {
+		it("GET /api/v1/health with no Origin → passes (uptime probes)", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/health",
+			});
+			expect(r.kind).toBe("passed");
+		});
+
+		it("GET /api/v1/auth/github/start with no Origin → passes (OAuth nav)", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/auth/github/start",
+			});
+			expect(r.kind).toBe("passed");
+		});
+
+		it("GET /api/v1/auth/google/callback with no Origin → passes (OAuth callback)", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/auth/google/callback",
+			});
+			expect(r.kind).toBe("passed");
+		});
+
+		it("carve-out match is anchored — /api/v1/healthcheck does NOT bypass", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/healthcheck",
+			});
+			expect(r.kind).toBe("blocked");
+		});
+
+		it("carve-out match is anchored — /api/v1/auth/foo (no /start) does NOT bypass", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/auth/foo",
+			});
+			expect(r.kind).toBe("blocked");
+		});
+	});
+
+	describe("Dev mode escape hatch", () => {
+		it("ENV=dev with no Origin still passes on a normally-gated GET", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/comments",
+				env: { ALLOWED_ORIGINS: "", ENV: "dev" },
+			});
+			expect(r.kind).toBe("passed");
+		});
+
+		it("ENV=dev with arbitrary Origin still passes on POST", async () => {
+			const r = await runMiddleware(mw, {
+				method: "POST",
+				path: "/api/v1/comments",
+				origin: "https://anything.example.com",
+				env: { ALLOWED_ORIGINS: "", ENV: "dev" },
+			});
+			expect(r.kind).toBe("passed");
+		});
+	});
+
+	describe("CORS preflight (OPTIONS)", () => {
+		it("OPTIONS with allowed Origin → 204 with CORS headers", async () => {
+			const r = await runMiddleware(mw, {
+				method: "OPTIONS",
+				path: "/api/v1/comments",
+				origin: "https://blog.example.com",
+			});
+			expect(r.kind).toBe("preflight");
+			if (r.kind !== "preflight") return;
+			expect(r.status).toBe(204);
+			expect(r.headers["Access-Control-Allow-Origin"]).toBe(
+				"https://blog.example.com",
+			);
+			expect(r.headers["Access-Control-Allow-Methods"]).toMatch(/POST/);
+			expect(r.headers["Access-Control-Max-Age"]).toBe("86400");
+		});
+
+		it("OPTIONS with disallowed Origin → 204 with no CORS headers (browser will block)", async () => {
+			const r = await runMiddleware(mw, {
+				method: "OPTIONS",
+				path: "/api/v1/comments",
+				origin: "https://evil.example.com",
+			});
+			expect(r.kind).toBe("preflight");
+			if (r.kind !== "preflight") return;
+			expect(r.status).toBe(204);
+			expect(r.headers["Access-Control-Allow-Origin"]).toBeUndefined();
+		});
+	});
+
+	describe("ALLOWED_ORIGINS parsing", () => {
+		it("multi-value comma list — each origin allowed", async () => {
+			const env = {
+				ALLOWED_ORIGINS: "https://a.example.com, https://b.example.com",
+			};
+			for (const origin of [
+				"https://a.example.com",
+				"https://b.example.com",
+			]) {
+				const r = await runMiddleware(mw, {
+					method: "GET",
+					path: "/api/v1/comments",
+					origin,
+					env,
+				});
+				expect(r.kind).toBe("passed");
+			}
+		});
+
+		it("origin not on list is rejected even when list is non-empty", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/comments",
+				origin: "https://c.example.com",
+				env: {
+					ALLOWED_ORIGINS: "https://a.example.com, https://b.example.com",
+				},
+			});
+			expect(r.kind).toBe("blocked");
+		});
+	});
+});

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -200,6 +200,32 @@ describe("corsAndCsrf — Origin allowlist on /api/*", () => {
 			});
 			expect(r.kind).toBe("blocked");
 		});
+
+		it("carve-out is GET-only — POST /api/v1/health with no Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "POST",
+				path: "/api/v1/health",
+			});
+			expect(r.kind).toBe("blocked");
+			if (r.kind !== "blocked") return;
+			expect(r.status).toBe(403);
+		});
+
+		it("carve-out is GET-only — POST /api/v1/auth/github/start with no Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "POST",
+				path: "/api/v1/auth/github/start",
+			});
+			expect(r.kind).toBe("blocked");
+		});
+
+		it("carve-out is GET-only — PATCH /api/v1/auth/google/callback with no Origin → 403", async () => {
+			const r = await runMiddleware(mw, {
+				method: "PATCH",
+				path: "/api/v1/auth/google/callback",
+			});
+			expect(r.kind).toBe("blocked");
+		});
 	});
 
 	describe("Dev mode escape hatch", () => {

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -201,6 +201,34 @@ describe("corsAndCsrf — Origin allowlist on /api/*", () => {
 			expect(r.kind).toBe("blocked");
 		});
 
+		it("carve-out match rejects sub-paths — /api/v1/health/sub does NOT bypass", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/health/sub",
+			});
+			expect(r.kind).toBe("blocked");
+			if (r.kind !== "blocked") return;
+			expect(r.status).toBe(403);
+		});
+
+		it("carve-out match rejects sub-paths — /api/v1/auth/github/start/admin does NOT bypass", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/auth/github/start/admin",
+			});
+			expect(r.kind).toBe("blocked");
+			if (r.kind !== "blocked") return;
+			expect(r.status).toBe(403);
+		});
+
+		it("carve-out tolerates trailing slash — GET /api/v1/health/ still bypasses", async () => {
+			const r = await runMiddleware(mw, {
+				method: "GET",
+				path: "/api/v1/health/",
+			});
+			expect(r.kind).toBe("passed");
+		});
+
 		it("carve-out is GET-only — POST /api/v1/health with no Origin → 403", async () => {
 			const r = await runMiddleware(mw, {
 				method: "POST",


### PR DESCRIPTION
## Summary

- **Code change:** Extends `corsAndCsrf` middleware (`src/lib/cors.ts`) to apply the `ALLOWED_ORIGINS` allowlist to *every* method under `/api/*`, including GET reads. Previously only `POST/PATCH/DELETE` were gated, leaving comment trees, counts, and config endpoints reachable by any curl or third-party JS proxy.
- **Carve-outs** for routes that legitimately receive no `Origin` header: `GET /api/v1/health` (uptime monitors), `GET /api/v1/auth/:provider/{start,callback}` (OAuth top-level browser navigation). RSS feeds, permalinks, and the iframe page are mounted outside `/api/*` and remain unaffected.
- **Dev-mode bypass cleanup:** `ENV=dev` now cleanly bypasses the Origin check regardless of whether a header is present (previously a missing Origin still 403'd even in dev, which becomes painful once GETs are gated).
- **Design doc:** Adds `docs/api-keys-design.md` — forward-looking sketch of an API-keys system for non-browser consumers, multi-tenant SaaS, and per-site quotas. Not implemented in this PR; explicitly additive on top of the Origin allowlist.
- **README:** New "Access control" section documents the gating behavior, the carve-outs, and the SSG/server-side-fetcher workaround (consume `/feed/:slug` until keys ship).

## Commits

- `feat(security): gate API GET reads on Origin allowlist` — cors.ts + tests/cors.test.ts (19 new cases) + README note.
- `docs: add v2 API-keys design (not yet implemented)` — design doc + README pointer.

## Behavioral consequences

| Surface | Before | After |
|---|---|---|
| Widget fetches from an allowlisted origin | Works | Works (unchanged — browsers send `Origin`) |
| Widget fetches from a non-allowlisted origin | Worked (GET reads) | 403 on GET reads (intended hardening) |
| Direct curl to `GET /api/v1/comments` | 200 | 403 `err.origin.forbidden` |
| SSG build-time fetch with no Origin | 200 | 403 — workaround: consume `/feed/:slug` (RSS, ungated) |
| RSS feeds, permalinks, iframe page | Ungated | Ungated (outside `/api/*` mount) |
| Healthcheck, OAuth start/callback | Worked | Worked (carve-out) |

## Test plan

- [x] `npm test` — full suite passes (83 tests, 19 new in `tests/cors.test.ts`).
- [x] `npm run typecheck` — clean (both `tsconfig.json` and `tsconfig.widget.json`).
- [x] Live `wrangler dev` curl verification on port 8787:
  - `GET /api/v1/comments?slug=foo` no Origin → 403
  - same with `Origin: https://evil.example.com` → 403
  - same with `Origin: https://sumguy.com` → 200
  - same with `Origin: https://garrul.com` → 200
  - `GET /api/v1/health` no Origin → 200 (carve-out)
  - `GET /api/v1/auth/github/start` no Origin → reaches handler (503 due to blank `GH_CLIENT_ID` in `.dev.vars`, not 403)
  - `GET /api/v1/config` no Origin → 403
  - `GET /api/v1/config` with allowed Origin → 200
- [ ] Reviewer to spot-check: browser embed on an allowlisted page still loads comments + posts; embed on a non-allowlisted page fails gracefully with 403s in the network tab.

## Out of scope

- Implementing the API-keys system — only the design doc lands here.
- Multi-tenant schema changes (deferred to v2 per `CLAUDE.md`).
- Gating non-`/api` reads (RSS, permalinks, iframe page) — these are intentionally public.