### PR TITLE
feat(spam): layered opt-in anti-spam (heuristics + Akismet/Workers AI)

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -191,6 +191,27 @@ testing keys (`1x00000000...AA` for both). Without both values set the
 anonymous form blocks on posting. There is no "anonymous off" toggle
 in v1.
 
+### Optional extra anti-spam layers
+
+Three lightweight heuristics and a pluggable content classifier are
+available on top of Turnstile. **All off by default.** Flagged comments
+flip to `status='pending'` and land in the admin queue rather than
+being silently dropped.
+
+- `SPAM_HONEYPOT_MIN_MS` + `SPAM_FORM_TS_SECRET` — flag submissions
+  that arrive faster than wall-clock `N` ms after the form rendered.
+- `SPAM_LINK_THRESHOLD` — flag comments containing more than `N`
+  http(s)/mailto links.
+- `SPAM_FIRST_COMMENT_MODERATE=true` — every commenter's first-ever
+  comment goes to pending until you approve once.
+- `SPAM_PROVIDER` — set to `akismet` or `workers-ai` to enable a
+  content classifier (each has its own required secrets/bindings).
+
+See [`docs/ANTISPAM.md`](./docs/ANTISPAM.md) for the full layer
+breakdown, privacy tradeoffs (Akismet sends comment content off
+Cloudflare; Workers AI keeps it on-network), and recommended starter
+configs.
+
 ## 8. OAuth providers
 
 Two providers in v1: GitHub and Google. Generic OIDC is v2 backlog. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,13 @@ is on by default. From the end-user perspective:
    `/api/v1/comments`. The Worker verifies the Turnstile token, then
    creates a "ghost" user record keyed by the submitted name + hashed
    IP, and stores the comment under that ghost author.
+4. If the operator has enabled any **optional anti-spam layers**
+   (timing honeypot, link-count threshold, first-comment moderation,
+   Akismet, or Cloudflare Workers AI), a flagged comment is created
+   with `status='pending'` instead of `approved`. The widget surfaces
+   an "awaiting moderation" notice and the comment is hidden from the
+   public tree until an admin approves it from `/admin/queue`. None of
+   these layers are on by default; see `docs/ANTISPAM.md`.
 
 Anonymous authors have **no email**, so they're never accidentally
 notified on reply threads. They also have no provider avatar; instead

--- a/docs/ANTISPAM.md
+++ b/docs/ANTISPAM.md
@@ -1,0 +1,125 @@
+# Anti-spam
+
+Garrul defends against spam in layers. Everything documented here is **off by default** — turn on what you need.
+
+## What's always on
+
+These don't need configuration; they ship with every Garrul instance:
+
+- **Turnstile** — Cloudflare's CAPTCHA-alternative. Required for anonymous POSTs whenever `TURNSTILE_SITE_KEY` is set.
+- **Rate-limit** — KV-backed sliding window keyed on the hashed client IP. 1 comment per 10s and 5 per 10 min by default.
+- **Markdown sanitizer** — strict allowlist; only `https:`/`http:`/`mailto:` links survive, raw HTML and `<img>` are dropped, every link gets `rel="nofollow ugc"`.
+- **Field honeypot** — a hidden `website` input in the embed form. If a bot fills it, the POST is rejected with HTTP 400.
+
+## Optional layers
+
+All four heuristics + the classifier adapter flip a flagged comment to `status='pending'` so it lands in the admin queue at `/admin/queue?status=pending`. **Nothing is ever silently dropped.** You decide whether to approve.
+
+### 1. Honeypot timing (`SPAM_HONEYPOT_MIN_MS`)
+
+Bots typically POST immediately. Humans take seconds. The widget asks the server for a signed timestamp when the form loads; the server checks that enough wall-clock time passed before accepting.
+
+```toml
+SPAM_HONEYPOT_MIN_MS = "1500"   # flag if submit happens within 1.5s of form load
+```
+
+Also requires the HMAC secret:
+
+```
+wrangler secret put SPAM_FORM_TS_SECRET
+```
+
+Generate a strong random value (`openssl rand -hex 32`) and paste when prompted.
+
+### 2. Link-count threshold (`SPAM_LINK_THRESHOLD`)
+
+Counts `https?://` and `mailto:` occurrences in the comment body. Above the threshold, flag to pending.
+
+```toml
+SPAM_LINK_THRESHOLD = "3"   # flag any comment with more than 3 links
+```
+
+Strong signal against link-farm spam. Some legit comments (e.g. linking 4-5 papers in a technical thread) will get flagged — that's why this routes to the queue, not to the bin.
+
+### 3. First-comment moderation (`SPAM_FIRST_COMMENT_MODERATE`)
+
+Every new commenter's first-ever comment goes to `pending` until you approve once. Subsequent comments from the same author (same hashed IP for anonymous, same OAuth identity for signed-in users) post normally. Admins skip this check.
+
+```toml
+SPAM_FIRST_COMMENT_MODERATE = "true"
+```
+
+Highest precision of the three heuristics. Cost: you have to log in and approve. Use on low-traffic blogs; skip on busy ones.
+
+### 4. Content classifier (`SPAM_PROVIDER`)
+
+Pluggable third-party content classification. Pick one of:
+
+#### `akismet`
+
+```toml
+SPAM_PROVIDER = "akismet"
+```
+
+```
+wrangler secret put AKISMET_API_KEY     # your Akismet API key
+wrangler secret put AKISMET_SITE_URL    # public site URL, e.g. https://yourblog.example.com
+```
+
+**Privacy tradeoff.** Akismet receives the comment body, the author's display name, and the post URL. Garrul deliberately does **not** forward the raw client IP (it would conflict with the `ip-hash` design) — instead a constant placeholder is sent. This trims accuracy a little, but keeps Garrul's privacy posture intact.
+
+If you turn this on, **update your privacy policy** (template at [`docs/privacy-policy.template.md`](./privacy-policy.template.md)) to disclose that comment content is sent to Automattic. Akismet also requires a commercial license for paid sites — check their terms.
+
+#### `workers-ai`
+
+```toml
+SPAM_PROVIDER = "workers-ai"
+```
+
+Add an AI binding to `wrangler.toml`:
+
+```toml
+[ai]
+binding = "AI"
+```
+
+**Privacy posture.** Inference runs on Cloudflare's edge via your AI binding — no third-party API call leaves CF infrastructure. The classifier prompt is Llama-3.1-8b-Instruct asking SPAM/HAM. Verdicts are cached in the `RATE_LIMITS` KV namespace for 6 hours keyed on a SHA-256 hash of the body, so identical resubmissions don't re-bill.
+
+Tradeoff vs. Akismet: slower per check, generally pricier per inference, less spam-specific signal, but no third-party data egress. Good fit if your audience cares about that, or if you don't want to manage another vendor.
+
+### Combining
+
+Layers stack. With everything on, a comment is flagged if **any** signal trips. The classifier is only called when no heuristic has already flagged (saves cost/latency).
+
+## What's still possible (deferred)
+
+These aren't in the box yet — open an issue if you need them:
+
+- Disposable-email blocklist (relevant only for OAuth/notify-me flows).
+- IP-reputation lookups (StopForumSpam, AbuseIPDB) — would need to handle raw IPs, conflicts with privacy stance.
+- Bayesian / locally-trained classifier.
+- CleanTalk or other classifier vendors — the adapter interface is in `src/lib/spam/`; adding one is one new file.
+
+## Operating the queue
+
+Flagged comments appear at `/admin/queue?status=pending`. Each row has Approve / Spam / Delete buttons. Approving fires the `comment.approved` webhook and adds the comment to the public tree on next page load.
+
+The admin dashboard at `/admin` shows which anti-spam layers are active for the current deployment.
+
+## Logs
+
+When a comment is flagged, a JSON log line is emitted via `console.log`:
+
+```json
+{
+  "level": "info",
+  "msg": "spam.flagged",
+  "reasons": ["link_count:5", "first_comment"],
+  "post_slug": "hello-world",
+  "provider": "anon"
+}
+```
+
+Adapter failures (HTTP error, malformed response) emit `spam.adapter.error` with the provider name. **Comment bodies, author names, emails, and IPs are never logged** — only the signal names that fired.
+
+Tail with `wrangler tail` or query in your log aggregator.

--- a/docs/ANTISPAM.md
+++ b/docs/ANTISPAM.md
@@ -13,7 +13,7 @@ These don't need configuration; they ship with every Garrul instance:
 
 ## Optional layers
 
-All four heuristics + the classifier adapter flip a flagged comment to `status='pending'` so it lands in the admin queue at `/admin/queue?status=pending`. **Nothing is ever silently dropped.** You decide whether to approve.
+All three heuristics + the classifier adapter flip a flagged comment to `status='pending'` so it lands in the admin queue at `/admin/queue?status=pending`. **Nothing is ever silently dropped.** You decide whether to approve.
 
 ### 1. Honeypot timing (`SPAM_HONEYPOT_MIN_MS`)
 

--- a/docs/ANTISPAM.md
+++ b/docs/ANTISPAM.md
@@ -66,7 +66,7 @@ wrangler secret put AKISMET_API_KEY     # your Akismet API key
 wrangler secret put AKISMET_SITE_URL    # public site URL, e.g. https://yourblog.example.com
 ```
 
-**Privacy tradeoff.** Akismet receives the comment body, the author's display name, and the post URL. Garrul deliberately does **not** forward the raw client IP (it would conflict with the `ip-hash` design) — instead a constant placeholder is sent. This trims accuracy a little, but keeps Garrul's privacy posture intact.
+**Privacy tradeoff.** Akismet receives the comment body, the author's display name, and the post URL. Garrul deliberately does **not** forward the raw client IP (a constant placeholder is sent instead) or the OAuth-user email address. This trims accuracy a little, but keeps Garrul's privacy posture intact.
 
 If you turn this on, **update your privacy policy** (template at [`docs/privacy-policy.template.md`](./privacy-policy.template.md)) to disclose that comment content is sent to Automattic. Akismet also requires a commercial license for paid sites — check their terms.
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -55,6 +55,41 @@
       "name": "WEBHOOK_URL",
       "required": false,
       "addedIn": "1.0.0"
+    },
+    {
+      "name": "SPAM_PROVIDER",
+      "required": false,
+      "addedIn": "1.1.1"
+    },
+    {
+      "name": "AKISMET_API_KEY",
+      "required": false,
+      "addedIn": "1.1.1"
+    },
+    {
+      "name": "AKISMET_SITE_URL",
+      "required": false,
+      "addedIn": "1.1.1"
+    },
+    {
+      "name": "SPAM_LINK_THRESHOLD",
+      "required": false,
+      "addedIn": "1.1.1"
+    },
+    {
+      "name": "SPAM_HONEYPOT_MIN_MS",
+      "required": false,
+      "addedIn": "1.1.1"
+    },
+    {
+      "name": "SPAM_FIRST_COMMENT_MODERATE",
+      "required": false,
+      "addedIn": "1.1.1"
+    },
+    {
+      "name": "SPAM_FORM_TS_SECRET",
+      "required": false,
+      "addedIn": "1.1.1"
     }
   ],
   "kvNamespaces": [

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -346,13 +346,10 @@ export const getUsersByIds = async (
 };
 
 /**
- * Fetch all visible (non-spam, non-deleted-without-replies) comments for a
- * post. Caller assembles the tree; this just returns a flat ordered list.
- *
- * `deleted` comments ARE returned — the route layer replaces body_html with a
- * `[deleted]` placeholder iff the comment has surviving children, otherwise
- * filters it out entirely. Doing the visibility logic here would require an
- * extra query for child-existence per node.
+ * Fetch publicly visible comments for a post. Excludes `spam` (silent drop)
+ * and `pending` (admin-queue-only — never leaks via the public tree).
+ * Returned `deleted` comments are kept so the tree builder can preserve
+ * chain ancestry; their body_html is blanked at render time.
  */
 export const listCommentsForPost = async (
 	db: D1Database,
@@ -364,7 +361,7 @@ export const listCommentsForPost = async (
 			        renderer_version, status, edited_at, deleted_at,
 			        ip_hash, user_agent, created_at
 			 FROM comments
-			 WHERE post_slug = ? AND status != 'spam'
+			 WHERE post_slug = ? AND status NOT IN ('spam', 'pending')
 			 ORDER BY created_at ASC, id ASC`,
 		)
 		.bind(post_slug)

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -346,10 +346,11 @@ export const getUsersByIds = async (
 };
 
 /**
- * Fetch publicly visible comments for a post. Excludes `spam` (silent drop)
- * and `pending` (admin-queue-only — never leaks via the public tree).
- * Returned `deleted` comments are kept so the tree builder can preserve
- * chain ancestry; their body_html is blanked at render time.
+ * Fetch publicly visible comments for a post. Excludes `spam` and
+ * `pending` — both are stored in D1 and visible in the admin queue,
+ * but never leak via the public tree. Returned `deleted` comments are
+ * kept so the tree builder can preserve chain ancestry; their body_html
+ * is blanked at render time.
  */
 export const listCommentsForPost = async (
 	db: D1Database,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,15 @@ export type Bindings = {
 	PUBLIC_BASE_URL: string;
 	CANONICAL_URL?: string;
 	WEBHOOK_URL: string;
+	// Anti-spam (all optional; each feature opts in when its env var is set).
+	SPAM_PROVIDER?: string;
+	AKISMET_API_KEY?: string;
+	AKISMET_SITE_URL?: string;
+	AI?: Ai;
+	SPAM_LINK_THRESHOLD?: string;
+	SPAM_HONEYPOT_MIN_MS?: string;
+	SPAM_FIRST_COMMENT_MODERATE?: string;
+	SPAM_FORM_TS_SECRET?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/src/lib/spam/akismet.ts
+++ b/src/lib/spam/akismet.ts
@@ -41,7 +41,6 @@ export const checkAkismet = async (
 	// neutral placeholder so the request passes Akismet's required-fields
 	// check; the model is robust to a uniform constant.
 	form.set("user_ip", "127.0.0.1");
-	if (input.is_first_comment) form.set("is_test", "0");
 
 	try {
 		const res = await fetch(

--- a/src/lib/spam/akismet.ts
+++ b/src/lib/spam/akismet.ts
@@ -32,7 +32,9 @@ export const checkAkismet = async (
 	form.set("blog", cfg.siteUrl);
 	form.set("comment_type", "comment");
 	form.set("comment_author", input.author_name);
-	if (input.author_email) form.set("comment_author_email", input.author_email);
+	// Privacy posture: author_email is deliberately omitted so OAuth users'
+	// email addresses don't egress to Automattic, consistent with the
+	// constant-IP choice below. Documented in docs/ANTISPAM.md.
 	form.set("comment_content", input.body_md);
 	if (input.post_url) form.set("permalink", input.post_url);
 	if (input.user_agent) form.set("user_agent", input.user_agent);

--- a/src/lib/spam/akismet.ts
+++ b/src/lib/spam/akismet.ts
@@ -49,7 +49,14 @@ export const checkAkismet = async (
 			`https://${cfg.apiKey}.rest.akismet.com/1.1/comment-check`,
 			{
 				method: "POST",
-				headers: { "content-type": "application/x-www-form-urlencoded" },
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					// App-identifying UA per Akismet's API contract — they
+					// use it for rate-limit bucketing and abuse reporting.
+					// Without it every Garrul instance shares the default
+					// Workers UA with every other CF Worker.
+					"user-agent": "Garrul/1 | Akismet/1.1",
+				},
 				body: form.toString(),
 			},
 		);

--- a/src/lib/spam/akismet.ts
+++ b/src/lib/spam/akismet.ts
@@ -1,0 +1,97 @@
+/**
+ * Akismet content classifier.
+ *
+ * Privacy note: this sends `body_md`, the author's display name, and the
+ * post URL to Automattic. We deliberately do NOT forward the raw client IP
+ * or the hashed IP — Akismet can't do anything useful with a Garrul-specific
+ * HMAC, and shipping the raw IP would break the project's privacy posture
+ * (see src/lib/ip-hash.ts). Operators who enable Akismet must disclose this
+ * in their privacy policy; the template at docs/privacy-policy.template.md
+ * has a stub for it.
+ *
+ * API: https://akismet.com/developers/comment-check/
+ * Endpoint: POST https://{api-key}.rest.akismet.com/1.1/comment-check
+ * Body: application/x-www-form-urlencoded
+ * Response: "true" (spam) or "false" (ham). An "X-akismet-pro-tip: discard"
+ * header marks high-confidence "blatant spam" that's safe to silently drop —
+ * we still flag to `pending` rather than dropping, but it's recorded.
+ */
+
+import type { SpamCheckInput, SpamVerdict } from "./index";
+
+type AkismetConfig = {
+	apiKey: string;
+	siteUrl: string;
+};
+
+export const checkAkismet = async (
+	cfg: AkismetConfig,
+	input: SpamCheckInput,
+): Promise<SpamVerdict | null> => {
+	const form = new URLSearchParams();
+	form.set("blog", cfg.siteUrl);
+	form.set("comment_type", "comment");
+	form.set("comment_author", input.author_name);
+	if (input.author_email) form.set("comment_author_email", input.author_email);
+	form.set("comment_content", input.body_md);
+	if (input.post_url) form.set("permalink", input.post_url);
+	if (input.user_agent) form.set("user_agent", input.user_agent);
+	// Akismet expects user_ip; we don't send the real IP for privacy reasons,
+	// but a missing value makes the call less accurate. Send 127.0.0.1 as a
+	// neutral placeholder so the request passes Akismet's required-fields
+	// check; the model is robust to a uniform constant.
+	form.set("user_ip", "127.0.0.1");
+	if (input.is_first_comment) form.set("is_test", "0");
+
+	try {
+		const res = await fetch(
+			`https://${cfg.apiKey}.rest.akismet.com/1.1/comment-check`,
+			{
+				method: "POST",
+				headers: { "content-type": "application/x-www-form-urlencoded" },
+				body: form.toString(),
+			},
+		);
+		if (!res.ok) {
+			const body = await res.text().catch(() => "");
+			console.error(
+				JSON.stringify({
+					level: "warn",
+					msg: "spam.adapter.error",
+					provider: "akismet",
+					status: res.status,
+					body: body.slice(0, 200),
+				}),
+			);
+			return null;
+		}
+		const text = (await res.text()).trim().toLowerCase();
+		const proTip = res.headers.get("x-akismet-pro-tip");
+		if (text === "true") {
+			return {
+				spam: true,
+				reason: proTip === "discard" ? "akismet.discard" : "akismet.spam",
+			};
+		}
+		if (text === "false") return { spam: false };
+		console.error(
+			JSON.stringify({
+				level: "warn",
+				msg: "spam.adapter.error",
+				provider: "akismet",
+				unexpected_body: text.slice(0, 60),
+			}),
+		);
+		return null;
+	} catch (err) {
+		console.error(
+			JSON.stringify({
+				level: "warn",
+				msg: "spam.adapter.error",
+				provider: "akismet",
+				error: String(err),
+			}),
+		);
+		return null;
+	}
+};

--- a/src/lib/spam/heuristics.ts
+++ b/src/lib/spam/heuristics.ts
@@ -10,6 +10,12 @@
 
 const encoder = new TextEncoder();
 
+// Upper bound on form-token lifetime, applied by verifyFormTimestamp.
+// Stops a scripted attacker from minting one token, waiting `minMs`, and
+// then reusing it indefinitely. One hour comfortably covers a human
+// reading + composing a long reply.
+const FORM_TS_MAX_AGE_MS = 60 * 60 * 1000;
+
 /**
  * HMAC-SHA-256 of the timestamp (ms since epoch) using SPAM_FORM_TS_SECRET.
  * Token format: "<ms>.<hex-sig>". Verification recomputes the sig and checks
@@ -87,6 +93,9 @@ export const verifyFormTimestamp = async (
 	// Negative elapsed = clock skew or replayed-from-future. Treat as flag.
 	if (elapsed < 0) return { flag: true, reason: "form_ts.future" };
 	if (elapsed < minMs) return { flag: true, reason: "form_ts.too_fast" };
+	if (elapsed > FORM_TS_MAX_AGE_MS) {
+		return { flag: true, reason: "form_ts.too_old" };
+	}
 	return { flag: false };
 };
 

--- a/src/lib/spam/heuristics.ts
+++ b/src/lib/spam/heuristics.ts
@@ -1,0 +1,120 @@
+/**
+ * Lightweight, in-core anti-spam heuristics. Pure functions (one DB read for
+ * `isFirstComment`); no external dependencies. Each heuristic is independently
+ * gated by its env var — when unset, the caller skips it entirely.
+ *
+ * A `true` flag downgrades the eventual `insertComment` status to `'pending'`.
+ * Nothing here 400s the request; flagged comments still land in D1 and appear
+ * in the admin queue at /admin/queue?status=pending.
+ */
+
+const encoder = new TextEncoder();
+
+/**
+ * HMAC-SHA-256 of the timestamp (ms since epoch) using SPAM_FORM_TS_SECRET.
+ * Token format: "<ms>.<hex-sig>". Verification recomputes the sig and checks
+ * elapsed time against `minMs`.
+ *
+ * Kept in this file (rather than reused from lib/ip-hash) because the input
+ * here is a number and we want a stable, self-contained API for tests.
+ */
+const importHmacKey = (secret: string): Promise<CryptoKey> =>
+	crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+
+const hex = (buf: ArrayBuffer): string =>
+	Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, "0")).join("");
+
+/**
+ * Mint a signed form-render timestamp. The widget submits this back; the
+ * server checks that enough wall-clock time has passed before accepting.
+ */
+export const signFormTimestamp = async (
+	nowMs: number,
+	secret: string,
+): Promise<string> => {
+	const key = await importHmacKey(secret);
+	const sig = await crypto.subtle.sign(
+		"HMAC",
+		key,
+		encoder.encode(String(nowMs)),
+	);
+	return `${nowMs}.${hex(sig)}`;
+};
+
+/**
+ * Verify a form-render timestamp token.
+ *
+ * Returns `{ flag: true }` if the token is missing, malformed, fails HMAC
+ * verification, OR the elapsed wall-clock time is below `minMs`. Returns
+ * `{ flag: false }` only when the token is genuine AND the human spent at
+ * least `minMs` filling the form.
+ */
+export const verifyFormTimestamp = async (
+	token: string | undefined,
+	secret: string,
+	nowMs: number,
+	minMs: number,
+): Promise<{ flag: boolean; reason?: string }> => {
+	if (!token) return { flag: true, reason: "form_ts.missing" };
+	const dot = token.indexOf(".");
+	if (dot <= 0) return { flag: true, reason: "form_ts.malformed" };
+	const tsRaw = token.slice(0, dot);
+	const sigRaw = token.slice(dot + 1);
+	const ts = Number.parseInt(tsRaw, 10);
+	if (!Number.isFinite(ts)) return { flag: true, reason: "form_ts.malformed" };
+
+	const key = await importHmacKey(secret);
+	const expected = hex(
+		await crypto.subtle.sign("HMAC", key, encoder.encode(String(ts))),
+	);
+	// Constant-time compare on equal-length strings.
+	if (expected.length !== sigRaw.length) {
+		return { flag: true, reason: "form_ts.bad_sig" };
+	}
+	let diff = 0;
+	for (let i = 0; i < expected.length; i++) {
+		diff |= expected.charCodeAt(i) ^ sigRaw.charCodeAt(i);
+	}
+	if (diff !== 0) return { flag: true, reason: "form_ts.bad_sig" };
+
+	const elapsed = nowMs - ts;
+	// Negative elapsed = clock skew or replayed-from-future. Treat as flag.
+	if (elapsed < 0) return { flag: true, reason: "form_ts.future" };
+	if (elapsed < minMs) return { flag: true, reason: "form_ts.too_fast" };
+	return { flag: false };
+};
+
+/**
+ * Count URL-like substrings in the markdown body. Anything matching
+ * `http(s)://` or `mailto:` schemes counts — matches the renderer allowlist
+ * in src/lib/markdown.ts. Bare-text URLs that the renderer auto-links also
+ * count (gfm autolink rule).
+ */
+const URL_RE = /\b(?:https?:\/\/|mailto:)\S+/gi;
+export const countLinks = (bodyMd: string): number => {
+	if (!bodyMd) return 0;
+	const matches = bodyMd.match(URL_RE);
+	return matches ? matches.length : 0;
+};
+
+/**
+ * True when this is the author's first-ever comment (no prior rows in D1
+ * keyed on user_id). Caller gates on SPAM_FIRST_COMMENT_MODERATE before
+ * paying the query.
+ */
+export const isFirstComment = async (
+	db: D1Database,
+	userId: string,
+): Promise<boolean> => {
+	const row = await db
+		.prepare(`SELECT 1 AS one FROM comments WHERE user_id = ? LIMIT 1`)
+		.bind(userId)
+		.first<{ one: number } | null>();
+	return row == null;
+};

--- a/src/lib/spam/heuristics.ts
+++ b/src/lib/spam/heuristics.ts
@@ -93,8 +93,10 @@ export const verifyFormTimestamp = async (
 /**
  * Count URL-like substrings in the markdown body. Anything matching
  * `http(s)://` or `mailto:` schemes counts — matches the renderer allowlist
- * in src/lib/markdown.ts. Bare-text URLs that the renderer auto-links also
- * count (gfm autolink rule).
+ * in src/lib/markdown.ts. Scheme-less domains (e.g. `www.example.com`)
+ * are NOT counted; if a spammer relies on the gfm autolinker to make a
+ * bare domain clickable, this signal misses it, but the rendered HTML
+ * will still go through the strict sanitizer.
  */
 const URL_RE = /\b(?:https?:\/\/|mailto:)\S+/gi;
 export const countLinks = (bodyMd: string): number => {

--- a/src/lib/spam/index.ts
+++ b/src/lib/spam/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Pluggable content-classifier dispatch. Mirrors src/lib/email.ts:
+ *   - SPAM_PROVIDER selects the implementation ("akismet" | "workers-ai").
+ *   - When unset, this returns `null` ("no opinion") and the caller falls
+ *     back to whatever the in-core heuristics decided.
+ *   - Adapters that fail transiently also return `null` rather than throwing;
+ *     a spam check should never break comment posting.
+ *
+ * A non-null `{ spam: true }` verdict flips the eventual `insertComment`
+ * status to `'pending'`. Verdicts are never silently discarded.
+ */
+
+import { checkAkismet } from "./akismet";
+import { checkWorkersAi } from "./workers-ai";
+
+export type SpamCheckInput = {
+	body_md: string;
+	author_name: string;
+	author_email?: string | null;
+	user_agent: string | null;
+	post_url: string | null;
+	is_first_comment: boolean;
+};
+
+export type SpamVerdict = { spam: boolean; reason?: string };
+
+export type SpamEnv = {
+	SPAM_PROVIDER?: string;
+	AKISMET_API_KEY?: string;
+	AKISMET_SITE_URL?: string;
+	AI?: Ai;
+	RATE_LIMITS?: KVNamespace;
+};
+
+export const checkSpam = async (
+	env: SpamEnv,
+	input: SpamCheckInput,
+): Promise<SpamVerdict | null> => {
+	const provider = env.SPAM_PROVIDER;
+	if (!provider) return null;
+	if (provider === "akismet") {
+		if (!env.AKISMET_API_KEY || !env.AKISMET_SITE_URL) return null;
+		return checkAkismet(
+			{ apiKey: env.AKISMET_API_KEY, siteUrl: env.AKISMET_SITE_URL },
+			input,
+		);
+	}
+	if (provider === "workers-ai") {
+		if (!env.AI) return null;
+		return checkWorkersAi(
+			{ ai: env.AI, cache: env.RATE_LIMITS ?? null },
+			input,
+		);
+	}
+	console.error(
+		JSON.stringify({
+			level: "warn",
+			msg: "spam.adapter.unknown_provider",
+			provider,
+		}),
+	);
+	return null;
+};

--- a/src/lib/spam/workers-ai.ts
+++ b/src/lib/spam/workers-ai.ts
@@ -1,0 +1,111 @@
+/**
+ * Cloudflare Workers AI classifier.
+ *
+ * Privacy posture: nothing leaves the Cloudflare edge — the AI binding
+ * routes the inference call internally. Operators concerned about shipping
+ * comment bodies to a third party (Akismet) should prefer this provider.
+ *
+ * Tradeoff: it's an LLM call, so it's slower and pricier per check than
+ * Akismet. We cache verdicts in KV (RATE_LIMITS namespace) keyed on a
+ * short hash of body_md so identical resubmissions don't re-bill.
+ */
+
+import type { SpamCheckInput, SpamVerdict } from "./index";
+
+type WorkersAiConfig = {
+	ai: Ai;
+	cache: KVNamespace | null;
+};
+
+const MODEL = "@cf/meta/llama-3.1-8b-instruct";
+const CACHE_TTL_SECONDS = 60 * 60 * 6; // 6h — body hash is content-addressed
+const MAX_BODY_FOR_PROMPT = 2_000; // truncate for cost / latency
+
+const encoder = new TextEncoder();
+
+const cacheKey = async (bodyMd: string): Promise<string> => {
+	const digest = await crypto.subtle.digest("SHA-256", encoder.encode(bodyMd));
+	const hex = Array.from(new Uint8Array(digest), (b) =>
+		b.toString(16).padStart(2, "0"),
+	).join("");
+	return `spamcache:${hex.slice(0, 32)}`;
+};
+
+const buildPrompt = (input: SpamCheckInput): string => {
+	const body = input.body_md.slice(0, MAX_BODY_FOR_PROMPT);
+	return [
+		"You are a spam classifier for blog comments. Reply with exactly one word: SPAM or HAM.",
+		"SPAM examples: SEO link farms, drug/casino/loan promos, paid backlink injections, gibberish or AI-generated promo, fake reviews with URLs.",
+		"HAM examples: genuine reactions, questions, disagreement, technical discussion, even if poorly written.",
+		"Borderline cases (off-topic but human, short, opinionated) are HAM.",
+		"",
+		`Author: ${input.author_name}`,
+		`First-time commenter: ${input.is_first_comment ? "yes" : "no"}`,
+		"Comment:",
+		body,
+		"",
+		"Classification:",
+	].join("\n");
+};
+
+export const checkWorkersAi = async (
+	cfg: WorkersAiConfig,
+	input: SpamCheckInput,
+): Promise<SpamVerdict | null> => {
+	const key = await cacheKey(input.body_md);
+	if (cfg.cache) {
+		const cached = await cfg.cache.get(key);
+		if (cached === "spam") return { spam: true, reason: "workers-ai.cached" };
+		if (cached === "ham") return { spam: false };
+	}
+
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const out: any = await cfg.ai.run(MODEL, {
+			messages: [
+				{ role: "system", content: "You are a spam classifier. Reply SPAM or HAM only." },
+				{ role: "user", content: buildPrompt(input) },
+			],
+			max_tokens: 4,
+			temperature: 0,
+		});
+		const raw =
+			typeof out === "string"
+				? out
+				: typeof out?.response === "string"
+					? out.response
+					: "";
+		const norm = raw.trim().toUpperCase();
+		const isSpam = norm.startsWith("SPAM");
+		const isHam = norm.startsWith("HAM");
+		if (!isSpam && !isHam) {
+			console.error(
+				JSON.stringify({
+					level: "warn",
+					msg: "spam.adapter.error",
+					provider: "workers-ai",
+					unexpected_response: raw.slice(0, 60),
+				}),
+			);
+			return null;
+		}
+		if (cfg.cache) {
+			await cfg.cache.put(key, isSpam ? "spam" : "ham", {
+				expirationTtl: CACHE_TTL_SECONDS,
+			});
+		}
+		return isSpam
+			? { spam: true, reason: "workers-ai.spam" }
+			: { spam: false };
+	} catch (err) {
+		console.error(
+			JSON.stringify({
+				level: "warn",
+				msg: "spam.adapter.error",
+				provider: "workers-ai",
+				error: String(err),
+			}),
+		);
+		return null;
+	}
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -233,13 +233,18 @@ ${body}
 </html>`;
 
 const spamSummary = (env: Bindings): string => {
+	// Match the same gating evaluateSpam uses at runtime, otherwise the
+	// dashboard would claim a layer is active when its value is invalid
+	// (e.g. SPAM_LINK_THRESHOLD='NaN', SPAM_HONEYPOT_MIN_MS='0').
 	const provider = env.SPAM_PROVIDER || "off";
 	const heuristics: string[] = [];
-	if (env.SPAM_HONEYPOT_MIN_MS && env.SPAM_FORM_TS_SECRET) {
-		heuristics.push(`honeypot-timing(${env.SPAM_HONEYPOT_MIN_MS}ms)`);
+	const minMs = Number.parseInt(env.SPAM_HONEYPOT_MIN_MS ?? "", 10);
+	if (Number.isFinite(minMs) && minMs > 0 && env.SPAM_FORM_TS_SECRET) {
+		heuristics.push(`honeypot-timing(${minMs}ms)`);
 	}
-	if (env.SPAM_LINK_THRESHOLD) {
-		heuristics.push(`link-threshold(>${env.SPAM_LINK_THRESHOLD})`);
+	const linkThreshold = Number.parseInt(env.SPAM_LINK_THRESHOLD ?? "", 10);
+	if (Number.isFinite(linkThreshold) && linkThreshold >= 0) {
+		heuristics.push(`link-threshold(>${linkThreshold})`);
 	}
 	if (env.SPAM_FIRST_COMMENT_MODERATE === "true") {
 		heuristics.push("first-comment-moderation");

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -232,7 +232,23 @@ ${body}
 </body>
 </html>`;
 
-const renderDashboard = (stats: AdminStats): string => `
+const spamSummary = (env: Bindings): string => {
+	const provider = env.SPAM_PROVIDER || "off";
+	const heuristics: string[] = [];
+	if (env.SPAM_HONEYPOT_MIN_MS && env.SPAM_FORM_TS_SECRET) {
+		heuristics.push(`honeypot-timing(${env.SPAM_HONEYPOT_MIN_MS}ms)`);
+	}
+	if (env.SPAM_LINK_THRESHOLD) {
+		heuristics.push(`link-threshold(>${env.SPAM_LINK_THRESHOLD})`);
+	}
+	if (env.SPAM_FIRST_COMMENT_MODERATE === "true") {
+		heuristics.push("first-comment-moderation");
+	}
+	const heuristicsLabel = heuristics.length > 0 ? heuristics.join(", ") : "none";
+	return `provider=<code>${escapeHtml(provider)}</code> · heuristics=<code>${escapeHtml(heuristicsLabel)}</code>`;
+};
+
+const renderDashboard = (stats: AdminStats, env: Bindings): string => `
 <div class="card">
   <h2>Overview</h2>
   <div class="stat-grid">
@@ -242,6 +258,7 @@ const renderDashboard = (stats: AdminStats): string => `
     <div class="stat"><div class="v">${stats.total_users}</div><div class="l">users</div></div>
     <div class="stat"><div class="v">${stats.banned_users}</div><div class="l">banned</div></div>
   </div>
+  <p class="muted">Anti-spam: ${spamSummary(env)}. See <a href="/admin/settings">Settings</a> to change.</p>
 </div>
 <div class="card">
   <h3>Quick actions</h3>
@@ -383,6 +400,13 @@ const renderSettings = (env: Bindings): string => {
 		["GOOGLE_CLIENT_ID", env.GOOGLE_CLIENT_ID ? "(set)" : "(unset)"],
 		["OAUTH_CALLBACK_BASE", env.OAUTH_CALLBACK_BASE ?? "(falls back to request origin)"],
 		["EMAIL_PROVIDER", env.EMAIL_PROVIDER ?? "(unset)"],
+		["SPAM_PROVIDER", env.SPAM_PROVIDER || "(unset)"],
+		["AKISMET_API_KEY", env.AKISMET_API_KEY ? "(set)" : "(unset)"],
+		["AKISMET_SITE_URL", env.AKISMET_SITE_URL ?? "(unset)"],
+		["SPAM_LINK_THRESHOLD", env.SPAM_LINK_THRESHOLD ?? "(unset)"],
+		["SPAM_HONEYPOT_MIN_MS", env.SPAM_HONEYPOT_MIN_MS ?? "(unset)"],
+		["SPAM_FIRST_COMMENT_MODERATE", env.SPAM_FIRST_COMMENT_MODERATE ?? "(unset)"],
+		["SPAM_FORM_TS_SECRET", env.SPAM_FORM_TS_SECRET ? "(set)" : "(unset)"],
 	];
 	const body = rows
 		.map(([k, v]) => `<tr><td><code>${k}</code></td><td>${escapeHtml(v)}</td></tr>`)
@@ -435,7 +459,7 @@ admin.get("/", async (c) => {
 	if (user instanceof Response) return user;
 	const stats = await adminStats(c.env.DB);
 	const updateInfo = await peekCachedLatestVersion(c.env);
-	return c.html(layout("Dashboard", renderDashboard(stats), user, updateInfo));
+	return c.html(layout("Dashboard", renderDashboard(stats, c.env), user, updateInfo));
 });
 
 admin.get("/queue", async (c) => {

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -136,15 +136,20 @@ const serializeComment = (c: Comment, author: User) => {
 
 /**
  * Mint a signed HMAC timestamp so the widget can prove how long the form was
- * displayed before submission. Verified server-side when
- * `SPAM_HONEYPOT_MIN_MS` is configured; otherwise the token is ignored.
+ * displayed before submission. Verified server-side when both
+ * `SPAM_HONEYPOT_MIN_MS` and `SPAM_FORM_TS_SECRET` are configured.
  *
- * 404s when no secret is configured — the widget always asks for a token but
- * tolerates a missing one (the existing field-honeypot still applies).
+ * 404s when either is missing — the widget always asks for a token but
+ * tolerates a missing one (the existing field-honeypot still applies),
+ * and we don't want to expose an endpoint that signs tokens nothing
+ * will ever check.
  */
 comments.get("/form-token", async (c) => {
 	const secret = c.env.SPAM_FORM_TS_SECRET;
-	if (!secret) return c.json({ error: "not_found" }, 404);
+	const minMs = Number.parseInt(c.env.SPAM_HONEYPOT_MIN_MS ?? "", 10);
+	if (!secret || !Number.isFinite(minMs) || minMs <= 0) {
+		return c.json({ error: "not_found" }, 404);
+	}
 	const token = await signFormTimestamp(Date.now(), secret);
 	return c.json({ token });
 });

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -188,10 +188,14 @@ const evaluateSpam = async (
 		if (n > linkThreshold) reasons.push(`link_count:${n}`);
 	}
 
+	// Compute is_first_comment if either the moderate-on-first heuristic
+	// or the classifier is enabled — classifiers use it as a feature even
+	// when the operator hasn't asked us to auto-moderate on it.
+	const moderateFirst = env.SPAM_FIRST_COMMENT_MODERATE === "true";
 	let isFirst = false;
-	if (env.SPAM_FIRST_COMMENT_MODERATE === "true") {
+	if (moderateFirst || env.SPAM_PROVIDER) {
 		isFirst = await isFirstComment(env.DB, author.id);
-		if (isFirst) reasons.push("first_comment");
+		if (moderateFirst && isFirst) reasons.push("first_comment");
 	}
 
 	// Skip the classifier call when a heuristic already flagged — the

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -45,6 +45,14 @@ import { verifyTurnstile } from "../lib/turnstile";
 import { writeEvent } from "../lib/analytics";
 import { fireWebhook } from "../lib/webhook";
 import {
+	countLinks,
+	isFirstComment,
+	signFormTimestamp,
+	verifyFormTimestamp,
+} from "../lib/spam/heuristics";
+import { checkSpam } from "../lib/spam";
+import type { CommentStatus } from "../db/queries";
+import {
 	buildTree,
 	type ReactionCount,
 	type TreeAuthor,
@@ -88,6 +96,7 @@ type CreateBody = {
 	turnstile_token?: string;
 	post_title?: string | null;
 	post_url?: string | null;
+	form_ts?: string;
 	[HONEYPOT_FIELD]?: string;
 };
 
@@ -123,6 +132,80 @@ const serializeComment = (c: Comment, author: User) => {
 			avatar_url: author.avatar_url,
 		},
 	};
+};
+
+/**
+ * Mint a signed HMAC timestamp so the widget can prove how long the form was
+ * displayed before submission. Verified server-side when
+ * `SPAM_HONEYPOT_MIN_MS` is configured; otherwise the token is ignored.
+ *
+ * 404s when no secret is configured — the widget always asks for a token but
+ * tolerates a missing one (the existing field-honeypot still applies).
+ */
+comments.get("/form-token", async (c) => {
+	const secret = c.env.SPAM_FORM_TS_SECRET;
+	if (!secret) return c.json({ error: "not_found" }, 404);
+	const token = await signFormTimestamp(Date.now(), secret);
+	return c.json({ token });
+});
+
+/**
+ * Run the configured anti-spam signals against a candidate comment and
+ * decide whether it goes in as `approved` or `pending`. Each signal is
+ * gated by its own env var. Admins skip the check entirely. Heuristics
+ * run first and short-circuit the (potentially paid) classifier call.
+ */
+const evaluateSpam = async (
+	env: Bindings,
+	author: User,
+	bodyMd: string,
+	postUrl: string | null,
+	userAgent: string | null,
+	formTs: string | undefined,
+): Promise<{ status: CommentStatus; reasons: string[] }> => {
+	if (author.is_admin) return { status: "approved", reasons: [] };
+	const reasons: string[] = [];
+
+	const minMs = Number.parseInt(env.SPAM_HONEYPOT_MIN_MS ?? "", 10);
+	if (Number.isFinite(minMs) && minMs > 0 && env.SPAM_FORM_TS_SECRET) {
+		const v = await verifyFormTimestamp(
+			formTs,
+			env.SPAM_FORM_TS_SECRET,
+			Date.now(),
+			minMs,
+		);
+		if (v.flag) reasons.push(v.reason ?? "form_ts");
+	}
+
+	const linkThreshold = Number.parseInt(env.SPAM_LINK_THRESHOLD ?? "", 10);
+	if (Number.isFinite(linkThreshold) && linkThreshold >= 0) {
+		const n = countLinks(bodyMd);
+		if (n > linkThreshold) reasons.push(`link_count:${n}`);
+	}
+
+	let isFirst = false;
+	if (env.SPAM_FIRST_COMMENT_MODERATE === "true") {
+		isFirst = await isFirstComment(env.DB, author.id);
+		if (isFirst) reasons.push("first_comment");
+	}
+
+	// Skip the classifier call when a heuristic already flagged — the
+	// outcome is already `pending` and the call may cost money/latency.
+	if (reasons.length === 0 && env.SPAM_PROVIDER) {
+		const verdict = await checkSpam(env, {
+			body_md: bodyMd,
+			author_name: author.name,
+			author_email: author.email,
+			user_agent: userAgent,
+			post_url: postUrl,
+			is_first_comment: isFirst,
+		});
+		if (verdict?.spam) reasons.push(verdict.reason ?? "classifier");
+	}
+
+	return reasons.length > 0
+		? { status: "pending", reasons }
+		: { status: "approved", reasons: [] };
 };
 
 comments.post("/", async (c) => {
@@ -219,6 +302,27 @@ comments.post("/", async (c) => {
 		parent_id = parent.id;
 	}
 
+	const userAgent = c.req.header("user-agent") ?? null;
+	const verdict = await evaluateSpam(
+		c.env,
+		author,
+		bodyCheck.body,
+		postUrl,
+		userAgent,
+		body.form_ts,
+	);
+	if (verdict.reasons.length > 0) {
+		console.log(
+			JSON.stringify({
+				level: "info",
+				msg: "spam.flagged",
+				reasons: verdict.reasons,
+				post_slug: slug,
+				provider: author.provider,
+			}),
+		);
+	}
+
 	const body_html = renderMarkdown(bodyCheck.body);
 	const inserted = await insertComment(c.env.DB, {
 		post_slug: slug,
@@ -227,17 +331,20 @@ comments.post("/", async (c) => {
 		body_md: bodyCheck.body,
 		body_html,
 		renderer_version: CURRENT_RENDERER_VERSION,
+		status: verdict.status,
 		ip_hash: ipHash,
-		user_agent: c.req.header("user-agent") ?? null,
+		user_agent: userAgent,
 	});
 
 	// Bust the cached first page. Older pages bypass cache, so there's
-	// nothing else to invalidate.
+	// nothing else to invalidate. Pending comments don't appear in the
+	// public tree but the cache key is the same; busting is still correct.
 	await c.env.TREE_CACHE.delete(`tree:${slug}:first`);
 
 	writeEvent(c.env.ANALYTICS, "comment.posted", {
 		post_slug: slug,
 		provider: author.provider,
+		outcome: verdict.status,
 	});
 	fireWebhook(c.env, c.executionCtx, {
 		event: "comment.posted",
@@ -247,18 +354,18 @@ comments.post("/", async (c) => {
 		ts: inserted.created_at,
 	});
 
-	// Enqueue notifications for every active subscriber, except the
-	// author themselves (signed-in case — match on email; anonymous
-	// authors have no email so they're never accidentally notified).
-	const fanout = (async () => {
-		const subs = await listActiveSubscriptionsForPost(c.env.DB, slug);
-		const authorEmail = author.email?.toLowerCase() ?? null;
-		for (const sub of subs) {
-			if (authorEmail && sub.email === authorEmail) continue;
-			await enqueueNotification(c.env.DB, sub.id, inserted.id);
-		}
-	})();
-	if (c.executionCtx) c.executionCtx.waitUntil(fanout);
+	// Pending comments don't notify subscribers — admins approve first.
+	if (verdict.status === "approved") {
+		const fanout = (async () => {
+			const subs = await listActiveSubscriptionsForPost(c.env.DB, slug);
+			const authorEmail = author.email?.toLowerCase() ?? null;
+			for (const sub of subs) {
+				if (authorEmail && sub.email === authorEmail) continue;
+				await enqueueNotification(c.env.DB, sub.id, inserted.id);
+			}
+		})();
+		if (c.executionCtx) c.executionCtx.waitUntil(fanout);
+	}
 
 	return c.json({ comment: serializeComment(inserted, author) }, 201);
 });

--- a/src/routes/permalink.ts
+++ b/src/routes/permalink.ts
@@ -26,7 +26,11 @@ permalink.get("/:id", async (c) => {
 
 	const comment = await getComment(c.env.DB, id);
 	if (!comment) return c.text("not found", 404);
-	if (comment.status === "deleted" || comment.status === "spam") {
+	if (
+		comment.status === "deleted" ||
+		comment.status === "spam" ||
+		comment.status === "pending"
+	) {
 		return c.text("not found", 404);
 	}
 

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -108,6 +108,7 @@ const STYLE_CSS = `
 }
 .gr-form button[disabled] { opacity: 0.6; cursor: progress; }
 .gr-error { color: var(--garrul-error, #b91c1c); font-size: 0.9em; }
+.gr-error.is-notice { color: var(--garrul-notice, #1e6091); }
 .gr-list { display: flex; flex-direction: column; gap: 1rem; }
 .gr-thread { display: flex; flex-direction: column; gap: 0.75rem; }
 .gr-replies { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 0.5rem; padding-left: 1.25rem; border-left: 2px solid var(--garrul-border, #d0d3d8); }
@@ -287,6 +288,30 @@ type WidgetCtx = {
 	me: Me;
 	editWindowMs: number;
 	reload: () => void;
+};
+
+/**
+ * Fetch the signed form-render timestamp from the server (once per page
+ * load). When anti-spam timing is disabled the route 404s and we return
+ * an empty string — the server then ignores the absent `form_ts`. The
+ * promise is cached so reply forms and the top-level form share one fetch.
+ */
+let formTokenPromise: Promise<string> | null = null;
+const getFormToken = (apiBase: string): Promise<string> => {
+	if (formTokenPromise) return formTokenPromise;
+	formTokenPromise = (async () => {
+		try {
+			const res = await fetch(`${apiBase}/api/v1/comments/form-token`, {
+				credentials: "include",
+			});
+			if (!res.ok) return "";
+			const json = (await res.json()) as { token?: string };
+			return json.token ?? "";
+		} catch {
+			return "";
+		}
+	})();
+	return formTokenPromise;
 };
 
 const REACTION_KINDS: { kind: string; emoji: string }[] = [
@@ -474,6 +499,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 				'input[name="cf-turnstile-response"]',
 			) as HTMLInputElement | null)?.value ?? "";
 		try {
+			const formTs = await getFormToken(ctx.apiBase);
 			const res = await fetch(`${ctx.apiBase}/api/v1/comments`, {
 				method: "POST",
 				credentials: "include",
@@ -485,14 +511,26 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 					parent_id: parent.id,
 					turnstile_token: turnstileToken,
 					website: "",
+					form_ts: formTs,
 					post_title: ctx.host.dataset.title ?? null,
 					post_url: ctx.host.dataset.url ?? null,
 				}),
 			});
-			const json = (await res.json()) as { error?: string };
+			const json = (await res.json()) as {
+				error?: string;
+				comment?: { status?: string };
+			};
 			if (!res.ok) {
 				errBox.textContent = json.error ?? `HTTP ${res.status}`;
 				errBox.hidden = false;
+				submit.disabled = false;
+				return;
+			}
+			if (json.comment?.status === "pending") {
+				errBox.textContent = "Comment submitted — awaiting moderation.";
+				errBox.classList.add("is-notice");
+				errBox.hidden = false;
+				ta.value = "";
 				submit.disabled = false;
 				return;
 			}
@@ -981,6 +1019,7 @@ const submit = async (
 	const turnstileToken = tokenInput?.value ?? "";
 
 	try {
+		const formTs = await getFormToken(apiBase);
 		const res = await fetch(`${apiBase}/api/v1/comments`, {
 			method: "POST",
 			credentials: "include",
@@ -991,16 +1030,34 @@ const submit = async (
 				body,
 				turnstile_token: turnstileToken,
 				website: honeypot,
+				form_ts: formTs,
 				post_title: host.dataset.title ?? null,
 				post_url: host.dataset.url ?? null,
 			}),
 		});
-		const json = (await res.json()) as { error?: string };
+		const json = (await res.json()) as {
+			error?: string;
+			comment?: { status?: string };
+		};
 		if (!res.ok) {
 			if (errEl) {
 				errEl.textContent = json.error ?? `HTTP ${res.status}`;
 				errEl.hidden = false;
 			}
+			if (submitBtn) submitBtn.disabled = false;
+			return;
+		}
+
+		if (json.comment?.status === "pending") {
+			if (errEl) {
+				errEl.textContent = "Comment submitted — awaiting moderation.";
+				errEl.classList.add("is-notice");
+				errEl.hidden = false;
+			}
+			const bodyInput = form.querySelector(
+				".gr-body-input",
+			) as HTMLTextAreaElement | null;
+			if (bodyInput) bodyInput.value = "";
 			if (submitBtn) submitBtn.disabled = false;
 			return;
 		}

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -291,14 +291,22 @@ type WidgetCtx = {
 };
 
 /**
- * Fetch the signed form-render timestamp from the server (once per page
- * load). When anti-spam timing is disabled the route 404s and we return
- * an empty string — the server then ignores the absent `form_ts`. The
- * promise is cached so reply forms and the top-level form share one fetch.
+ * Fetch the signed form-render timestamp from the server. The token
+ * carries the wall-clock at mint time, so the honeypot-timing heuristic
+ * only works if we mint *when the form first appears*, not when the
+ * user clicks submit (otherwise `elapsed` is just network latency).
+ *
+ * Call `prefetchFormToken(apiBase)` at form-render to start the fetch,
+ * then `getFormToken(apiBase)` inside the submit handler to await the
+ * already-in-flight (or resolved) promise. The promise is cached at
+ * module scope so reply forms and the top-level form share one fetch.
+ *
+ * When anti-spam timing is disabled the route 404s and we resolve to
+ * an empty string — the server then ignores the absent `form_ts`.
  */
 let formTokenPromise: Promise<string> | null = null;
-const getFormToken = (apiBase: string): Promise<string> => {
-	if (formTokenPromise) return formTokenPromise;
+const prefetchFormToken = (apiBase: string): void => {
+	if (formTokenPromise) return;
 	formTokenPromise = (async () => {
 		try {
 			const res = await fetch(`${apiBase}/api/v1/comments/form-token`, {
@@ -311,7 +319,10 @@ const getFormToken = (apiBase: string): Promise<string> => {
 			return "";
 		}
 	})();
-	return formTokenPromise;
+};
+const getFormToken = (apiBase: string): Promise<string> => {
+	prefetchFormToken(apiBase);
+	return formTokenPromise as Promise<string>;
 };
 
 const REACTION_KINDS: { kind: string; emoji: string }[] = [
@@ -461,6 +472,9 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 };
 
 const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
+	// Mint the timing token now so the honeypot-timing heuristic has
+	// real elapsed seconds to measure when the user eventually submits.
+	prefetchFormToken(ctx.apiBase);
 	const wrap = el("form", "gr-reply-form");
 	const ta = el("textarea");
 	ta.placeholder = `Reply to @${parent.author.name}…`;
@@ -914,6 +928,9 @@ const loadOnce = async (
 		reload,
 	};
 	const authBlock = buildAuthBlock(me, apiBase, reload, reload);
+	// Mint the timing token now so the honeypot-timing heuristic has
+	// real elapsed seconds to measure when the user eventually submits.
+	prefetchFormToken(apiBase);
 	const form = buildForm(siteKey, me != null);
 	const list = el("div", "gr-list");
 	if (data.threads.length === 0) {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -508,6 +508,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 		submit.disabled = true;
 		errBox.hidden = true;
 		errBox.textContent = "";
+		errBox.classList.remove("is-notice");
 		const turnstileToken =
 			(wrap.querySelector(
 				'input[name="cf-turnstile-response"]',
@@ -1021,6 +1022,7 @@ const submit = async (
 	if (errEl) {
 		errEl.hidden = true;
 		errEl.textContent = "";
+		errEl.classList.remove("is-notice");
 	}
 	const submitBtn = form.querySelector("button[type=submit]") as HTMLButtonElement | null;
 	if (submitBtn) submitBtn.disabled = true;

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -301,6 +301,11 @@ type WidgetCtx = {
  * already-in-flight (or resolved) promise. The promise is cached at
  * module scope so reply forms and the top-level form share one fetch.
  *
+ * Assumes one widget mount per document — the bundle hard-codes
+ * `getElementById("garrul")`, so a second mount with a different
+ * `apiBase` would silently reuse the first's token. If that mounting
+ * model changes, scope this cache to the widget context instead.
+ *
  * When anti-spam timing is disabled the route 404s and we resolve to
  * an empty string — the server then ignores the absent `form_ts`.
  */

--- a/tests/spam-adapter.test.ts
+++ b/tests/spam-adapter.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Adapter dispatch + per-provider tests. The dispatcher must return null
+ * when unconfigured (the caller treats null as "no opinion" — heuristics
+ * decide alone). Provider tests use mocked transports so the suite stays
+ * offline; CLAUDE.md forbids network in tests.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkSpam, type SpamCheckInput } from "../src/lib/spam";
+
+const input: SpamCheckInput = {
+	body_md: "Hello world",
+	author_name: "Daisy",
+	author_email: null,
+	user_agent: "test-ua",
+	post_url: "https://example.com/post",
+	is_first_comment: false,
+};
+
+describe("checkSpam dispatcher", () => {
+	it("returns null when SPAM_PROVIDER is unset", async () => {
+		const v = await checkSpam({}, input);
+		expect(v).toBeNull();
+	});
+
+	it("returns null when provider is unknown", async () => {
+		const v = await checkSpam({ SPAM_PROVIDER: "bogus" }, input);
+		expect(v).toBeNull();
+	});
+
+	it("returns null for akismet when API key or site URL missing", async () => {
+		expect(await checkSpam({ SPAM_PROVIDER: "akismet" }, input)).toBeNull();
+		expect(
+			await checkSpam(
+				{ SPAM_PROVIDER: "akismet", AKISMET_API_KEY: "x" },
+				input,
+			),
+		).toBeNull();
+	});
+
+	it("returns null for workers-ai when AI binding is missing", async () => {
+		expect(await checkSpam({ SPAM_PROVIDER: "workers-ai" }, input)).toBeNull();
+	});
+});
+
+describe("akismet provider", () => {
+	const originalFetch = globalThis.fetch;
+	let lastUrl = "";
+	let lastBody = "";
+
+	beforeEach(() => {
+		lastUrl = "";
+		lastBody = "";
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	const mockFetch = (response: { ok: boolean; text: string; proTip?: string }) => {
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			lastUrl = url;
+			lastBody = String(init?.body ?? "");
+			const headers = new Headers();
+			if (response.proTip) headers.set("x-akismet-pro-tip", response.proTip);
+			return new Response(response.text, {
+				status: response.ok ? 200 : 500,
+				headers,
+			});
+		}) as typeof fetch;
+	};
+
+	it("returns spam=true when Akismet says 'true'", async () => {
+		mockFetch({ ok: true, text: "true" });
+		const v = await checkSpam(
+			{
+				SPAM_PROVIDER: "akismet",
+				AKISMET_API_KEY: "key",
+				AKISMET_SITE_URL: "https://example.com",
+			},
+			input,
+		);
+		expect(v).toEqual({ spam: true, reason: "akismet.spam" });
+		expect(lastUrl).toContain("key.rest.akismet.com");
+		expect(lastBody).toContain("blog=https%3A%2F%2Fexample.com");
+		expect(lastBody).toContain("comment_author=Daisy");
+		expect(lastBody).toContain("comment_content=Hello+world");
+		// Privacy posture: a fixed placeholder IP, never the real client IP.
+		expect(lastBody).toContain("user_ip=127.0.0.1");
+	});
+
+	it("returns spam=false when Akismet says 'false'", async () => {
+		mockFetch({ ok: true, text: "false" });
+		const v = await checkSpam(
+			{
+				SPAM_PROVIDER: "akismet",
+				AKISMET_API_KEY: "key",
+				AKISMET_SITE_URL: "https://example.com",
+			},
+			input,
+		);
+		expect(v).toEqual({ spam: false });
+	});
+
+	it("marks pro-tip 'discard' verdicts with the discard reason", async () => {
+		mockFetch({ ok: true, text: "true", proTip: "discard" });
+		const v = await checkSpam(
+			{
+				SPAM_PROVIDER: "akismet",
+				AKISMET_API_KEY: "key",
+				AKISMET_SITE_URL: "https://example.com",
+			},
+			input,
+		);
+		expect(v).toEqual({ spam: true, reason: "akismet.discard" });
+	});
+
+	it("returns null on HTTP failure (degrade to no opinion)", async () => {
+		mockFetch({ ok: false, text: "server error" });
+		const v = await checkSpam(
+			{
+				SPAM_PROVIDER: "akismet",
+				AKISMET_API_KEY: "key",
+				AKISMET_SITE_URL: "https://example.com",
+			},
+			input,
+		);
+		expect(v).toBeNull();
+	});
+
+	it("returns null on unexpected response body", async () => {
+		mockFetch({ ok: true, text: "maybe" });
+		const v = await checkSpam(
+			{
+				SPAM_PROVIDER: "akismet",
+				AKISMET_API_KEY: "key",
+				AKISMET_SITE_URL: "https://example.com",
+			},
+			input,
+		);
+		expect(v).toBeNull();
+	});
+});
+
+describe("workers-ai provider", () => {
+	const makeAi = (response: string) => ({
+		// Cloudflare's Ai.run returns either a string or { response: string }.
+		run: vi.fn(async () => ({ response })),
+	});
+
+	class StubKV {
+		map = new Map<string, string>();
+		async get(key: string) {
+			return this.map.get(key) ?? null;
+		}
+		async put(key: string, value: string) {
+			this.map.set(key, value);
+		}
+	}
+
+	it("returns spam=true when the model says SPAM", async () => {
+		const ai = makeAi("SPAM");
+		const kv = new StubKV();
+		const v = await checkSpam(
+			{
+				SPAM_PROVIDER: "workers-ai",
+				AI: ai as unknown as Ai,
+				RATE_LIMITS: kv as unknown as KVNamespace,
+			},
+			input,
+		);
+		expect(v).toEqual({ spam: true, reason: "workers-ai.spam" });
+		expect(ai.run).toHaveBeenCalledOnce();
+		// Caches the verdict so a second call short-circuits.
+		expect([...kv.map.values()]).toContain("spam");
+	});
+
+	it("returns spam=false when the model says HAM", async () => {
+		const ai = makeAi("HAM");
+		const v = await checkSpam(
+			{ SPAM_PROVIDER: "workers-ai", AI: ai as unknown as Ai },
+			input,
+		);
+		expect(v).toEqual({ spam: false });
+	});
+
+	it("uses cached verdict without calling the model again", async () => {
+		const ai = makeAi("SPAM");
+		const kv = new StubKV();
+		await checkSpam(
+			{
+				SPAM_PROVIDER: "workers-ai",
+				AI: ai as unknown as Ai,
+				RATE_LIMITS: kv as unknown as KVNamespace,
+			},
+			input,
+		);
+		expect(ai.run).toHaveBeenCalledTimes(1);
+
+		await checkSpam(
+			{
+				SPAM_PROVIDER: "workers-ai",
+				AI: ai as unknown as Ai,
+				RATE_LIMITS: kv as unknown as KVNamespace,
+			},
+			input,
+		);
+		expect(ai.run).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns null when the model emits something unrecognized", async () => {
+		const ai = makeAi("maybe?");
+		const v = await checkSpam(
+			{ SPAM_PROVIDER: "workers-ai", AI: ai as unknown as Ai },
+			input,
+		);
+		expect(v).toBeNull();
+	});
+
+	it("returns null when the model call throws", async () => {
+		const ai = { run: vi.fn(async () => { throw new Error("ai down"); }) };
+		const v = await checkSpam(
+			{ SPAM_PROVIDER: "workers-ai", AI: ai as unknown as Ai },
+			input,
+		);
+		expect(v).toBeNull();
+	});
+});

--- a/tests/spam-heuristics.test.ts
+++ b/tests/spam-heuristics.test.ts
@@ -85,6 +85,15 @@ describe("signFormTimestamp / verifyFormTimestamp", () => {
 		expect(v.flag).toBe(true);
 		expect(v.reason).toBe("form_ts.future");
 	});
+
+	it("flags a token older than one hour (max-age cap)", async () => {
+		const t0 = 1_000_000;
+		const token = await signFormTimestamp(t0, SECRET);
+		const oneHourPlus = t0 + 60 * 60 * 1000 + 1;
+		const v = await verifyFormTimestamp(token, SECRET, oneHourPlus, 1000);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.too_old");
+	});
 });
 
 // Minimal D1 stub that returns null for the "is there any row" probe

--- a/tests/spam-heuristics.test.ts
+++ b/tests/spam-heuristics.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Heuristic unit tests. Pure logic + one D1 stub for isFirstComment.
+ *
+ * These are the lightweight, always-on-if-configured signals from
+ * src/lib/spam/heuristics.ts. They're called BEFORE the (potentially
+ * paid) classifier adapter, so coverage here pays off in two ways:
+ * faster regressions and protection against accidentally weakening
+ * the precision of the form-ts HMAC check.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	countLinks,
+	isFirstComment,
+	signFormTimestamp,
+	verifyFormTimestamp,
+} from "../src/lib/spam/heuristics";
+
+const SECRET = "test-secret-do-not-use-anywhere-real";
+
+describe("countLinks", () => {
+	it("returns 0 for empty input", () => {
+		expect(countLinks("")).toBe(0);
+	});
+	it("counts a single https URL", () => {
+		expect(countLinks("see https://example.com today")).toBe(1);
+	});
+	it("counts http, https, and mailto", () => {
+		const md = "a http://a.b and https://c.d and mailto:x@y.z";
+		expect(countLinks(md)).toBe(3);
+	});
+	it("counts URLs even inside markdown link syntax", () => {
+		expect(countLinks("[x](https://a.b) and [y](https://c.d)")).toBe(2);
+	});
+	it("ignores plain text that looks like a domain but has no scheme", () => {
+		expect(countLinks("a.b.c is not a link, neither is www.x.y")).toBe(0);
+	});
+});
+
+describe("signFormTimestamp / verifyFormTimestamp", () => {
+	it("a freshly signed token verifies after enough elapsed time", async () => {
+		const t0 = 1_000_000;
+		const token = await signFormTimestamp(t0, SECRET);
+		const v = await verifyFormTimestamp(token, SECRET, t0 + 2000, 1000);
+		expect(v.flag).toBe(false);
+	});
+
+	it("flags submissions faster than minMs", async () => {
+		const t0 = 1_000_000;
+		const token = await signFormTimestamp(t0, SECRET);
+		const v = await verifyFormTimestamp(token, SECRET, t0 + 500, 1000);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.too_fast");
+	});
+
+	it("flags missing token", async () => {
+		const v = await verifyFormTimestamp(undefined, SECRET, 1, 1);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.missing");
+	});
+
+	it("flags malformed token (no dot)", async () => {
+		const v = await verifyFormTimestamp("garbage", SECRET, 1, 1);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.malformed");
+	});
+
+	it("flags a forged signature", async () => {
+		const token = await signFormTimestamp(1_000_000, SECRET);
+		const forged = `${token.slice(0, token.length - 1)}0`;
+		const v = await verifyFormTimestamp(forged, SECRET, 1_002_000, 1000);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.bad_sig");
+	});
+
+	it("flags a token signed with the wrong secret", async () => {
+		const token = await signFormTimestamp(1_000_000, "different-secret");
+		const v = await verifyFormTimestamp(token, SECRET, 1_002_000, 1000);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.bad_sig");
+	});
+
+	it("flags a future-dated token (negative elapsed)", async () => {
+		const token = await signFormTimestamp(2_000_000, SECRET);
+		const v = await verifyFormTimestamp(token, SECRET, 1_000_000, 1000);
+		expect(v.flag).toBe(true);
+		expect(v.reason).toBe("form_ts.future");
+	});
+});
+
+// Minimal D1 stub that returns null for the "is there any row" probe
+// when the userId has not been seen, and a row otherwise. We only
+// implement the prepare/bind/first surface that isFirstComment uses.
+type Bind = string | number | null;
+class StubD1 {
+	private seen = new Set<string>();
+	mark(userId: string) {
+		this.seen.add(userId);
+	}
+	prepare(_sql: string) {
+		const seen = this.seen;
+		return {
+			bind(...args: Bind[]) {
+				const userId = String(args[0]);
+				return {
+					async first<T>(): Promise<T | null> {
+						return seen.has(userId) ? ({ one: 1 } as unknown as T) : null;
+					},
+				};
+			},
+		};
+	}
+}
+
+describe("isFirstComment", () => {
+	it("returns true when the user has no prior rows", async () => {
+		const db = new StubD1() as unknown as D1Database;
+		expect(await isFirstComment(db, "user-1")).toBe(true);
+	});
+	it("returns false when the user has at least one prior row", async () => {
+		const stub = new StubD1();
+		stub.mark("user-1");
+		const db = stub as unknown as D1Database;
+		expect(await isFirstComment(db, "user-1")).toBe(false);
+	});
+});

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -38,6 +38,21 @@ PUBLIC_BASE_URL = "https://comments.example.com"
 # Leave unset in dev; the worker falls back to the request origin.
 OAUTH_CALLBACK_BASE = "https://comments.example.com"
 
+# Anti-spam (all optional; OFF by default). See docs/ANTISPAM.md.
+# Pluggable content classifier — "akismet" or "workers-ai". Leave unset for none.
+# SPAM_PROVIDER = "akismet"
+# SPAM_PROVIDER = "workers-ai"
+#
+# Lightweight in-core heuristics. Unset = off. Tripped signals flag the
+# comment to status='pending' (admin queue) — never a silent drop.
+# SPAM_LINK_THRESHOLD = "3"            # flag if > N URLs in body
+# SPAM_HONEYPOT_MIN_MS = "1500"        # flag if form submitted faster than N ms
+# SPAM_FIRST_COMMENT_MODERATE = "true" # first comment from a new author → pending
+#
+# For SPAM_PROVIDER = "workers-ai", also add this binding:
+# [ai]
+# binding = "AI"
+
 # Notification digest job runs every 15 minutes; tune to taste.
 # Comments newer than 5 minutes are debounced so a reply burst coalesces
 # into a single email per subscriber.
@@ -55,6 +70,9 @@ crons = ["*/15 * * * *"]
 #   wrangler secret put GOOGLE_CLIENT_SECRET
 #   wrangler secret put RESEND_API_KEY
 #   wrangler secret put WEBHOOK_URL           # optional, fire-and-forget POST on new comment
+#   wrangler secret put SPAM_FORM_TS_SECRET   # HMAC key for signed form-timestamp tokens (set when SPAM_HONEYPOT_MIN_MS is used)
+#   wrangler secret put AKISMET_API_KEY       # required when SPAM_PROVIDER = "akismet"
+#   wrangler secret put AKISMET_SITE_URL      # public site URL for Akismet (e.g. https://yourblog.example.com)
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

Adds layered, **off-by-default** anti-spam on top of the existing Turnstile + rate-limit + sanitizer + field-honeypot stack. Self-hosters opt into what fits their privacy/operational appetite. Nothing is ever silently dropped — flagged comments go to `status='pending'` and land in the existing `/admin/queue?status=pending` UI.

- **Three lightweight heuristics** (no external dependency):
  - HMAC-signed form-timestamp honeypot (`SPAM_HONEYPOT_MIN_MS` + `SPAM_FORM_TS_SECRET`)
  - Link-count threshold (`SPAM_LINK_THRESHOLD`)
  - First-comment moderation (`SPAM_FIRST_COMMENT_MODERATE`)
- **Pluggable classifier adapter** mirroring `src/lib/email.ts`:
  - `akismet` provider — sends body + author + post URL, deliberately substitutes `user_ip=127.0.0.1` to preserve Garrul's no-raw-IP posture
  - `workers-ai` provider — Llama-3.1-8b on the Cloudflare AI binding, verdicts cached 6h in KV
- **Public tree hides pending rows**; subscriber email fanout skipped until approval.
- **Admin dashboard + settings** show which layers are active so operators don't need to grep wrangler.toml.
- **Widget** fetches a signed form-token at load and surfaces an "awaiting moderation" notice when the server returns pending.
- **Docs**: new `docs/ANTISPAM.md` covering privacy tradeoff per provider.

Commits are atomic per concern (core module → bindings → API → widget → admin → tests → docs).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 167 passing across 15 files (new `spam-heuristics` + `spam-adapter` suites)
- [x] `npm run build` — `embed.js` 5.49 KB gzipped (ceiling 20 KB)
- [ ] Manual e2e with `wrangler dev`:
  - [ ] Defaults unset → identical behavior to main
  - [ ] `SPAM_LINK_THRESHOLD=2` → 3-link comment lands in `/admin/queue?status=pending`, hidden from public GET
  - [ ] `SPAM_HONEYPOT_MIN_MS=2000` → curl submission with stale form_ts flags
  - [ ] `SPAM_FIRST_COMMENT_MODERATE=true` → first ghost comment pending; second from same IP hash approved
  - [ ] `SPAM_PROVIDER=akismet` with `author=akismet-guaranteed-spam` → pending
  - [ ] `SPAM_PROVIDER=workers-ai` → obvious spam pending, normal comment approved
- [ ] `wrangler tail` — confirm structured `spam.flagged` log lines, no PII in payloads