### PR TITLE
feat: roles, webhooks v2, voting, usage, saved replies, importer, domain filtering

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,110 @@
+# Webhooks
+
+Outbound HTTP notifications when comments change state. Configure
+endpoints in `/admin/webhooks`.
+
+## Payload (v1)
+
+```json
+{
+  "event": "comment.posted",
+  "comment_id": "01HXX0000000000000000",
+  "post_slug": "blog/hello-world",
+  "user_id":   "01HXY0000000000000000",
+  "ts": 1700000000000
+}
+```
+
+Events:
+
+- `comment.posted` — a new comment was accepted (may still be `pending`
+  if the spam pipeline holds it for review)
+- `comment.edited` — author edited inside the edit window
+- `comment.deleted` — admin/mod deleted (soft-delete)
+- `comment.approved` — admin/mod approved a pending/spam comment
+- `comment.spam` — admin/mod marked spam
+
+Headers:
+
+- `Content-Type: application/json`
+- `User-Agent: Garrul-Webhook/2.0`
+- `X-Garrul-Signature: t=<ms_epoch>,v1=<hex_sha256>` *(only if the
+  endpoint has an HMAC secret)*
+
+## Verifying the signature
+
+Required for any endpoint that has a secret configured. Reject every
+unsigned delivery on an endpoint you configured *with* a secret —
+treating unsigned requests as valid defeats the point of having one.
+
+The signed payload is `<ts>.<raw_body>` — the literal request body
+prefixed by the timestamp from the header. **Hash the raw bytes, not a
+re-serialized JSON object** — re-serializing reorders keys.
+
+```js
+// Node 18+ / any standard HMAC library
+import crypto from "node:crypto";
+
+const TOLERANCE_MS = 5 * 60 * 1000;
+
+function verify(secret, rawBody, header) {
+  if (!header) return false;
+  const parts = Object.fromEntries(
+    header.split(",").map(p => p.split("=", 2)),
+  );
+  const ts = Number(parts.t);
+  const sig = parts.v1;
+  if (!ts || !sig) return false;
+  if (Math.abs(Date.now() - ts) > TOLERANCE_MS) return false;
+  const want = crypto
+    .createHmac("sha256", secret)
+    .update(`${ts}.${rawBody}`)
+    .digest("hex");
+  // Constant-time compare — never use === on the hex strings.
+  return (
+    want.length === sig.length &&
+    crypto.timingSafeEqual(Buffer.from(want), Buffer.from(sig))
+  );
+}
+```
+
+The tolerance defends against replays of an old delivery. Five minutes
+matches the sender's default — anything inside that window with a valid
+signature is accepted.
+
+## Retries and auto-disable
+
+Failed deliveries (network error or non-2xx response) are retried via
+an exponential schedule:
+
+| Attempt | Delay from previous |
+|--------:|---------------------|
+| 1       | +1 minute           |
+| 2       | +5 minutes          |
+| 3       | +30 minutes         |
+| 4       | +2 hours            |
+| 5       | +6 hours            |
+
+After 5 retries (≈9h total) the delivery is given up and the
+endpoint's failure counter increments. After 10 consecutive give-ups
+the endpoint is auto-paused — the admin UI shows the `auto-paused`
+note. Re-enabling the endpoint clears the counter and pause marker.
+
+Each retry signs with a *fresh* timestamp so the receiver's tolerance
+check still passes hours after the original event.
+
+## Adapter selection
+
+The default `generic` adapter sends the v1 payload above. `slack` and
+`discord` adapters reshape the body for those platforms — set this on
+the endpoint when the target URL is a Slack or Discord incoming
+webhook. Adapter changes do not require receiver changes.
+
+## Legacy `WEBHOOK_URL`
+
+Operators on the pre-v2 release shipped a single `WEBHOOK_URL` env var
+with no signing and no retries. That still works: when set with no
+table rows, Garrul synthesizes an unsigned, retry-less endpoint at
+dispatch time. The admin page flags this with a banner so you know to
+migrate. Add a real endpoint (with a secret) and unset the env var to
+gain signing + retries.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "migrate": "tsx src/db/migrate.ts",
     "rerender": "tsx scripts/rerender.ts",
     "seed-demo": "tsx scripts/seed-demo.ts",
+    "import-disqus": "tsx scripts/import-disqus.ts",
     "db:export": "bash scripts/db-export.sh",
     "upgrade": "tsx scripts/upgrade.ts",
     "manifest:build": "tsx scripts/upgrade/build-manifest.ts",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -90,6 +90,26 @@
       "name": "SPAM_FORM_TS_SECRET",
       "required": false,
       "addedIn": "1.1.1"
+    },
+    {
+      "name": "CF_API_TOKEN",
+      "required": false,
+      "addedIn": "1.8.0"
+    },
+    {
+      "name": "CF_ACCOUNT_ID",
+      "required": false,
+      "addedIn": "1.8.0"
+    },
+    {
+      "name": "VOTING_ENABLED",
+      "required": false,
+      "addedIn": "1.8.0"
+    },
+    {
+      "name": "DOWNVOTES_ENABLED",
+      "required": false,
+      "addedIn": "1.8.0"
     }
   ],
   "kvNamespaces": [
@@ -134,7 +154,12 @@
     "0001_init.sql",
     "0002_notifications.sql",
     "0003_subscription_confirm.sql",
-    "0004_admin_observability.sql"
+    "0004_admin_observability.sql",
+    "0005_user_roles.sql",
+    "0006_webhook_endpoints.sql",
+    "0007_votes.sql",
+    "0008_saved_replies.sql",
+    "0009_import_tracking.sql"
   ],
   "breakingChanges": []
 }

--- a/scripts/import-disqus.ts
+++ b/scripts/import-disqus.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env tsx
+/**
+ * Import a Disqus comment-export XML file into the local or remote D1.
+ *
+ *   npm run import-disqus -- ./disqus-export.xml             # local D1
+ *   npm run import-disqus -- ./disqus-export.xml --remote    # production D1
+ *
+ * Flags:
+ *   --remote            Use the deployed D1 binding instead of Miniflare.
+ *   --dry-run           Parse + plan only. No INSERTs run.
+ *   --include-deleted   Bring Disqus-deleted comments across (default: skip).
+ *   --include-spam      Bring Disqus-spam comments across (default: skip).
+ *   --slug=<slug>       Pin every imported thread to one slug (rare —
+ *                       useful when migrating a single page).
+ *
+ * Idempotent: re-running on the same XML inserts zero new rows (every
+ * comment carries `import_source='disqus'` + a Disqus dsq_id under
+ * `import_id`, and migration 0009 puts a partial UNIQUE index on that
+ * pair).
+ *
+ * Why this is a local CLI, not a Worker endpoint:
+ *   Big Disqus exports easily exceed the Workers free-tier 100k D1
+ *   writes/day quota in a single import. Running locally via wrangler
+ *   d1 execute counts those writes against your D1 budget, but does
+ *   NOT spend any Worker requests. The admin upload endpoint
+ *   (operator page) wraps this same library but caps the per-call
+ *   write volume.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import { runDisqusImport } from "../src/lib/disqus-import";
+
+const DB_NAME = "garrul-db";
+
+const args = process.argv.slice(2);
+const positional = args.filter((a) => !a.startsWith("--"));
+const xmlPath = positional[0];
+if (!xmlPath) {
+	console.error("usage: npm run import-disqus -- <path-to-disqus.xml> [--remote] [--dry-run]");
+	process.exit(2);
+}
+const isRemote = args.includes("--remote");
+const dryRun = args.includes("--dry-run");
+const includeDeleted = args.includes("--include-deleted");
+const includeSpam = args.includes("--include-spam");
+const slugFlag = args.find((a) => a.startsWith("--slug="));
+const slugOverride = slugFlag ? slugFlag.slice("--slug=".length) : null;
+
+const remoteFlag = isRemote ? "--remote" : "--local";
+
+// The importer needs to talk to D1. tsx running locally can't bind D1
+// directly — we drive it through `wrangler d1 execute` per statement.
+// That's only viable for thousands-not-millions of rows. The admin
+// endpoint uses the same library inside the Worker where DB is bound
+// natively, which is the production path.
+const sqlEsc = (s: string): string => s.replace(/'/g, "''");
+
+const runWrangler = (sql: string): string =>
+	execFileSync(
+		"wrangler",
+		["d1", "execute", DB_NAME, remoteFlag, "--command", sql],
+		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+	);
+
+const d1: D1Database = {
+	prepare(rawSql: string) {
+		let sql = rawSql;
+		const binds: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				binds.push(...args);
+				return this;
+			},
+			async first<T = unknown>(): Promise<T | null> {
+				const resolved = resolve(sql, binds);
+				const out = runWrangler(resolved);
+				const rows = parseRows(out);
+				return (rows[0] as T) ?? null;
+			},
+			async all<T = unknown>(): Promise<{ results: T[] }> {
+				const resolved = resolve(sql, binds);
+				const out = runWrangler(resolved);
+				return { results: parseRows(out) as T[] };
+			},
+			async run() {
+				const resolved = resolve(sql, binds);
+				runWrangler(resolved);
+				return { meta: { changes: 1 } };
+			},
+		} as unknown as D1PreparedStatement;
+	},
+} as unknown as D1Database;
+
+const resolve = (sql: string, binds: unknown[]): string => {
+	let i = 0;
+	return sql.replace(/\?/g, () => {
+		const v = binds[i++];
+		if (v === null || v === undefined) return "NULL";
+		if (typeof v === "number") return String(v);
+		return `'${sqlEsc(String(v))}'`;
+	});
+};
+
+const parseRows = (output: string): Record<string, unknown>[] => {
+	// wrangler d1 execute --command prints a small JSON envelope when
+	// the query returns rows. We only need the rows arm — anything else
+	// (errors / empty result sets) becomes [].
+	const m = output.match(/\[(\s*\{[\s\S]*?\}\s*)\]/);
+	if (!m) return [];
+	try {
+		return JSON.parse(m[0]) as Record<string, unknown>[];
+	} catch {
+		return [];
+	}
+};
+
+(async () => {
+	if (!isRemote) {
+		console.warn(`[import-disqus] running against LOCAL D1 (Miniflare).`);
+	}
+	const xml = readFileSync(xmlPath, "utf8");
+	const secret = process.env.IP_HASH_SECRET ?? "disqus-import-secret-fallback";
+
+	const plan = await runDisqusImport(d1, xml, secret, {
+		dry_run: dryRun,
+		include_deleted: includeDeleted,
+		include_spam: includeSpam,
+		slug_override: slugOverride,
+	});
+
+	console.log(
+		`[import-disqus] ${dryRun ? "DRY RUN" : "DONE"}`,
+		JSON.stringify(plan, null, 2),
+	);
+})().catch((err) => {
+	console.error("[import-disqus] failed:", err);
+	process.exit(1);
+});

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -80,6 +80,7 @@ ${renderUpdateBanner(updateInfo)}
     <a href="/admin/users">Users</a>
     <a href="/admin/audit">Audit</a>
     <a href="/admin/subscriptions">Subscriptions</a>
+    <a href="/admin/webhooks">Webhooks</a>
     <a href="/admin/operator">Operator</a>
     <a href="/admin/settings">Settings</a>
     <a href="/admin/about">About</a>

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -103,7 +103,8 @@ ${renderUpdateBanner(updateInfo)}
   <h1>Garrul Admin</h1>
   <nav>
     <a href="/admin">Dashboard</a>
-    <a href="/admin/queue">Queue</a>${adminOnlyLinks}
+    <a href="/admin/queue">Queue</a>
+    <a href="/admin/saved-replies">Replies</a>${adminOnlyLinks}
     <a href="/admin/about">About</a>
   </nav>
   <span class="me">${escapeHtml(currentUser.name)} ${rolePill} <button class="help-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button></span>

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -58,7 +58,23 @@ export const layout = (
 	body: string,
 	currentUser: User,
 	updateInfo: UpdateInfo | null,
-): string => `
+): string => {
+	const isAdmin = currentUser.role === "admin";
+	const rolePill =
+		currentUser.role === "admin"
+			? '<span class="pill admin">admin</span>'
+			: currentUser.role === "mod"
+				? '<span class="pill mod">mod</span>'
+				: "";
+	const adminOnlyLinks = isAdmin
+		? `
+    <a href="/admin/users">Users</a>
+    <a href="/admin/audit">Audit</a>
+    <a href="/admin/subscriptions">Subscriptions</a>
+    <a href="/admin/operator">Operator</a>
+    <a href="/admin/settings">Settings</a>`
+		: "";
+	return `
 <!doctype html>
 <html lang="en">
 <head>
@@ -76,15 +92,10 @@ ${renderUpdateBanner(updateInfo)}
   <h1>Garrul Admin</h1>
   <nav>
     <a href="/admin">Dashboard</a>
-    <a href="/admin/queue">Queue</a>
-    <a href="/admin/users">Users</a>
-    <a href="/admin/audit">Audit</a>
-    <a href="/admin/subscriptions">Subscriptions</a>
-    <a href="/admin/operator">Operator</a>
-    <a href="/admin/settings">Settings</a>
+    <a href="/admin/queue">Queue</a>${adminOnlyLinks}
     <a href="/admin/about">About</a>
   </nav>
-  <span class="me">${escapeHtml(currentUser.name)} <span class="pill admin">admin</span> <button class="help-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button></span>
+  <span class="me">${escapeHtml(currentUser.name)} ${rolePill} <button class="help-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button></span>
 </header>
 <div class="toast-tray" role="status" aria-live="polite" aria-atomic="true"
      x-data="{ items: [] }"
@@ -110,3 +121,4 @@ ${body}
         defer></script>
 </body>
 </html>`;
+};

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -53,11 +53,16 @@ export const renderUpdateBanner = (info: UpdateInfo | null): string => {
 </div>`;
 };
 
+export type LayoutOpts = {
+	usage_link?: boolean;
+};
+
 export const layout = (
 	title: string,
 	body: string,
 	currentUser: User,
 	updateInfo: UpdateInfo | null,
+	opts: LayoutOpts = {},
 ): string => `
 <!doctype html>
 <html lang="en">
@@ -81,6 +86,7 @@ ${renderUpdateBanner(updateInfo)}
     <a href="/admin/audit">Audit</a>
     <a href="/admin/subscriptions">Subscriptions</a>
     <a href="/admin/webhooks">Webhooks</a>
+    ${opts.usage_link ? '<a href="/admin/usage">Usage</a>' : ""}
     <a href="/admin/operator">Operator</a>
     <a href="/admin/settings">Settings</a>
     <a href="/admin/about">About</a>

--- a/src/admin-ui/pages/operator.ts
+++ b/src/admin-ui/pages/operator.ts
@@ -98,5 +98,67 @@ export const renderOperator = (data: OperatorData): string => {
 </div>
 
 ${seedCard}
+
+<div class="card" x-data="{
+  busy: false,
+  result: null,
+  error: null,
+  dryRun: true,
+  includeDeleted: false,
+  includeSpam: false,
+  async run(file) {
+    if (!file) return;
+    if (file.size > 50 * 1024 * 1024) {
+      this.error = 'file too large (max 50 MB)';
+      return;
+    }
+    this.busy = true; this.error = null; this.result = null;
+    try {
+      const text = await file.text();
+      const r = await fetch('/admin/api/ops/import-disqus', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/xml',
+          'x-dry-run': this.dryRun ? '1' : '0',
+          'x-include-deleted': this.includeDeleted ? '1' : '0',
+          'x-include-spam': this.includeSpam ? '1' : '0',
+        },
+        body: text,
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || 'import failed');
+      this.result = j;
+    } catch (e) {
+      this.error = e.message || 'import failed';
+    } finally {
+      this.busy = false;
+    }
+  }
+}">
+  <h3>Import Disqus export</h3>
+  <p class="muted">Uploads a Disqus comment-export XML file and ingests it
+    into D1. Idempotent: re-running the same file is a no-op
+    (deduplicated by Disqus comment ID). Imported HTML is stripped and
+    re-rendered through the standard markdown allowlist.</p>
+  <p>
+    <label style="display:inline-flex;gap:0.3rem;align-items:center;margin-right:0.8rem">
+      <input type="checkbox" x-model="dryRun"> Dry run (parse + plan only)
+    </label>
+    <label style="display:inline-flex;gap:0.3rem;align-items:center;margin-right:0.8rem">
+      <input type="checkbox" x-model="includeDeleted"> Include deleted
+    </label>
+    <label style="display:inline-flex;gap:0.3rem;align-items:center">
+      <input type="checkbox" x-model="includeSpam"> Include spam
+    </label>
+  </p>
+  <input type="file" accept=".xml,application/xml,text/xml"
+         :disabled="busy"
+         @change="run($event.target.files[0])">
+  <p class="muted" x-show="busy">Importing… don't navigate away.</p>
+  <pre x-show="result" x-text="result &amp;&amp; JSON.stringify(result, null, 2)"
+       style="background:var(--bg);padding:0.6rem;border-radius:4px;font-size:0.85rem"></pre>
+  <p style="color:var(--bad)" x-show="error" x-text="error"></p>
+  <p class="muted">For large exports prefer the CLI: <code>npm run import-disqus -- ./export.xml --dry-run</code>.</p>
+</div>
 `;
 };

--- a/src/admin-ui/pages/queue.ts
+++ b/src/admin-ui/pages/queue.ts
@@ -64,6 +64,19 @@ const authorCell = (c: AdminComment): string => {
 </a>`;
 };
 
+// Net vote score with up/down split. We render the net first (the value
+// brigading mitigation cares about) and a muted sub-line with the raw
+// counts so a mod scanning the queue can spot e.g. 50↑/49↓ noise.
+const scoreCell = (c: AdminComment): string => {
+	const up = c.score_up ?? 0;
+	const down = c.score_down ?? 0;
+	const net = up - down;
+	const cls = net > 0 ? "score-pos" : net < 0 ? "score-neg" : "muted";
+	return `
+<span class="score ${cls}">${net > 0 ? "+" : ""}${net}</span>
+<div class="muted" style="font-size:0.75rem">${up}↑ ${down}↓</div>`;
+};
+
 // Embed values as JSON-stringified, HTML-escaped literals so the resulting
 // Alpine expression is well-formed regardless of the underlying string
 // content (defense in depth: ULIDs are safe today, but the typing is just
@@ -142,6 +155,7 @@ export const renderQueue = (
   <td class="bulk-cell"><input type="checkbox" :value="${jsLiteral(c.id)}" x-model="selected" :disabled="busy"></td>
   <td><span class="pill ${c.status}">${c.status}</span></td>
   <td>${authorCell(c)}</td>
+  <td class="score-cell" title="up / down">${scoreCell(c)}</td>
   <td>
     <div class="muted">${new Date(c.created_at).toISOString().slice(0, 16).replace("T", " ")}</div>
     <div><code>${escapeHtml(c.post_slug)}</code></div>
@@ -155,7 +169,7 @@ export const renderQueue = (
 </tr>`,
 				)
 				.join("")
-		: `<tr><td colspan="6" class="muted">No comments match.</td></tr>`;
+		: `<tr><td colspan="7" class="muted">No comments match.</td></tr>`;
 
 	const allIds = rows.map((r) => r.id);
 
@@ -212,7 +226,7 @@ ${filterBar}
   <table>
     <thead><tr>
       <th class="bulk-cell"><input type="checkbox" @change="toggleAll($event)" :checked="selected.length > 0 && selected.length === allIds.length"></th>
-      <th>Status</th><th>Author</th><th>Meta</th><th>Body</th><th>Actions</th>
+      <th>Status</th><th>Author</th><th title="Vote score">Score</th><th>Meta</th><th>Body</th><th>Actions</th>
     </tr></thead>
     <tbody>${rowsHtml}</tbody>
   </table>

--- a/src/admin-ui/pages/queue.ts
+++ b/src/admin-ui/pages/queue.ts
@@ -108,6 +108,13 @@ const actionButtons = (id: string, status: CommentStatus): string => {
 			`<button :disabled="busy" class="bad" @click="${rowAct(id, "delete", "Deleted")}">Delete</button>`,
 		);
 	}
+	// Reply opens the saved-replies picker — mods only see it on
+	// approved/pending comments. No point replying to deleted/spam.
+	if (status !== "deleted" && status !== "spam") {
+		parts.push(
+			`<button :disabled="busy" @click="$dispatch('open-reply', { id: ${jsLiteral(id)} })">Reply</button>`,
+		);
+	}
 	return parts.join("");
 };
 
@@ -184,6 +191,57 @@ export const renderQueue = (
 	return `
 <div class="filter-bar"><span class="muted">filter:</span> ${tabs}</div>
 ${filterBar}
+<div x-data="{
+  open: false,
+  commentId: null,
+  replies: [],
+  selected: null,
+  busy: false,
+  body: '',
+  loaded: false,
+  async load() {
+    if (this.loaded) return;
+    this.busy = true;
+    try {
+      const r = await fetch('/admin/api/saved-replies', { headers: { accept: 'application/json' } });
+      if (!r.ok) throw new Error('Could not load saved replies');
+      const j = await r.json();
+      this.replies = Array.isArray(j.replies) ? j.replies : [];
+      this.loaded = true;
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Load failed', kind: 'bad' });
+    } finally {
+      this.busy = false;
+    }
+  },
+  pick(r) {
+    this.selected = r;
+    this.body = r.body_md;
+  },
+  async send() {
+    if (!this.selected || !this.commentId) return;
+    this.busy = true;
+    try {
+      const r = await fetch('/admin/api/saved-replies/' + this.selected.id + '/post', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ comment_id: this.commentId, body_md: this.body }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.error || ('Post failed: ' + r.status));
+      }
+      this.$dispatch('toast', { text: 'Reply posted' });
+      this.open = false;
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Post failed', kind: 'bad' });
+    } finally {
+      this.busy = false;
+    }
+  }
+}"
+@open-reply.window="open=true; commentId=$event.detail.id; selected=null; body=''; load();"
+@keydown.escape.window="open=false">
 <div class="card" x-data="{
   selected: [],
   bulkBusy: false,
@@ -238,5 +296,38 @@ ${filterBar}
     <button :disabled="bulkBusy" class="bad" @click="bulk('delete')">Delete</button>
     <button :disabled="bulkBusy" @click="selected = []">Clear</button>
   </div>
+</div>
+<div class="reply-modal" x-show="open" x-cloak role="dialog" aria-label="Reply with a saved reply"
+     @click.self="open=false">
+  <div class="reply-modal-inner">
+    <h3 style="margin-top:0">Reply with a saved reply</h3>
+    <p class="muted" x-show="!replies.length && loaded">
+      No saved replies yet — <a href="/admin/saved-replies/new">create one</a>.
+    </p>
+    <ul class="reply-list" x-show="replies.length">
+      <template x-for="r in replies" :key="r.id">
+        <li>
+          <button type="button"
+                  :class="selected && selected.id === r.id ? 'reply-pick active' : 'reply-pick'"
+                  @click="pick(r)">
+            <strong x-text="r.title"></strong>
+            <span class="muted" x-text="r.scope"></span>
+          </button>
+        </li>
+      </template>
+    </ul>
+    <div x-show="selected">
+      <label>Body (markdown)<br>
+        <textarea x-model="body" rows="8" maxlength="8000"
+                  style="width:100%;min-height:160px;font-family:ui-monospace,monospace"></textarea>
+      </label>
+      <p>
+        <button :disabled="busy || !body.trim()" @click="send()">Post reply</button>
+        <button :disabled="busy" @click="open=false" class="btn">Cancel</button>
+      </p>
+    </div>
+    <p x-show="!selected && replies.length" class="muted">Pick a reply above to preview and post.</p>
+  </div>
+</div>
 </div>`;
 };

--- a/src/admin-ui/pages/saved-replies.ts
+++ b/src/admin-ui/pages/saved-replies.ts
@@ -1,0 +1,186 @@
+/**
+ * Saved Replies admin page — canned moderator responses.
+ *
+ * Two surfaces:
+ *   - renderSavedRepliesList(replies, viewer)
+ *     Tabular list of every reply visible to the viewer. Each row links
+ *     to /admin/saved-replies/:id for edit; the new-reply button opens
+ *     /admin/saved-replies/new.
+ *   - renderSavedReplyForm(opts)
+ *     The form is reused for both create and edit. The mode is implicit
+ *     in `opts.existing`: when present, the form posts to PATCH; when
+ *     absent, to POST.
+ *
+ * Mutate buttons only render when the viewer owns the reply — the API
+ * enforces this server-side regardless, but hiding the buttons keeps
+ * the UI honest.
+ */
+import type { SavedReply, User } from "../../db/queries";
+import { escapeHtml } from "../escape";
+
+const formatTs = (ts: number): string =>
+	new Date(ts).toISOString().slice(0, 16).replace("T", " ");
+
+const ownerCell = (
+	reply: SavedReply,
+	viewer: User,
+	ownerName: string | null,
+): string => {
+	if (reply.owner_id === viewer.id) return '<span class="muted">you</span>';
+	return ownerName ? escapeHtml(ownerName) : `<span class="muted">deleted user</span>`;
+};
+
+const scopePill = (scope: SavedReply["scope"]): string =>
+	scope === "shared"
+		? '<span class="pill approved">shared</span>'
+		: '<span class="pill" style="border-color:var(--accent);color:var(--accent)">private</span>';
+
+const replyRow = (
+	reply: SavedReply,
+	viewer: User,
+	ownerName: string | null,
+): string => {
+	const mine = reply.owner_id === viewer.id;
+	return `
+<tr>
+  <td>
+    <div><strong>${escapeHtml(reply.title)}</strong></div>
+    <div class="muted" style="font-size:0.75rem">updated ${formatTs(reply.updated_at)}</div>
+  </td>
+  <td>${scopePill(reply.scope)}</td>
+  <td>${ownerCell(reply, viewer, ownerName)}</td>
+  <td class="actions">
+    ${mine ? `<a href="/admin/saved-replies/${escapeHtml(reply.id)}" class="btn">Edit</a>` : '<span class="muted">read-only</span>'}
+  </td>
+</tr>`;
+};
+
+export const renderSavedRepliesList = (
+	replies: SavedReply[],
+	viewer: User,
+	ownersById: Map<string, string>,
+): string => {
+	const rows = replies.length
+		? replies
+				.map((r) => replyRow(r, viewer, ownersById.get(r.owner_id) ?? null))
+				.join("")
+		: '<tr><td colspan="4" class="muted">No saved replies yet.</td></tr>';
+	return `
+<div class="card">
+  <h3 style="margin-top:0">Saved replies</h3>
+  <p class="muted">
+    Pre-written replies you (or your team) can drop into the moderation
+    queue. Mark a reply as <strong>shared</strong> to make it visible to
+    every mod and admin; <strong>private</strong> replies are visible
+    only to you. Markdown goes through the same sanitizer as comment
+    bodies; raw HTML is stripped.
+  </p>
+  <p><a href="/admin/saved-replies/new" class="btn">+ New saved reply</a></p>
+  <table>
+    <thead><tr>
+      <th>Title</th><th>Scope</th><th>Owner</th><th>Actions</th>
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</div>`;
+};
+
+export const renderSavedReplyForm = (opts: {
+	existing: SavedReply | null;
+	error: string | null;
+}): string => {
+	const e = opts.existing;
+	const action = e
+		? `/admin/api/saved-replies/${escapeHtml(e.id)}`
+		: `/admin/api/saved-replies`;
+	const method = e ? "PATCH" : "POST";
+	const heading = e ? "Edit saved reply" : "New saved reply";
+	const errorBanner = opts.error
+		? `<div class="card" style="border-left:3px solid var(--bad)"><strong>Error:</strong> ${escapeHtml(opts.error)}</div>`
+		: "";
+	const title = e?.title ?? "";
+	const body = e?.body_md ?? "";
+	const scope = e?.scope ?? "private";
+	const deleteButton = e
+		? `
+<button type="button" class="bad" :disabled="busy"
+        @click="del('${escapeHtml(e.id)}')">Delete saved reply</button>`
+		: "";
+	return `
+${errorBanner}
+<div class="card" x-data="{
+  busy: false,
+  async submit(form) {
+    this.busy = true;
+    try {
+      const body = {
+        title: form.title.value,
+        body_md: form.body_md.value,
+        scope: form.scope.value,
+      };
+      const r = await fetch('${action}', {
+        method: '${method}',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.error || ('Save failed: ' + r.status));
+      }
+      this.$dispatch('toast', { text: 'Saved' });
+      setTimeout(() => location.href = '/admin/saved-replies', 300);
+    } catch (err) {
+      this.$dispatch('toast', { text: err.message || 'Save failed', kind: 'bad' });
+      this.busy = false;
+    }
+  },
+  async del(id) {
+    if (!confirm('Delete this saved reply?')) return;
+    this.busy = true;
+    try {
+      const r = await fetch('/admin/api/saved-replies/' + id, {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.error || ('Delete failed: ' + r.status));
+      }
+      this.$dispatch('toast', { text: 'Deleted' });
+      setTimeout(() => location.href = '/admin/saved-replies', 300);
+    } catch (err) {
+      this.$dispatch('toast', { text: err.message || 'Delete failed', kind: 'bad' });
+      this.busy = false;
+    }
+  },
+}">
+  <h3 style="margin-top:0">${heading}</h3>
+  <form @submit.prevent="submit($event.target)">
+    <p>
+      <label>Title<br>
+        <input type="text" name="title" required maxlength="120"
+               value="${escapeHtml(title)}" style="width:100%;max-width:480px">
+      </label>
+    </p>
+    <p>
+      <label>Body (markdown)<br>
+        <textarea name="body_md" required rows="10"
+                  maxlength="8000" style="width:100%;min-height:160px;font-family:ui-monospace,monospace">${escapeHtml(body)}</textarea>
+      </label>
+    </p>
+    <p>
+      <label>Scope<br>
+        <select name="scope">
+          <option value="private"${scope === "private" ? " selected" : ""}>Private — only you</option>
+          <option value="shared"${scope === "shared" ? " selected" : ""}>Shared — all mods + admins</option>
+        </select>
+      </label>
+    </p>
+    <p>
+      <button type="submit" :disabled="busy">Save</button>
+      ${deleteButton}
+      <a href="/admin/saved-replies" class="btn">Cancel</a>
+    </p>
+  </form>
+</div>`;
+};

--- a/src/admin-ui/pages/usage.ts
+++ b/src/admin-ui/pages/usage.ts
@@ -1,0 +1,187 @@
+/**
+ * Cloudflare usage dashboard — renders today's Workers / D1 / KV usage
+ * against the free-tier ceilings. Two render modes:
+ *
+ *   renderUsageSetup()    — token absent. Shows the wrangler secret put
+ *                           commands and the required token scopes.
+ *   renderUsageDashboard() — token present. Shows three usage panels,
+ *                           each with its own success/error state.
+ *
+ * Chart strategy: each panel emits a tiny inline SVG bar with the
+ * free-tier ceiling drawn as a vertical line. No JS chart library —
+ * keeps the admin bundle thin and the page renderable without
+ * client-side execution.
+ */
+import { escapeHtml } from "../escape";
+import type { Panel, UsageSnapshot } from "../../lib/cf-usage";
+
+// Free-tier limits as of 2026-05. Update alongside Cloudflare's docs.
+const LIMITS = {
+	workers_requests_per_day: 100_000,
+	d1_reads_per_day: 5_000_000,
+	d1_writes_per_day: 100_000,
+	d1_storage_bytes: 5 * 1024 * 1024 * 1024,
+	kv_reads_per_day: 100_000,
+	kv_writes_per_day: 1_000,
+} as const;
+
+const fmt = (n: number): string => n.toLocaleString("en-US");
+
+const pct = (used: number, ceiling: number): number =>
+	ceiling === 0 ? 0 : Math.min(100, (used / ceiling) * 100);
+
+const barColor = (p: number): string =>
+	p >= 90 ? "var(--bad)" : p >= 75 ? "var(--warn)" : "var(--ok)";
+
+// Single-bar SVG with the ceiling tick. Width is fluid via viewBox so
+// it scales inside the card.
+const usageBar = (used: number, ceiling: number, label: string): string => {
+	const p = pct(used, ceiling);
+	const c = barColor(p);
+	return `
+<div class="usage-row">
+  <div class="usage-label">
+    <strong>${escapeHtml(label)}</strong>
+    <span class="muted">${fmt(used)} / ${fmt(ceiling)}</span>
+  </div>
+  <svg viewBox="0 0 200 14" preserveAspectRatio="none"
+       style="width:100%;height:14px;background:var(--card-soft);border-radius:3px"
+       role="img" aria-label="${escapeHtml(`${label}: ${p.toFixed(1)}%`)}">
+    <rect x="0" y="0" width="${p * 2}" height="14" fill="${c}"/>
+  </svg>
+  <div class="muted" style="font-size:0.75rem">${p.toFixed(1)}% of free-tier ceiling</div>
+</div>`;
+};
+
+const panelError = (label: string, err: string): string => `
+<div class="card">
+  <h3 style="margin-top:0">${escapeHtml(label)}</h3>
+  <p class="muted">Couldn't fetch this metric: <code>${escapeHtml(err)}</code></p>
+</div>`;
+
+const workersPanel = (
+	w: Panel<{ today: number; last30d: number }>,
+): string => {
+	if (!w.ok) return panelError("Workers", w.error);
+	return `
+<div class="card">
+  <h3 style="margin-top:0">Workers requests</h3>
+  ${usageBar(w.data.today, LIMITS.workers_requests_per_day, "Today")}
+  <p class="muted" style="margin-top:0.6rem">
+    Last 30 days: <strong>${fmt(w.data.last30d)}</strong> total requests.
+  </p>
+</div>`;
+};
+
+const d1Panel = (
+	d: Panel<{
+		reads_today: number;
+		writes_today: number;
+		storage_bytes: number | null;
+	}>,
+): string => {
+	if (!d.ok) return panelError("D1", d.error);
+	return `
+<div class="card">
+  <h3 style="margin-top:0">D1 database</h3>
+  ${usageBar(d.data.reads_today, LIMITS.d1_reads_per_day, "Row reads (today)")}
+  ${usageBar(d.data.writes_today, LIMITS.d1_writes_per_day, "Row writes (today)")}
+  <p class="muted" style="font-size:0.8rem;margin-top:0.6rem">
+    Storage size is not exposed via the analytics API — check the
+    <a href="https://dash.cloudflare.com" target="_blank" rel="noopener">Cloudflare dashboard</a>
+    for current consumption (free-tier ceiling: ${fmt(LIMITS.d1_storage_bytes / 1024 / 1024 / 1024)} GB).
+  </p>
+</div>`;
+};
+
+const kvPanel = (
+	k: Panel<{
+		reads_today: number;
+		writes_today: number;
+		storage_bytes: number | null;
+	}>,
+): string => {
+	if (!k.ok) return panelError("KV", k.error);
+	return `
+<div class="card">
+  <h3 style="margin-top:0">KV namespaces</h3>
+  ${usageBar(k.data.reads_today, LIMITS.kv_reads_per_day, "Reads (today)")}
+  ${usageBar(k.data.writes_today, LIMITS.kv_writes_per_day, "Writes (today)")}
+  <p class="muted" style="font-size:0.8rem;margin-top:0.6rem">
+    Includes every KV namespace on the account. Garrul uses four:
+    <code>SESSIONS</code>, <code>OAUTH_STATE</code>, <code>RATE_LIMITS</code>,
+    <code>TREE_CACHE</code>.
+  </p>
+</div>`;
+};
+
+export const renderUsageDashboard = (snapshot: UsageSnapshot): string => {
+	const asOf = new Date(snapshot.asOf).toISOString().replace("T", " ").slice(0, 16);
+	return `
+<div class="card">
+  <h2 style="margin-top:0">Cloudflare usage</h2>
+  <p class="muted">
+    Live counters from Cloudflare's GraphQL Analytics API.
+    Cached for 5 minutes (snapshot: <code>${escapeHtml(asOf)} UTC</code>).
+    Free-tier ceilings shown next to each bar; bars turn yellow at 75%
+    and red at 90%.
+  </p>
+</div>
+${workersPanel(snapshot.workers)}
+${d1Panel(snapshot.d1)}
+${kvPanel(snapshot.kv)}`;
+};
+
+export const renderUsageSetup = (): string => `
+<div class="card">
+  <h2 style="margin-top:0">Cloudflare usage — not configured</h2>
+  <p>
+    This page surfaces today's Workers, D1, and KV usage against the
+    free-tier ceilings so you can see headroom before you hit a limit.
+    It's fully optional — the rest of the admin works without it.
+  </p>
+  <h3>Setup</h3>
+  <ol>
+    <li>
+      Create a Cloudflare API token at
+      <a href="https://dash.cloudflare.com/profile/api-tokens"
+         target="_blank" rel="noopener">dash.cloudflare.com/profile/api-tokens</a>
+      with the following least-privilege scopes:
+      <ul>
+        <li><code>Account · Account Analytics · Read</code></li>
+        <li><code>Account · D1 · Read</code></li>
+        <li><code>Account · Workers KV Storage · Read</code></li>
+      </ul>
+    </li>
+    <li>
+      Find your account ID in the right sidebar of any zone's overview
+      page (or run <code>wrangler whoami</code>).
+    </li>
+    <li>
+      Set the two secrets and redeploy:
+      <pre><code>wrangler secret put CF_API_TOKEN
+wrangler secret put CF_ACCOUNT_ID</code></pre>
+    </li>
+  </ol>
+  <p class="muted">
+    The token never leaves the Worker — there is no client-side JS that
+    sees it, and it's not echoed in any UI. The Worker validates it on
+    first load with a low-privilege <code>/user/tokens/verify</code>
+    probe.
+  </p>
+</div>`;
+
+export const renderUsageTokenError = (error: string): string => `
+<div class="card">
+  <h2 style="margin-top:0">Cloudflare usage — token error</h2>
+  <p>
+    The <code>CF_API_TOKEN</code> currently configured did not validate.
+    Cloudflare's verify endpoint returned: <code>${escapeHtml(error)}</code>.
+  </p>
+  <p>
+    Common causes: the token was revoked, the wrong account ID is set,
+    or a scope was dropped. Re-create the token with the three scopes
+    listed in the setup guide and run <code>wrangler secret put
+    CF_API_TOKEN</code> again.
+  </p>
+</div>`;

--- a/src/admin-ui/pages/user-detail.ts
+++ b/src/admin-ui/pages/user-detail.ts
@@ -2,6 +2,8 @@ import type {
 	AdminComment,
 	AdminUserDetail,
 	AuditRowWithAdmin,
+	User,
+	UserRole,
 } from "../../db/queries";
 import { identiconSvg } from "../../lib/identicon";
 import { sanitizeForEmail as resanitizeBodyHtml } from "../../lib/markdown";
@@ -10,14 +12,36 @@ import { escapeHtml } from "../escape";
 const formatTs = (ts: number): string =>
 	new Date(ts).toISOString().slice(0, 16).replace("T", " ");
 
-const userHeader = (d: AdminUserDetail): string => {
+const rolePill = (role: UserRole): string => {
+	if (role === "admin") return '<span class="pill admin">admin</span>';
+	if (role === "mod") return '<span class="pill mod">mod</span>';
+	return "";
+};
+
+const userHeader = (d: AdminUserDetail, viewer: User): string => {
 	const u = d.user;
 	const avatar = u.avatar_url
 		? `<img class="author-avatar" src="${escapeHtml(u.avatar_url)}" alt="" width="64" height="64">`
 		: `<span class="author-avatar" style="width:64px;height:64px">${identiconSvg(u.id, 64)}</span>`;
 	const badges: string[] = [];
-	if (u.is_admin) badges.push('<span class="pill admin">admin</span>');
+	const pill = rolePill(u.role);
+	if (pill) badges.push(pill);
 	if (u.is_banned) badges.push('<span class="pill banned">banned</span>');
+	const canManageRole = viewer.role === "admin" && viewer.id !== u.id;
+	const roleControls = canManageRole
+		? `
+  <div class="actions" x-data="{ busy: false, role: ${JSON.stringify(u.role)} }">
+    <template x-if="role !== 'user'">
+      <button :disabled="busy" @click="busy=true; setRole('user').then(r=>{role=r}).finally(()=>busy=false)">Demote to user</button>
+    </template>
+    <template x-if="role !== 'mod'">
+      <button :disabled="busy" @click="busy=true; setRole('mod').then(r=>{role=r}).finally(()=>busy=false)">Make mod</button>
+    </template>
+    <template x-if="role !== 'admin'">
+      <button :disabled="busy" @click="busy=true; setRole('admin').then(r=>{role=r}).finally(()=>busy=false)">Make admin</button>
+    </template>
+  </div>`
+		: "";
 	return `
 <div class="user-head">
   ${avatar}
@@ -34,7 +58,8 @@ const userHeader = (d: AdminUserDetail): string => {
       <button :disabled="busy" @click="busy=true; setBanned(false).then(()=>{banned=false}).finally(()=>busy=false)">Unban</button>
     </template>
   </div>
-</div>`;
+</div>
+${roleControls}`;
 };
 
 const commentRow = (c: AdminComment): string => `
@@ -69,7 +94,10 @@ const auditTable = (rows: AuditRowWithAdmin[]): string => {
 </div>`;
 };
 
-export const renderUserDetail = (d: AdminUserDetail): string => {
+export const renderUserDetail = (
+	d: AdminUserDetail,
+	viewer: User,
+): string => {
 	const u = d.user;
 	const commentsHtml = d.comments.length
 		? d.comments.map(commentRow).join("")
@@ -95,9 +123,24 @@ export const renderUserDetail = (d: AdminUserDetail): string => {
       this.$dispatch('toast', { text: e.message, kind: 'bad' });
       throw e;
     });
+  },
+  setRole(role) {
+    return fetch('/admin/api/users/${escapeHtml(u.id)}/role', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role }),
+    }).then(async r => {
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(j.error || ('action failed: ' + r.status));
+      this.$dispatch('toast', { text: 'Role updated to ' + j.role });
+      return j.role;
+    }).catch(e => {
+      this.$dispatch('toast', { text: e.message, kind: 'bad' });
+      throw e;
+    });
   }
 }">
-  ${userHeader(d)}
+  ${userHeader(d, viewer)}
   <div class="user-stats">
     <div><span class="muted">Reactions received:</span> ${d.reactions_received}</div>
   </div>

--- a/src/admin-ui/pages/users.ts
+++ b/src/admin-ui/pages/users.ts
@@ -6,13 +6,18 @@ export const renderUsers = (
 	q: string,
 	nextCursor: string | null,
 ): string => {
+	const rolePill = (u: User): string => {
+		if (u.role === "admin") return '<span class="pill admin">admin</span>';
+		if (u.role === "mod") return '<span class="pill mod">mod</span>';
+		return "";
+	};
 	const rowsHtml = rows.length
 		? rows
 				.map(
 					(u) => `
 <tr x-data="{ busy: false, banned: ${u.is_banned} }">
   <td>
-    <div>${escapeHtml(u.name)} ${u.is_admin ? '<span class="pill admin">admin</span>' : ""}
+    <div><a href="/admin/users/${escapeHtml(u.id)}">${escapeHtml(u.name)}</a> ${rolePill(u)}
       <span x-show="banned" class="pill banned">banned</span></div>
     <div class="muted">${escapeHtml(u.email ?? "—")}</div>
   </td>

--- a/src/admin-ui/pages/webhooks.ts
+++ b/src/admin-ui/pages/webhooks.ts
@@ -1,0 +1,221 @@
+import type { WebhookEndpoint } from "../../db/queries";
+import { escapeHtml } from "../escape";
+
+const formatTs = (ts: number | null): string =>
+	ts == null ? "—" : new Date(ts).toISOString().slice(0, 16).replace("T", " ");
+
+const ALL_EVENTS = [
+	"comment.posted",
+	"comment.edited",
+	"comment.deleted",
+	"comment.approved",
+	"comment.spam",
+] as const;
+
+const ADAPTERS: Array<{ value: string; label: string }> = [
+	{ value: "generic", label: "Generic JSON (v1 contract)" },
+	{ value: "slack", label: "Slack incoming webhook" },
+	{ value: "discord", label: "Discord webhook" },
+];
+
+const endpointRow = (e: WebhookEndpoint): string => {
+	const eventsLabel = e.events == null ? "all events" : e.events.join(", ");
+	const signedPill = e.secret
+		? '<span class="pill approved">signed</span>'
+		: '<span class="pill pending">unsigned</span>';
+	const statusPill = e.enabled
+		? '<span class="pill approved">enabled</span>'
+		: '<span class="pill spam">disabled</span>';
+	const autoDisableNote = e.disabled_at
+		? `<div class="muted" style="font-size:0.75rem">auto-paused ${formatTs(e.disabled_at)} after ${e.fail_count} fails</div>`
+		: "";
+	return `
+<tr x-data="{ busy: false, enabled: ${e.enabled} }">
+  <td>
+    <div><code>${escapeHtml(e.url)}</code></div>
+    <div class="muted" style="font-size:0.75rem">${escapeHtml(eventsLabel)} · ${escapeHtml(e.adapter)}</div>
+    ${autoDisableNote}
+  </td>
+  <td>${signedPill}</td>
+  <td><template x-if="enabled">${statusPill}</template>
+      <template x-if="!enabled"><span class="pill spam">disabled</span></template></td>
+  <td class="muted">${formatTs(e.created_at)}</td>
+  <td class="actions">
+    <a href="/admin/webhooks/${escapeHtml(e.id)}" class="btn">Edit</a>
+    <button :disabled="busy" class="bad" @click="busy=true; del('${escapeHtml(e.id)}').finally(()=>busy=false)">Delete</button>
+  </td>
+</tr>`;
+};
+
+const eventChecklist = (selected: ReadonlySet<string>): string =>
+	ALL_EVENTS.map(
+		(ev) => `
+<label style="display:inline-flex;gap:0.3rem;align-items:center;margin-right:0.8rem">
+  <input type="checkbox" name="event_${ev}" ${selected.has(ev) ? "checked" : ""}> ${escapeHtml(ev)}
+</label>`,
+	).join("");
+
+const adapterSelect = (selected: string): string =>
+	ADAPTERS.map(
+		(a) =>
+			`<option value="${escapeHtml(a.value)}"${a.value === selected ? " selected" : ""}>${escapeHtml(a.label)}</option>`,
+	).join("");
+
+export const renderWebhooksList = (
+	endpoints: WebhookEndpoint[],
+	envShim: { active: boolean; url: string },
+): string => {
+	const rows = endpoints.length
+		? endpoints.map(endpointRow).join("")
+		: '<tr><td colspan="5" class="muted">No webhook endpoints configured yet.</td></tr>';
+	const envBanner = envShim.active
+		? `
+<div class="card" style="border-left:3px solid var(--warn)">
+  <p>
+    <strong>Legacy <code>WEBHOOK_URL</code> in use</strong> —
+    <code>${escapeHtml(envShim.url)}</code> is being delivered to as an
+    unsigned, retry-less endpoint. Add a real endpoint below (with an HMAC
+    secret) and remove the env var to gain signing + automatic retries.
+  </p>
+</div>`
+		: "";
+	return `
+<div x-data="{
+  del(id) {
+    if (!confirm('Delete this webhook endpoint? Pending retries will be cancelled.')) return Promise.resolve();
+    return fetch('/admin/api/webhooks/' + id, { method: 'DELETE', headers: { 'content-type': 'application/json' } })
+      .then(async r => {
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}));
+          throw new Error(j.error || ('delete failed: ' + r.status));
+        }
+        this.$dispatch('toast', { text: 'Endpoint deleted' });
+        setTimeout(() => location.reload(), 300);
+      })
+      .catch(e => { this.$dispatch('toast', { text: e.message, kind: 'bad' }); });
+  }
+}">
+${envBanner}
+<div class="card">
+  <h3 style="margin-top:0">Webhook endpoints</h3>
+  <p class="muted">
+    Each enabled endpoint receives a POST per matching event. Endpoints
+    with an HMAC secret get an <code>X-Garrul-Signature</code> header;
+    receivers should reject unsigned deliveries in production. Failed
+    deliveries are retried with exponential backoff for ~9 hours before
+    the row is given up; an endpoint that gives up 10 deliveries in a
+    row is auto-paused.
+  </p>
+  <p><a href="/admin/webhooks/new" class="btn">+ Add endpoint</a></p>
+  <table>
+    <thead><tr><th>URL</th><th>Signed</th><th>Status</th><th>Created</th><th>Actions</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</div>
+</div>`;
+};
+
+export type WebhookFormData = {
+	endpoint: WebhookEndpoint | null; // null = new
+	error: string | null;
+};
+
+export const renderWebhookForm = (data: WebhookFormData): string => {
+	const e = data.endpoint;
+	const isNew = e == null;
+	const selectedEvents = new Set<string>(e?.events ?? ALL_EVENTS);
+	const url = e?.url ?? "";
+	const secret = e?.secret ?? "";
+	const adapter = e?.adapter ?? "generic";
+	const enabled = e?.enabled ?? true;
+	const heading = isNew ? "Add webhook endpoint" : "Edit webhook endpoint";
+	const action = isNew
+		? "/admin/api/webhooks"
+		: `/admin/api/webhooks/${escapeHtml(e.id)}`;
+	const errorBlock = data.error
+		? `<p style="color:var(--bad)">${escapeHtml(data.error)}</p>`
+		: "";
+	const submitLabel = isNew ? "Create endpoint" : "Save changes";
+	return `
+<a href="/admin/webhooks" class="muted">← back to webhooks</a>
+<div class="card" x-data="{
+  busy: false,
+  error: ${JSON.stringify(data.error)},
+  async submit(e) {
+    e.preventDefault();
+    if (this.busy) return;
+    this.busy = true; this.error = null;
+    const form = new FormData(e.target);
+    const events = ${JSON.stringify(ALL_EVENTS)}.filter(ev => form.get('event_' + ev));
+    const body = {
+      url: form.get('url'),
+      secret: form.get('secret') || null,
+      events: events.length === ${ALL_EVENTS.length} ? null : events,
+      adapter: form.get('adapter'),
+      enabled: form.get('enabled') === 'on',
+    };
+    try {
+      const r = await fetch(${JSON.stringify(action)}, {
+        method: ${JSON.stringify(isNew ? "POST" : "PATCH")},
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(j.error || ('save failed: ' + r.status));
+      this.$dispatch('toast', { text: 'Endpoint saved' });
+      setTimeout(() => location.href = '/admin/webhooks', 300);
+    } catch (err) {
+      this.error = err.message;
+    } finally {
+      this.busy = false;
+    }
+  }
+}">
+  <h3 style="margin-top:0">${heading}</h3>
+  ${errorBlock}
+  <p x-show="error" style="color:var(--bad)" x-text="error"></p>
+  <form @submit="submit">
+    <p>
+      <label>URL<br>
+        <input type="text" name="url" required value="${escapeHtml(url)}"
+          placeholder="https://example.com/webhooks/garrul"
+          style="width:100%;max-width:560px">
+      </label>
+    </p>
+    <p>
+      <label>HMAC secret (recommended)<br>
+        <input type="text" name="secret" value="${escapeHtml(secret)}"
+          placeholder="whsec_…"
+          style="width:100%;max-width:560px">
+      </label>
+      <span class="muted" style="display:block;font-size:0.8rem">
+        Leave blank to send unsigned. Rotating the secret invalidates the
+        old signature immediately — coordinate with the receiver before
+        changing this on a live endpoint.
+      </span>
+    </p>
+    <p>
+      <label>Adapter<br>
+        <select name="adapter">${adapterSelect(adapter)}</select>
+      </label>
+    </p>
+    <p>
+      Events:<br>
+      ${eventChecklist(selectedEvents)}
+      <span class="muted" style="display:block;font-size:0.8rem">
+        All boxes checked = no filter (every event matches).
+      </span>
+    </p>
+    <p>
+      <label>
+        <input type="checkbox" name="enabled" ${enabled ? "checked" : ""}>
+        Enabled
+      </label>
+    </p>
+    <button :disabled="busy" type="submit">
+      <span x-show="!busy">${submitLabel}</span>
+      <span x-show="busy">Saving…</span>
+    </button>
+  </form>
+</div>`;
+};

--- a/src/admin-ui/pages/webhooks.ts
+++ b/src/admin-ui/pages/webhooks.ts
@@ -138,7 +138,7 @@ export const renderWebhookForm = (data: WebhookFormData): string => {
 	const submitLabel = isNew ? "Create endpoint" : "Save changes";
 	return `
 <a href="/admin/webhooks" class="muted">← back to webhooks</a>
-<div class="card" x-data="{
+<div class="card" x-data="${escapeHtml(`{
   busy: false,
   error: ${JSON.stringify(data.error)},
   async submit(e) {
@@ -170,7 +170,7 @@ export const renderWebhookForm = (data: WebhookFormData): string => {
       this.busy = false;
     }
   }
-}">
+}`)}">
   <h3 style="margin-top:0">${heading}</h3>
   ${errorBlock}
   <p x-show="error" style="color:var(--bad)" x-text="error"></p>

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -109,6 +109,22 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
             border-radius: 0 0 8px 8px; }
 .bulk-bar span:first-child { font-weight: 600; margin-right: auto; }
 [x-cloak] { display: none !important; }
+.reply-modal { position: fixed; inset: 0; background: rgba(0,0,0,0.55);
+               display: flex; align-items: flex-start; justify-content: center;
+               padding-top: 6vh; z-index: 1100; }
+.reply-modal-inner { background: var(--panel); border: 1px solid var(--border);
+                     border-radius: 8px; padding: 1.25rem; width: min(560px, 92vw);
+                     max-height: 85vh; overflow: auto; box-shadow: 0 12px 32px rgba(0,0,0,0.45); }
+.reply-list { list-style: none; padding: 0; margin: 0 0 0.75rem; max-height: 30vh;
+              overflow: auto; border: 1px solid var(--border); border-radius: 6px; }
+.reply-list li { border-bottom: 1px solid var(--border); }
+.reply-list li:last-child { border-bottom: none; }
+.reply-pick { display: flex; justify-content: space-between; gap: 0.75rem;
+              width: 100%; padding: 0.5rem 0.75rem; background: transparent;
+              border: none; color: var(--fg); text-align: left; cursor: pointer; }
+.reply-pick:hover { background: var(--bg); }
+.reply-pick.active { background: var(--accent); color: var(--bg); }
+.reply-pick.active .muted { color: var(--bg); opacity: 0.85; }
 .comment-card { border: 1px solid var(--border); border-radius: 6px;
                 padding: 0.75rem; margin: 0.5rem 0; }
 .comment-card-head { display: flex; justify-content: space-between;

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -98,6 +98,10 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .muted { color: var(--muted); }
 .pager { display: flex; justify-content: space-between; margin-top: 1rem; }
 .bulk-cell { width: 32px; }
+.score-cell { width: 70px; text-align: center; font-variant-numeric: tabular-nums; }
+.score { font-weight: 600; }
+.score-pos { color: #15803d; }
+.score-neg { color: #b91c1c; }
 .bulk-bar { position: sticky; bottom: 0; display: flex; align-items: center;
             gap: 0.5rem; padding: 0.75rem 1rem; background: var(--panel);
             border-top: 1px solid var(--border); margin: 1rem -1rem -1rem;

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -67,6 +67,7 @@ th { color: var(--muted); font-weight: 500; font-size: 0.8rem; text-transform: u
 .pill.pending { color: var(--warn); border-color: var(--warn); }
 .pill.spam, .pill.deleted, .pill.banned { color: var(--bad); border-color: var(--bad); }
 .pill.admin { color: var(--accent); border-color: var(--accent); }
+.pill.mod { color: var(--warn); border-color: var(--warn); }
 button, .btn { background: var(--bg); color: var(--text); border: 1px solid var(--border);
                padding: 0.3rem 0.6rem; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
 button:hover { border-color: var(--accent); }

--- a/src/db/migrations/0005_user_roles.sql
+++ b/src/db/migrations/0005_user_roles.sql
@@ -1,0 +1,23 @@
+-- User roles: introduce a tri-valued `role` column so moderation can be
+-- delegated to users who are not full admins.
+--
+-- Forward-only. Once applied, never edit — add a 0006_*.sql migration instead.
+--
+-- Roles:
+--   'user'  — default; can comment, react, vote
+--   'mod'   — can use the moderation queue (approve/spam/delete/bulk +
+--             reply); cannot ban users, edit settings, run operator scripts,
+--             or grant/revoke roles
+--   'admin' — full access; can grant/revoke 'mod' and 'admin' on others
+--
+-- `is_admin` is kept alive for one release cycle as a derived column so the
+-- existing /api/v1/auth/me response shape and any consumer reading users.is_admin
+-- directly do not break. Invariant: is_admin = 1 ⇔ role = 'admin'. The query
+-- layer writes both together; a later migration will drop `is_admin`.
+
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';
+
+-- Backfill existing admins so the invariant holds on first deploy.
+UPDATE users SET role = 'admin' WHERE is_admin = 1;
+
+CREATE INDEX IF NOT EXISTS users_role_idx ON users(role);

--- a/src/db/migrations/0006_webhook_endpoints.sql
+++ b/src/db/migrations/0006_webhook_endpoints.sql
@@ -1,0 +1,68 @@
+-- Multi-endpoint webhook dispatch with HMAC signing + retry log.
+-- Forward-only. Once applied, never edit — add a 0007_*.sql migration instead.
+--
+-- webhook_endpoints replaces the single-URL WEBHOOK_URL env var with a
+-- table-driven list. Each endpoint can be signed (secret != NULL produces
+-- an `X-Garrul-Signature` header on every delivery) or unsigned. `events`
+-- is a comma-separated list of WebhookEvent values; an empty string means
+-- "all events". `adapter` controls payload formatting:
+--   'generic' — the stable v1 contract documented in src/lib/webhook.ts
+--   'slack'   — Slack incoming-webhook shape (added in Feature #3)
+--   'discord' — Discord embed shape (added in Feature #3)
+-- `fail_count` is a running tally of consecutive failures; reset to 0 on
+-- the first success after a failure. `disabled_at` is set by the retry
+-- handler when fail_count exceeds the giveup threshold so the operator
+-- can see why deliveries stopped without a flood of cron log lines.
+--
+-- WEBHOOK_URL is preserved as a backward-compat shim. If the env var is
+-- set and no endpoint with id='_env' exists, the dispatcher synthesizes
+-- one in-memory (adapter='generic', secret=NULL, events=NULL → all). No
+-- consumer breakage on upgrade; admin UI flags the unsigned env-shim and
+-- nudges the operator to migrate to a table row.
+
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+	id           TEXT PRIMARY KEY,           -- ULID
+	url          TEXT NOT NULL,
+	secret       TEXT,                       -- HMAC key; NULL = unsigned (legacy)
+	events       TEXT,                       -- comma-separated WebhookEvent list, NULL/'' = all
+	adapter      TEXT NOT NULL DEFAULT 'generic',
+	enabled      INTEGER NOT NULL DEFAULT 1, -- 0 = paused by admin
+	fail_count   INTEGER NOT NULL DEFAULT 0,
+	disabled_at  INTEGER,                    -- auto-disabled by retry handler when fail_count exceeds threshold
+	created_at   INTEGER NOT NULL,
+	updated_at   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_enabled ON webhook_endpoints(enabled, id);
+
+-- webhook_deliveries is the retry log. A row is inserted on a failed POST
+-- (network error, non-2xx) with next_attempt_at set per exponential
+-- backoff (60s, 5m, 30m, 2h, 6h — see RETRY_SCHEDULE in src/lib/webhook.ts).
+-- A successful initial POST writes no row (the no-op write is the common
+-- case and we want to keep this table small on the free-tier 5GB cap).
+-- The cron handler picks up rows where next_attempt_at <= now and retries.
+-- After MAX_ATTEMPTS the row is marked status='giveup' and the endpoint's
+-- fail_count is incremented; the endpoint auto-disables once it crosses
+-- the threshold.
+--
+-- `payload` stores the rendered body bytes (adapter-formatted, ready to
+-- POST again) so a retry produces the exact same signature timestamp/body
+-- pair — replays would be valid for the configured window but we mint a
+-- fresh timestamp+signature on each retry so the receiver's replay-window
+-- check still passes hours later.
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+	id              TEXT PRIMARY KEY,           -- ULID
+	endpoint_id     TEXT NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+	event           TEXT NOT NULL,              -- WebhookEvent
+	payload         TEXT NOT NULL,              -- raw body to POST
+	status          TEXT NOT NULL,              -- pending|delivered|giveup
+	attempts        INTEGER NOT NULL DEFAULT 0,
+	last_error      TEXT,                       -- HTTP status or fetch error string
+	next_attempt_at INTEGER NOT NULL,           -- ms epoch
+	created_at      INTEGER NOT NULL,
+	delivered_at    INTEGER                     -- ms epoch on first success
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_pending
+	ON webhook_deliveries(status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_endpoint
+	ON webhook_deliveries(endpoint_id, created_at DESC);

--- a/src/db/migrations/0007_votes.sql
+++ b/src/db/migrations/0007_votes.sql
@@ -1,0 +1,29 @@
+-- Authenticated voting on comments.
+--
+-- Rationale: the existing `reactions` table is multi-emoji per user (PK on
+-- (comment_id, user_id, kind)), which means a malicious client could send
+-- both `up` and `down` and the row count is what we'd query — they would
+-- cancel themselves. Voting needs strict mutual exclusion: at most one
+-- (comment_id, user_id) row, value -1 or 1.
+--
+-- Counters are denormalized onto `comments` so the read path
+-- (listCommentsForPost) stays a single SELECT — adding a JOIN for every
+-- post fetch would hit free-tier D1 row-reads hard on busy threads. The
+-- vote write path updates both rows in a D1 batch.
+
+CREATE TABLE IF NOT EXISTS votes (
+	comment_id TEXT NOT NULL REFERENCES comments(id),
+	user_id    TEXT NOT NULL REFERENCES users(id),
+	value      INTEGER NOT NULL CHECK (value IN (-1, 1)),
+	created_at INTEGER NOT NULL,
+	PRIMARY KEY (comment_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS votes_user_idx ON votes(user_id);
+
+ALTER TABLE comments ADD COLUMN score_up   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE comments ADD COLUMN score_down INTEGER NOT NULL DEFAULT 0;
+
+-- Supports `sort=top` on the list endpoint without a separate aggregation.
+CREATE INDEX IF NOT EXISTS comments_score_idx
+	ON comments(post_slug, status, (score_up - score_down) DESC, created_at);

--- a/src/db/migrations/0008_saved_replies.sql
+++ b/src/db/migrations/0008_saved_replies.sql
@@ -1,0 +1,37 @@
+-- 0008_saved_replies.sql
+--
+-- Saved replies: canned moderator responses. A mod (or admin) authors a
+-- title + a markdown body, optionally shares it with the team, and can
+-- post it as a top-level reply on any comment from the queue.
+--
+-- Why the `scope` split:
+--   - 'private': only the owner sees / uses it. Mods can have personal
+--     drafts (welcomes, signature blocks) without polluting the team's
+--     shared list.
+--   - 'shared':  visible + usable by every mod + admin on the instance.
+--
+-- The body is stored as markdown only; we re-render via the standard
+-- `renderMarkdown` allowlist pipeline at *post time*, so we don't risk
+-- the saved row carrying stale or insufficiently-sanitized HTML across
+-- renderer-version bumps.
+
+CREATE TABLE IF NOT EXISTS saved_replies (
+  id          TEXT PRIMARY KEY,
+  owner_id    TEXT NOT NULL,
+  title       TEXT NOT NULL,
+  body_md     TEXT NOT NULL,
+  scope       TEXT NOT NULL DEFAULT 'private'
+                 CHECK (scope IN ('private', 'shared')),
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL,
+  FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Fast lookup for the picker: every mod loads
+--   (their private replies) UNION (shared replies)
+-- on the queue page. Two narrow indexes cover both arms cheaply.
+CREATE INDEX IF NOT EXISTS saved_replies_owner_idx
+  ON saved_replies(owner_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS saved_replies_scope_idx
+  ON saved_replies(scope, created_at DESC) WHERE scope = 'shared';

--- a/src/db/migrations/0009_import_tracking.sql
+++ b/src/db/migrations/0009_import_tracking.sql
@@ -1,0 +1,31 @@
+-- 0009_import_tracking.sql
+--
+-- Track imported comments so re-running the same import is idempotent.
+--
+-- Without these columns, a Disqus (or future WordPress / generic CSV)
+-- importer that crashes halfway through has no way to safely resume —
+-- re-running would duplicate every row up to the crash point.
+--
+-- Design:
+--   * `import_source` is a free-form tag, e.g. 'disqus', 'wordpress'.
+--   * `import_id` is the source platform's stable ID for the post
+--     (Disqus uses `dsq:link` and a per-comment `dsq:id`).
+--   * A partial UNIQUE index on the pair lets multiple sources coexist:
+--     two different `disqus` imports of the same XML are a re-run (no-op),
+--     while a parallel WordPress import with overlapping IDs is allowed.
+--   * Native rows (typed in via the widget) skip the columns entirely —
+--     `WHERE import_source IS NOT NULL` keeps the index narrow and the
+--     constraint inert for normal traffic.
+
+ALTER TABLE comments ADD COLUMN import_source TEXT;
+ALTER TABLE comments ADD COLUMN import_id     TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS comments_import_idx
+  ON comments(import_source, import_id)
+  WHERE import_source IS NOT NULL;
+
+-- Ghost users created by an importer are flagged so the operator can
+-- distinguish a real anonymous commenter from a Disqus carryover. We
+-- reuse `provider='anon'` so existing rate-limit + read paths Just Work;
+-- the marker lives in a side column to keep that join semantics intact.
+ALTER TABLE users ADD COLUMN import_source TEXT;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1125,6 +1125,7 @@ export type AuditTargetKind =
 	| "user"
 	| "subscription"
 	| "webhook"
+	| "saved_reply"
 	| "system";
 
 export const ADMIN_ACTIONS = [
@@ -1150,6 +1151,10 @@ export const ADMIN_ACTIONS = [
 	"role.revoke_mod",
 	"role.grant_admin",
 	"role.revoke_admin",
+	"saved_reply.create",
+	"saved_reply.update",
+	"saved_reply.delete",
+	"saved_reply.post",
 ] as const;
 export type AdminAction = (typeof ADMIN_ACTIONS)[number];
 
@@ -2304,4 +2309,116 @@ export const getUserVotesOnPost = async (
 		if (r.value === 1 || r.value === -1) out.set(r.comment_id, r.value);
 	}
 	return out;
+};
+
+// -- saved replies ----------------------------------------------------------
+//
+// Canned moderator responses. The picker fetches the visible-to-me set
+// (`listSavedRepliesForUser`) which is `OWNER = me OR scope = 'shared'`.
+// Mutations are owner-only: even an admin should not be able to silently
+// edit a different mod's private reply through the API (we audit-log the
+// post action separately).
+
+export type SavedReplyScope = "private" | "shared";
+
+export type SavedReply = {
+	id: string;
+	owner_id: string;
+	title: string;
+	body_md: string;
+	scope: SavedReplyScope;
+	created_at: number;
+	updated_at: number;
+};
+
+export const isSavedReplyScope = (v: unknown): v is SavedReplyScope =>
+	v === "private" || v === "shared";
+
+export const listSavedRepliesForUser = async (
+	db: D1Database,
+	user_id: string,
+): Promise<SavedReply[]> => {
+	const result = await db
+		.prepare(
+			`SELECT id, owner_id, title, body_md, scope, created_at, updated_at
+			   FROM saved_replies
+			  WHERE owner_id = ? OR scope = 'shared'
+			  ORDER BY created_at DESC`,
+		)
+		.bind(user_id)
+		.all<SavedReply>();
+	return result.results ?? [];
+};
+
+export const getSavedReply = async (
+	db: D1Database,
+	id: string,
+): Promise<SavedReply | null> => {
+	return await db
+		.prepare(
+			`SELECT id, owner_id, title, body_md, scope, created_at, updated_at
+			   FROM saved_replies WHERE id = ?`,
+		)
+		.bind(id)
+		.first<SavedReply>();
+};
+
+export const insertSavedReply = async (
+	db: D1Database,
+	input: {
+		owner_id: string;
+		title: string;
+		body_md: string;
+		scope: SavedReplyScope;
+	},
+): Promise<SavedReply> => {
+	const id = ulid();
+	const now = Date.now();
+	await db
+		.prepare(
+			`INSERT INTO saved_replies
+			   (id, owner_id, title, body_md, scope, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(id, input.owner_id, input.title, input.body_md, input.scope, now, now)
+		.run();
+	return {
+		id,
+		owner_id: input.owner_id,
+		title: input.title,
+		body_md: input.body_md,
+		scope: input.scope,
+		created_at: now,
+		updated_at: now,
+	};
+};
+
+export const updateSavedReply = async (
+	db: D1Database,
+	id: string,
+	owner_id: string,
+	patch: { title: string; body_md: string; scope: SavedReplyScope },
+): Promise<boolean> => {
+	const now = Date.now();
+	const result = await db
+		.prepare(
+			`UPDATE saved_replies
+			    SET title = ?, body_md = ?, scope = ?, updated_at = ?
+			  WHERE id = ? AND owner_id = ?`,
+		)
+		.bind(patch.title, patch.body_md, patch.scope, now, id, owner_id)
+		.run();
+	return (result.meta?.changes ?? 0) > 0;
+};
+
+export const deleteSavedReply = async (
+	db: D1Database,
+	id: string,
+	owner_id: string,
+): Promise<boolean> => {
+	const result = await db
+		.prepare(`DELETE FROM saved_replies WHERE id = ? AND owner_id = ?`)
+		.bind(id, owner_id)
+		.run();
+	return (result.meta?.changes ?? 0) > 0;
 };

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -53,6 +53,8 @@ export type Comment = {
 	ip_hash: string | null;
 	user_agent: string | null;
 	created_at: number;
+	score_up: number;
+	score_down: number;
 };
 
 type UserRow = Omit<User, "is_admin" | "is_banned"> & {
@@ -294,6 +296,8 @@ export const insertComment = async (
 		ip_hash: input.ip_hash,
 		user_agent: input.user_agent,
 		created_at: now,
+		score_up: 0,
+		score_down: 0,
 	};
 };
 
@@ -305,7 +309,7 @@ export const getComment = async (
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
 			        renderer_version, status, edited_at, deleted_at,
-			        ip_hash, user_agent, created_at
+			        ip_hash, user_agent, created_at, score_up, score_down
 			 FROM comments WHERE id = ?`,
 		)
 		.bind(id)
@@ -326,7 +330,7 @@ export const getCommentsByIds = async (
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
 			        renderer_version, status, edited_at, deleted_at,
-			        ip_hash, user_agent, created_at
+			        ip_hash, user_agent, created_at, score_up, score_down
 			   FROM comments WHERE id IN (${placeholders})`,
 		)
 		.bind(...ids)
@@ -373,7 +377,7 @@ export const listCommentsForPost = async (
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
 			        renderer_version, status, edited_at, deleted_at,
-			        ip_hash, user_agent, created_at
+			        ip_hash, user_agent, created_at, score_up, score_down
 			 FROM comments
 			 WHERE post_slug = ? AND status NOT IN ('spam', 'pending')
 			 ORDER BY created_at ASC, id ASC`,
@@ -396,7 +400,8 @@ export const listLatestApprovedComments = async (
 		.prepare(
 			`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
 			        c.renderer_version, c.status, c.edited_at, c.deleted_at,
-			        c.ip_hash, c.user_agent, c.created_at, u.name AS author_name
+			        c.ip_hash, c.user_agent, c.created_at, c.score_up, c.score_down,
+			        u.name AS author_name
 			   FROM comments c
 			   JOIN users u ON u.id = c.user_id
 			  WHERE c.post_slug = ? AND c.status = 'approved'
@@ -622,7 +627,7 @@ export const adminListComments = async (
 	const sql = `
 		SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
 		       c.renderer_version, c.status, c.edited_at, c.deleted_at,
-		       c.ip_hash, c.user_agent, c.created_at,
+		       c.ip_hash, c.user_agent, c.created_at, c.score_up, c.score_down,
 		       u.name       AS author_name,
 		       u.email      AS author_email,
 		       u.avatar_url AS author_avatar_url,
@@ -2146,4 +2151,126 @@ export const pruneWebhookDeliveries = async (
 		.bind(olderThan)
 		.run();
 	return (rs.meta as { changes?: number }).changes ?? 0;
+};
+
+// -- votes -------------------------------------------------------------------
+//
+// Voting is exclusive: at most one row per (comment_id, user_id) with value
+// -1 or 1. The reactions table is the wrong shape (multi-emoji per user)
+// because a malicious client could send both up and down — see the
+// votes migration for the full rationale.
+
+export type Vote = {
+	comment_id: string;
+	user_id: string;
+	value: -1 | 1;
+	created_at: number;
+};
+
+export type VoteValue = -1 | 0 | 1;
+
+export type VoteResult = {
+	score_up: number;
+	score_down: number;
+	my_vote: -1 | 0 | 1;
+};
+
+const reselectScores = async (
+	db: D1Database,
+	comment_id: string,
+	user_id: string,
+): Promise<VoteResult> => {
+	const row = await db
+		.prepare(
+			`SELECT c.score_up, c.score_down,
+			        COALESCE((SELECT value FROM votes
+			                   WHERE comment_id = c.id AND user_id = ?), 0) AS my_vote
+			   FROM comments c WHERE c.id = ?`,
+		)
+		.bind(user_id, comment_id)
+		.first<{ score_up: number; score_down: number; my_vote: number }>();
+	if (!row) return { score_up: 0, score_down: 0, my_vote: 0 };
+	const mv = row.my_vote === 1 || row.my_vote === -1 ? row.my_vote : 0;
+	return { score_up: row.score_up, score_down: row.score_down, my_vote: mv };
+};
+
+/**
+ * Atomically upsert a vote and recompute the denormalized counters on the
+ * parent comment. value=0 means "clear my vote". The denormalization keeps
+ * the public list query as a single SELECT against `comments` — no JOIN to
+ * an aggregation against `votes` per page load.
+ *
+ * Returns the post-write counters and the requester's now-vote so the
+ * widget can patch the DOM without busting the per-post tree cache.
+ */
+export const castVote = async (
+	db: D1Database,
+	comment_id: string,
+	user_id: string,
+	value: VoteValue,
+): Promise<VoteResult> => {
+	const now = Date.now();
+	if (value === 0) {
+		await db.batch([
+			db
+				.prepare(`DELETE FROM votes WHERE comment_id = ? AND user_id = ?`)
+				.bind(comment_id, user_id),
+			db
+				.prepare(
+					`UPDATE comments SET
+					   score_up   = (SELECT COUNT(*) FROM votes WHERE comment_id = ? AND value =  1),
+					   score_down = (SELECT COUNT(*) FROM votes WHERE comment_id = ? AND value = -1)
+					 WHERE id = ?`,
+				)
+				.bind(comment_id, comment_id, comment_id),
+		]);
+	} else {
+		await db.batch([
+			db
+				.prepare(
+					`INSERT INTO votes (comment_id, user_id, value, created_at)
+					 VALUES (?, ?, ?, ?)
+					 ON CONFLICT(comment_id, user_id) DO UPDATE SET
+					   value      = excluded.value,
+					   created_at = excluded.created_at`,
+				)
+				.bind(comment_id, user_id, value, now),
+			db
+				.prepare(
+					`UPDATE comments SET
+					   score_up   = (SELECT COUNT(*) FROM votes WHERE comment_id = ? AND value =  1),
+					   score_down = (SELECT COUNT(*) FROM votes WHERE comment_id = ? AND value = -1)
+					 WHERE id = ?`,
+				)
+				.bind(comment_id, comment_id, comment_id),
+		]);
+	}
+	return reselectScores(db, comment_id, user_id);
+};
+
+/**
+ * Returns the calling user's vote on each (comment_id) for one post, as
+ * a Map keyed by comment_id. Used to populate `my_vote` on the public
+ * list endpoint for authenticated viewers; anonymous viewers bypass this
+ * (the cached payload has no my_vote field).
+ */
+export const getUserVotesOnPost = async (
+	db: D1Database,
+	post_slug: string,
+	user_id: string,
+): Promise<Map<string, -1 | 1>> => {
+	const result = await db
+		.prepare(
+			`SELECT v.comment_id, v.value
+			   FROM votes v
+			   JOIN comments c ON c.id = v.comment_id
+			  WHERE c.post_slug = ? AND v.user_id = ?`,
+		)
+		.bind(post_slug, user_id)
+		.all<{ comment_id: string; value: number }>();
+	const out = new Map<string, -1 | 1>();
+	for (const r of result.results ?? []) {
+		if (r.value === 1 || r.value === -1) out.set(r.comment_id, r.value);
+	}
+	return out;
 };

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1800,3 +1800,346 @@ export const adminRotateSubscriptionConfirmToken = async (
 		.bind(new_token, id)
 		.run();
 };
+
+// -----------------------------------------------------------------------------
+// Webhook endpoints + deliveries (migration 0006).
+// -----------------------------------------------------------------------------
+
+export type WebhookAdapter = "generic" | "slack" | "discord";
+
+export const isWebhookAdapter = (v: unknown): v is WebhookAdapter =>
+	v === "generic" || v === "slack" || v === "discord";
+
+export type WebhookEndpoint = {
+	id: string;
+	url: string;
+	secret: string | null;
+	events: string[] | null; // null = all events
+	adapter: WebhookAdapter;
+	enabled: boolean;
+	fail_count: number;
+	disabled_at: number | null;
+	created_at: number;
+	updated_at: number;
+};
+
+type WebhookEndpointRow = {
+	id: string;
+	url: string;
+	secret: string | null;
+	events: string | null;
+	adapter: string;
+	enabled: number;
+	fail_count: number;
+	disabled_at: number | null;
+	created_at: number;
+	updated_at: number;
+};
+
+const toWebhookEndpoint = (row: WebhookEndpointRow): WebhookEndpoint => ({
+	id: row.id,
+	url: row.url,
+	secret: row.secret,
+	events:
+		row.events == null || row.events === ""
+			? null
+			: row.events
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean),
+	adapter: isWebhookAdapter(row.adapter) ? row.adapter : "generic",
+	enabled: row.enabled === 1,
+	fail_count: row.fail_count,
+	disabled_at: row.disabled_at,
+	created_at: row.created_at,
+	updated_at: row.updated_at,
+});
+
+export const listWebhookEndpoints = async (
+	db: D1Database,
+): Promise<WebhookEndpoint[]> => {
+	const rs = await db
+		.prepare(
+			`SELECT id, url, secret, events, adapter, enabled, fail_count,
+			        disabled_at, created_at, updated_at
+			   FROM webhook_endpoints
+			  ORDER BY created_at ASC`,
+		)
+		.all<WebhookEndpointRow>();
+	return (rs.results ?? []).map(toWebhookEndpoint);
+};
+
+export const listEnabledWebhookEndpoints = async (
+	db: D1Database,
+): Promise<WebhookEndpoint[]> => {
+	const rs = await db
+		.prepare(
+			`SELECT id, url, secret, events, adapter, enabled, fail_count,
+			        disabled_at, created_at, updated_at
+			   FROM webhook_endpoints
+			  WHERE enabled = 1
+			  ORDER BY created_at ASC`,
+		)
+		.all<WebhookEndpointRow>();
+	return (rs.results ?? []).map(toWebhookEndpoint);
+};
+
+export const getWebhookEndpoint = async (
+	db: D1Database,
+	id: string,
+): Promise<WebhookEndpoint | null> => {
+	const row = await db
+		.prepare(
+			`SELECT id, url, secret, events, adapter, enabled, fail_count,
+			        disabled_at, created_at, updated_at
+			   FROM webhook_endpoints WHERE id = ?`,
+		)
+		.bind(id)
+		.first<WebhookEndpointRow>();
+	return row ? toWebhookEndpoint(row) : null;
+};
+
+export type WebhookEndpointInput = {
+	url: string;
+	secret: string | null;
+	events: string[] | null;
+	adapter: WebhookAdapter;
+	enabled: boolean;
+};
+
+const serializeEvents = (events: string[] | null): string | null =>
+	events == null || events.length === 0 ? null : events.join(",");
+
+export const createWebhookEndpoint = async (
+	db: D1Database,
+	input: WebhookEndpointInput,
+): Promise<WebhookEndpoint> => {
+	const id = ulid();
+	const now = Date.now();
+	await db
+		.prepare(
+			`INSERT INTO webhook_endpoints
+			   (id, url, secret, events, adapter, enabled, fail_count,
+			    disabled_at, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)`,
+		)
+		.bind(
+			id,
+			input.url,
+			input.secret,
+			serializeEvents(input.events),
+			input.adapter,
+			input.enabled ? 1 : 0,
+			now,
+			now,
+		)
+		.run();
+	const created = await getWebhookEndpoint(db, id);
+	if (!created) throw new Error("webhook endpoint vanished after insert");
+	return created;
+};
+
+export const updateWebhookEndpoint = async (
+	db: D1Database,
+	id: string,
+	input: Partial<WebhookEndpointInput>,
+): Promise<void> => {
+	// Build the SET clause dynamically so callers can patch one field
+	// (e.g. just enabled, just secret) without overwriting siblings.
+	const sets: string[] = ["updated_at = ?"];
+	const values: (string | number | null)[] = [Date.now()];
+	if (input.url !== undefined) {
+		sets.push("url = ?");
+		values.push(input.url);
+	}
+	if (input.secret !== undefined) {
+		sets.push("secret = ?");
+		values.push(input.secret);
+	}
+	if (input.events !== undefined) {
+		sets.push("events = ?");
+		values.push(serializeEvents(input.events));
+	}
+	if (input.adapter !== undefined) {
+		sets.push("adapter = ?");
+		values.push(input.adapter);
+	}
+	if (input.enabled !== undefined) {
+		sets.push("enabled = ?");
+		values.push(input.enabled ? 1 : 0);
+		// Re-enabling clears the auto-disable marker + counter so the next
+		// failure cycle starts fresh, not from wherever it was paused.
+		if (input.enabled) {
+			sets.push("disabled_at = NULL");
+			sets.push("fail_count = 0");
+		}
+	}
+	values.push(id);
+	await db
+		.prepare(`UPDATE webhook_endpoints SET ${sets.join(", ")} WHERE id = ?`)
+		.bind(...values)
+		.run();
+};
+
+export const deleteWebhookEndpoint = async (
+	db: D1Database,
+	id: string,
+): Promise<void> => {
+	// ON DELETE CASCADE on webhook_deliveries.endpoint_id wipes the queue.
+	await db
+		.prepare(`DELETE FROM webhook_endpoints WHERE id = ?`)
+		.bind(id)
+		.run();
+};
+
+export const incrementWebhookFailCount = async (
+	db: D1Database,
+	id: string,
+	autoDisableAt: number | null,
+): Promise<void> => {
+	await db
+		.prepare(
+			`UPDATE webhook_endpoints
+			    SET fail_count = fail_count + 1,
+			        disabled_at = COALESCE(disabled_at, ?),
+			        enabled = CASE WHEN ? IS NULL THEN enabled ELSE 0 END,
+			        updated_at = ?
+			  WHERE id = ?`,
+		)
+		.bind(autoDisableAt, autoDisableAt, Date.now(), id)
+		.run();
+};
+
+export const resetWebhookFailCount = async (
+	db: D1Database,
+	id: string,
+): Promise<void> => {
+	await db
+		.prepare(
+			`UPDATE webhook_endpoints
+			    SET fail_count = 0, disabled_at = NULL, updated_at = ?
+			  WHERE id = ?`,
+		)
+		.bind(Date.now(), id)
+		.run();
+};
+
+export type WebhookDeliveryStatus = "pending" | "delivered" | "giveup";
+
+export type WebhookDelivery = {
+	id: string;
+	endpoint_id: string;
+	event: string;
+	payload: string;
+	status: WebhookDeliveryStatus;
+	attempts: number;
+	last_error: string | null;
+	next_attempt_at: number;
+	created_at: number;
+	delivered_at: number | null;
+};
+
+type WebhookDeliveryRow = Omit<WebhookDelivery, "status"> & { status: string };
+
+const toWebhookDelivery = (row: WebhookDeliveryRow): WebhookDelivery => {
+	const status: WebhookDeliveryStatus =
+		row.status === "delivered" || row.status === "giveup"
+			? row.status
+			: "pending";
+	return { ...row, status };
+};
+
+export const enqueueWebhookDelivery = async (
+	db: D1Database,
+	endpoint_id: string,
+	event: string,
+	payload: string,
+	next_attempt_at: number,
+): Promise<string> => {
+	const id = ulid();
+	await db
+		.prepare(
+			`INSERT INTO webhook_deliveries
+			   (id, endpoint_id, event, payload, status, attempts,
+			    last_error, next_attempt_at, created_at, delivered_at)
+			 VALUES (?, ?, ?, ?, 'pending', 0, NULL, ?, ?, NULL)`,
+		)
+		.bind(id, endpoint_id, event, payload, next_attempt_at, Date.now())
+		.run();
+	return id;
+};
+
+export const listPendingWebhookDeliveries = async (
+	db: D1Database,
+	now: number,
+	limit: number,
+): Promise<WebhookDelivery[]> => {
+	const rs = await db
+		.prepare(
+			`SELECT id, endpoint_id, event, payload, status, attempts,
+			        last_error, next_attempt_at, created_at, delivered_at
+			   FROM webhook_deliveries
+			  WHERE status = 'pending' AND next_attempt_at <= ?
+			  ORDER BY next_attempt_at ASC
+			  LIMIT ?`,
+		)
+		.bind(now, limit)
+		.all<WebhookDeliveryRow>();
+	return (rs.results ?? []).map(toWebhookDelivery);
+};
+
+export const markWebhookDelivered = async (
+	db: D1Database,
+	id: string,
+): Promise<void> => {
+	await db
+		.prepare(
+			`UPDATE webhook_deliveries
+			    SET status = 'delivered',
+			        attempts = attempts + 1,
+			        delivered_at = ?,
+			        last_error = NULL
+			  WHERE id = ?`,
+		)
+		.bind(Date.now(), id)
+		.run();
+};
+
+export const markWebhookFailed = async (
+	db: D1Database,
+	id: string,
+	next_attempt_at: number | null, // null → giveup
+	last_error: string,
+): Promise<void> => {
+	const status = next_attempt_at == null ? "giveup" : "pending";
+	const nextTs = next_attempt_at ?? 0;
+	await db
+		.prepare(
+			`UPDATE webhook_deliveries
+			    SET status = ?,
+			        attempts = attempts + 1,
+			        last_error = ?,
+			        next_attempt_at = ?
+			  WHERE id = ?`,
+		)
+		.bind(status, last_error, nextTs, id)
+		.run();
+};
+
+export const pruneWebhookDeliveries = async (
+	db: D1Database,
+	olderThan: number,
+): Promise<number> => {
+	// Keep the deliveries table from growing unbounded — delivered + giveup
+	// rows older than the threshold are removed. Pending rows are always
+	// kept so a long backoff schedule can't be silently dropped.
+	const rs = await db
+		.prepare(
+			`DELETE FROM webhook_deliveries
+			  WHERE status IN ('delivered', 'giveup')
+			    AND created_at < ?`,
+		)
+		.bind(olderThan)
+		.run();
+	return (rs.meta as { changes?: number }).changes ?? 0;
+};

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1155,6 +1155,7 @@ export const ADMIN_ACTIONS = [
 	"saved_reply.update",
 	"saved_reply.delete",
 	"saved_reply.post",
+	"import.disqus",
 ] as const;
 export type AdminAction = (typeof ADMIN_ACTIONS)[number];
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -25,6 +25,13 @@ export type Post = {
 	created_at: number;
 };
 
+export type UserRole = "user" | "mod" | "admin";
+
+export const USER_ROLES: readonly UserRole[] = ["user", "mod", "admin"] as const;
+
+export const isUserRole = (v: unknown): v is UserRole =>
+	v === "user" || v === "mod" || v === "admin";
+
 export type User = {
 	id: string;
 	provider: string;
@@ -34,6 +41,7 @@ export type User = {
 	avatar_url: string | null;
 	is_admin: boolean;
 	is_banned: boolean;
+	role: UserRole;
 	created_at: number;
 };
 
@@ -55,15 +63,17 @@ export type Comment = {
 	created_at: number;
 };
 
-type UserRow = Omit<User, "is_admin" | "is_banned"> & {
+type UserRow = Omit<User, "is_admin" | "is_banned" | "role"> & {
 	is_admin: number;
 	is_banned: number;
+	role: string;
 };
 
 const toUser = (row: UserRow): User => ({
 	...row,
 	is_admin: row.is_admin === 1,
 	is_banned: row.is_banned === 1,
+	role: isUserRole(row.role) ? row.role : "user",
 });
 
 export const upsertPost = async (
@@ -117,7 +127,7 @@ export const getOrCreateGhost = async (
 	const existing = await db
 		.prepare(
 			`SELECT id, provider, provider_id, name, email, avatar_url,
-			        is_admin, is_banned, created_at
+			        is_admin, is_banned, role, created_at
 			 FROM users WHERE provider = 'anon' AND provider_id = ?`,
 		)
 		.bind(ipHash)
@@ -144,6 +154,7 @@ export const getOrCreateGhost = async (
 		avatar_url: null,
 		is_admin: false,
 		is_banned: false,
+		role: "user",
 		created_at: now,
 	};
 };
@@ -177,7 +188,7 @@ export const upsertOauthUser = async (
 	const existing = await db
 		.prepare(
 			`SELECT id, provider, provider_id, name, email, avatar_url,
-			        is_admin, is_banned, created_at
+			        is_admin, is_banned, role, created_at
 			 FROM users WHERE provider = ? AND provider_id = ?`,
 		)
 		.bind(provider, provider_id)
@@ -203,13 +214,14 @@ export const upsertOauthUser = async (
 	const id = ulid();
 	const now = Date.now();
 	const is_admin = shouldPromote ? 1 : 0;
+	const role: UserRole = shouldPromote ? "admin" : "user";
 	await db
 		.prepare(
 			`INSERT INTO users (id, provider, provider_id, name, email,
-			                    avatar_url, is_admin, is_banned, created_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+			                    avatar_url, is_admin, is_banned, role, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
 		)
-		.bind(id, provider, provider_id, name, email, avatar_url, is_admin, now)
+		.bind(id, provider, provider_id, name, email, avatar_url, is_admin, role, now)
 		.run();
 	return {
 		id,
@@ -220,6 +232,7 @@ export const upsertOauthUser = async (
 		avatar_url,
 		is_admin: is_admin === 1,
 		is_banned: false,
+		role,
 		created_at: now,
 	};
 };
@@ -231,7 +244,7 @@ export const getUser = async (
 	const row = await db
 		.prepare(
 			`SELECT id, provider, provider_id, name, email, avatar_url,
-			        is_admin, is_banned, created_at
+			        is_admin, is_banned, role, created_at
 			 FROM users WHERE id = ?`,
 		)
 		.bind(id)
@@ -348,7 +361,7 @@ export const getUsersByIds = async (
 	const result = await db
 		.prepare(
 			`SELECT id, provider, provider_id, name, email, avatar_url,
-			        is_admin, is_banned, created_at
+			        is_admin, is_banned, role, created_at
 			   FROM users WHERE id IN (${placeholders})`,
 		)
 		.bind(...ids)
@@ -677,13 +690,13 @@ export const adminListUsers = async (
 		: "";
 	const sql = cursorCreatedAt != null && cursorId != null
 		? `SELECT id, provider, provider_id, name, email, avatar_url,
-		          is_admin, is_banned, created_at
+		          is_admin, is_banned, role, created_at
 		     FROM users
 		    WHERE (created_at, id) < (?, ?) ${filter}
 		    ORDER BY created_at DESC, id DESC
 		    LIMIT ?`
 		: `SELECT id, provider, provider_id, name, email, avatar_url,
-		          is_admin, is_banned, created_at
+		          is_admin, is_banned, role, created_at
 		     FROM users
 		    WHERE 1=1 ${filter}
 		    ORDER BY created_at DESC, id DESC
@@ -709,6 +722,20 @@ export const setUserBanned = async (
 	await db
 		.prepare(`UPDATE users SET is_banned = ? WHERE id = ?`)
 		.bind(banned ? 1 : 0, id)
+		.run();
+};
+
+// Writes role and is_admin together so the invariant `is_admin=1 ⇔ role='admin'`
+// is preserved while is_admin remains the public-facing column for /me.
+export const setUserRole = async (
+	db: D1Database,
+	id: string,
+	role: UserRole,
+): Promise<void> => {
+	const is_admin = role === "admin" ? 1 : 0;
+	await db
+		.prepare(`UPDATE users SET role = ?, is_admin = ? WHERE id = ?`)
+		.bind(role, is_admin, id)
 		.run();
 };
 
@@ -1110,6 +1137,10 @@ export const ADMIN_ACTIONS = [
 	"bulk.spam",
 	"bulk.delete",
 	"bulk.restore",
+	"role.grant_mod",
+	"role.revoke_mod",
+	"role.grant_admin",
+	"role.revoke_admin",
 ] as const;
 export type AdminAction = (typeof ADMIN_ACTIONS)[number];
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -744,6 +744,17 @@ export const setUserRole = async (
 		.run();
 };
 
+// Used by the role-change endpoint to refuse a demotion that would leave
+// the instance with zero admins. Self-demotion is already blocked, so
+// this guards the parallel-demotion edge case (two admins each demoting
+// the other simultaneously).
+export const countAdmins = async (db: D1Database): Promise<number> => {
+	const row = await db
+		.prepare(`SELECT COUNT(*) AS n FROM users WHERE role = 'admin'`)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+};
+
 export type AdminStats = {
 	total_comments: number;
 	pending_comments: number;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1092,6 +1092,7 @@ export type AuditTargetKind =
 	| "comment"
 	| "user"
 	| "subscription"
+	| "webhook"
 	| "system";
 
 export const ADMIN_ACTIONS = [
@@ -1110,6 +1111,9 @@ export const ADMIN_ACTIONS = [
 	"bulk.spam",
 	"bulk.delete",
 	"bulk.restore",
+	"webhook.create",
+	"webhook.update",
+	"webhook.delete",
 ] as const;
 export type AdminAction = (typeof ADMIN_ACTIONS)[number];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,17 @@ export type Bindings = {
 	// Set to "1" or "true" to suppress the "Powered by Garrul" attribution
 	// rendered under the comment list. Unset = attribution shown.
 	BRANDING_HIDDEN?: string;
+	// Cloudflare usage dashboard (optional). When both are set, /admin/usage
+	// surfaces today's Workers / D1 / KV usage vs the free-tier ceilings via
+	// Cloudflare's GraphQL Analytics API. Unset → the page shows a setup
+	// guide instead of charts and the nav link is hidden.
+	//
+	// Token scopes required (least-privilege):
+	//   - Account.Analytics: Read
+	//   - Account.D1: Read
+	//   - Account.Workers KV Storage: Read
+	CF_API_TOKEN?: string;
+	CF_ACCOUNT_ID?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { counts } from "./routes/api.counts";
 import { permalink } from "./routes/permalink";
 import { subscriptions } from "./routes/api.subscriptions";
 import { runDigest } from "./lib/digest";
+import { runWebhookRetries } from "./lib/webhook";
 import { log, requestLogger } from "./lib/log";
 import { corsAndCsrf } from "./lib/cors";
 import { sessionMiddleware } from "./lib/session";
@@ -168,6 +169,14 @@ export default {
 		env: Bindings,
 		ctx: ExecutionContext,
 	): Promise<void> => {
+		// Two independent passes per cron tick. waitUntil for both so a
+		// slow digest can't starve the webhook retry queue (and vice
+		// versa) — they each own their own wallclock budget.
 		ctx.waitUntil(runDigest(env));
+		ctx.waitUntil(
+			runWebhookRetries(env).catch((err) => {
+				log.error("scheduled.webhook_retries", { error: String(err) });
+			}),
+		);
 	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { health } from "./routes/health";
 import { comments } from "./routes/api.comments";
 import { config } from "./routes/api.config";
 import { reactions } from "./routes/api.reactions";
+import { votes } from "./routes/api.votes";
 import { auth } from "./routes/auth";
 import { embed } from "./routes/embed";
 import { agents } from "./routes/agents";
@@ -67,6 +68,11 @@ export type Bindings = {
 	//   - Account.Workers KV Storage: Read
 	CF_API_TOKEN?: string;
 	CF_ACCOUNT_ID?: string;
+	// Authenticated voting. Both default to enabled. Set to "0" or "false"
+	// to disable. Disabling downvotes is a brigading-mitigation switch the
+	// operator can flip without redeploy.
+	VOTING_ENABLED?: string;
+	DOWNVOTES_ENABLED?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -142,6 +148,7 @@ app.use("/api/*", sessionMiddleware());
 app.route("/api/v1/health", health);
 app.route("/api/v1/comments", comments);
 app.route("/api/v1/reactions", reactions);
+app.route("/api/v1/votes", votes);
 app.route("/api/v1/config", config);
 app.route("/api/v1/counts", counts);
 app.route("/api/v1/subscribe", subscriptions);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -23,7 +23,8 @@ export type EventName =
 	| "oauth.start"
 	| "oauth.complete"
 	| "oauth.failed"
-	| "reaction.toggled";
+	| "reaction.toggled"
+	| "vote.cast";
 
 type WriteFields = {
 	post_slug?: string | null;

--- a/src/lib/cf-usage.ts
+++ b/src/lib/cf-usage.ts
@@ -1,0 +1,344 @@
+/**
+ * Cloudflare GraphQL Analytics API client for the usage dashboard.
+ *
+ * The dashboard surfaces today's Workers / D1 / KV usage vs the
+ * free-tier ceilings. The API is queried server-side with a token
+ * stored in CF_API_TOKEN; results are cached in TREE_CACHE under
+ * `cfusage:*` for CACHE_TTL_SEC so a tab-flapping admin can't drive
+ * up our per-account analytics quota.
+ *
+ * Failure semantics: every panel is independent. If one of the three
+ * sub-queries (workers / d1 / kv) returns an error, the others still
+ * render — the caller gets `{ ok: false, error }` for the failing
+ * panel only. This keeps the page useful even when one of Cloudflare's
+ * APIs is intermittently down or the token is missing one scope.
+ *
+ * Free-tier ceilings (as of 2026-05) live in src/admin-ui/pages/usage.ts
+ * next to the chart that renders them. Update both sites together if
+ * the limits change.
+ */
+import { log } from "./log";
+
+export const isUsageConfigured = (env: {
+	CF_API_TOKEN?: string;
+	CF_ACCOUNT_ID?: string;
+}): boolean => Boolean(env.CF_API_TOKEN && env.CF_ACCOUNT_ID);
+
+const CF_GRAPHQL_URL = "https://api.cloudflare.com/client/v4/graphql";
+const CF_VERIFY_URL = "https://api.cloudflare.com/client/v4/user/tokens/verify";
+const CACHE_TTL_SEC = 300; // 5 minutes
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export type Panel<T> =
+	| { ok: true; data: T }
+	| { ok: false; error: string };
+
+export type UsageSnapshot = {
+	asOf: number; // ms epoch
+	workers: Panel<{ today: number; last30d: number }>;
+	d1: Panel<{
+		reads_today: number;
+		writes_today: number;
+		storage_bytes: number | null;
+	}>;
+	kv: Panel<{
+		reads_today: number;
+		writes_today: number;
+		storage_bytes: number | null;
+	}>;
+};
+
+type UsageEnv = {
+	CF_API_TOKEN?: string;
+	CF_ACCOUNT_ID?: string;
+	TREE_CACHE: KVNamespace;
+};
+
+const CACHE_KEY = "cfusage:snapshot";
+
+// -- token verification ------------------------------------------------------
+
+export type TokenVerifyResult =
+	| { ok: true; status: "active" | "disabled" | "expired" }
+	| { ok: false; error: string };
+
+export const verifyToken = async (
+	token: string,
+): Promise<TokenVerifyResult> => {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+	try {
+		const res = await fetch(CF_VERIFY_URL, {
+			headers: { authorization: `Bearer ${token}` },
+			signal: controller.signal,
+		});
+		if (!res.ok) {
+			return { ok: false, error: `http_${res.status}` };
+		}
+		const body = (await res.json().catch(() => null)) as
+			| { success?: boolean; result?: { status?: string } }
+			| null;
+		if (!body?.success || !body.result?.status) {
+			return { ok: false, error: "invalid_response" };
+		}
+		const status = body.result.status;
+		if (status === "active" || status === "disabled" || status === "expired") {
+			return { ok: true, status };
+		}
+		return { ok: false, error: `unknown_status:${status}` };
+	} catch (err) {
+		return { ok: false, error: String(err) };
+	} finally {
+		clearTimeout(timer);
+	}
+};
+
+// -- date helpers ------------------------------------------------------------
+
+const isoDay = (offsetDays: number): string => {
+	const d = new Date(Date.now() - offsetDays * 86_400_000);
+	return d.toISOString().slice(0, 10);
+};
+
+// -- GraphQL ----------------------------------------------------------------
+
+type GraphQLBody = {
+	query: string;
+	variables: Record<string, unknown>;
+};
+
+const graphql = async <T>(
+	token: string,
+	body: GraphQLBody,
+): Promise<T | { __error: string }> => {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+	try {
+		const res = await fetch(CF_GRAPHQL_URL, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify(body),
+			signal: controller.signal,
+		});
+		if (!res.ok) return { __error: `http_${res.status}` };
+		const json = (await res.json().catch(() => null)) as
+			| { data?: T; errors?: { message: string }[] }
+			| null;
+		if (!json) return { __error: "invalid_json" };
+		if (json.errors && json.errors.length > 0) {
+			return { __error: json.errors.map((e) => e.message).join("; ") };
+		}
+		if (!json.data) return { __error: "no_data" };
+		return json.data;
+	} catch (err) {
+		return { __error: String(err) };
+	} finally {
+		clearTimeout(timer);
+	}
+};
+
+const isError = <T>(v: T | { __error: string }): v is { __error: string } =>
+	typeof v === "object" && v !== null && "__error" in v;
+
+// -- Workers requests --------------------------------------------------------
+
+type WorkersResult = {
+	viewer: {
+		accounts: {
+			workersInvocationsAdaptive: { sum: { requests: number } }[];
+		}[];
+	};
+};
+
+const fetchWorkers = async (
+	token: string,
+	accountId: string,
+): Promise<Panel<{ today: number; last30d: number }>> => {
+	const today = isoDay(0);
+	const last30 = isoDay(30);
+	const query = `query ($accountTag: String!, $today: Date!, $last30: Date!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      today: workersInvocationsAdaptive(
+        filter: { date: $today }
+        limit: 10
+      ) { sum { requests } }
+      last30d: workersInvocationsAdaptive(
+        filter: { date_geq: $last30 }
+        limit: 1000
+      ) { sum { requests } }
+    }
+  }
+}`;
+	const data = await graphql<{
+		viewer: {
+			accounts: {
+				today: { sum: { requests: number } }[];
+				last30d: { sum: { requests: number } }[];
+			}[];
+		};
+	}>(token, {
+		query,
+		variables: { accountTag: accountId, today, last30 },
+	});
+	if (isError(data)) return { ok: false, error: data.__error };
+	const account = data.viewer.accounts[0];
+	if (!account) return { ok: false, error: "account_not_found" };
+	const sumOf = (rows: { sum: { requests: number } }[]): number =>
+		rows.reduce((acc, r) => acc + (r.sum?.requests ?? 0), 0);
+	return {
+		ok: true,
+		data: {
+			today: sumOf(account.today),
+			last30d: sumOf(account.last30d),
+		},
+	};
+};
+
+// -- D1 ----------------------------------------------------------------------
+
+type D1Data = {
+	reads_today: number;
+	writes_today: number;
+	storage_bytes: number | null;
+};
+
+const fetchD1 = async (
+	token: string,
+	accountId: string,
+): Promise<Panel<D1Data>> => {
+	const today = isoDay(0);
+	const query = `query ($accountTag: String!, $today: Date!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      d1AnalyticsAdaptiveGroups(
+        filter: { date: $today }
+        limit: 1000
+      ) {
+        sum {
+          readQueries
+          writeQueries
+        }
+      }
+    }
+  }
+}`;
+	const data = await graphql<{
+		viewer: {
+			accounts: {
+				d1AnalyticsAdaptiveGroups: {
+					sum: { readQueries: number; writeQueries: number };
+				}[];
+			}[];
+		};
+	}>(token, {
+		query,
+		variables: { accountTag: accountId, today },
+	});
+	if (isError(data)) return { ok: false, error: data.__error };
+	const account = data.viewer.accounts[0];
+	if (!account) return { ok: false, error: "account_not_found" };
+	const rows = account.d1AnalyticsAdaptiveGroups;
+	const reads = rows.reduce((a, r) => a + (r.sum?.readQueries ?? 0), 0);
+	const writes = rows.reduce((a, r) => a + (r.sum?.writeQueries ?? 0), 0);
+	// Storage size is not exposed via the analytics API; the dashboard
+	// shows null and links to the Cloudflare console for that metric.
+	return {
+		ok: true,
+		data: { reads_today: reads, writes_today: writes, storage_bytes: null },
+	};
+};
+
+// -- KV ----------------------------------------------------------------------
+
+type KvData = {
+	reads_today: number;
+	writes_today: number;
+	storage_bytes: number | null;
+};
+
+const fetchKv = async (
+	token: string,
+	accountId: string,
+): Promise<Panel<KvData>> => {
+	const today = isoDay(0);
+	const query = `query ($accountTag: String!, $today: Date!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      kvOperationsAdaptiveGroups(
+        filter: { date: $today, actionType_in: ["read", "write"] }
+        limit: 1000
+      ) {
+        sum { requests }
+        dimensions { actionType }
+      }
+    }
+  }
+}`;
+	const data = await graphql<{
+		viewer: {
+			accounts: {
+				kvOperationsAdaptiveGroups: {
+					sum: { requests: number };
+					dimensions: { actionType: string };
+				}[];
+			}[];
+		};
+	}>(token, {
+		query,
+		variables: { accountTag: accountId, today },
+	});
+	if (isError(data)) return { ok: false, error: data.__error };
+	const account = data.viewer.accounts[0];
+	if (!account) return { ok: false, error: "account_not_found" };
+	const rows = account.kvOperationsAdaptiveGroups;
+	let reads = 0;
+	let writes = 0;
+	for (const r of rows) {
+		const n = r.sum?.requests ?? 0;
+		if (r.dimensions.actionType === "read") reads += n;
+		else if (r.dimensions.actionType === "write") writes += n;
+	}
+	return {
+		ok: true,
+		data: { reads_today: reads, writes_today: writes, storage_bytes: null },
+	};
+};
+
+// -- public entry ------------------------------------------------------------
+
+export const fetchUsageSnapshot = async (
+	env: UsageEnv,
+	opts: { skipCache?: boolean } = {},
+): Promise<UsageSnapshot> => {
+	if (!env.CF_API_TOKEN || !env.CF_ACCOUNT_ID) {
+		throw new Error("usage_not_configured");
+	}
+	if (!opts.skipCache) {
+		const cached = await env.TREE_CACHE.get(CACHE_KEY, "json").catch(
+			() => null,
+		);
+		if (cached) return cached as UsageSnapshot;
+	}
+	const [workers, d1, kv] = await Promise.all([
+		fetchWorkers(env.CF_API_TOKEN, env.CF_ACCOUNT_ID),
+		fetchD1(env.CF_API_TOKEN, env.CF_ACCOUNT_ID),
+		fetchKv(env.CF_API_TOKEN, env.CF_ACCOUNT_ID),
+	]);
+	const snapshot: UsageSnapshot = {
+		asOf: Date.now(),
+		workers,
+		d1,
+		kv,
+	};
+	// Best-effort cache write — never let a KV failure block the page.
+	await env.TREE_CACHE.put(CACHE_KEY, JSON.stringify(snapshot), {
+		expirationTtl: CACHE_TTL_SEC,
+	}).catch((err) => {
+		log.warn("usage.cache_put_failed", { error: String(err) });
+	});
+	return snapshot;
+};

--- a/src/lib/disqus-import.ts
+++ b/src/lib/disqus-import.ts
@@ -102,6 +102,23 @@ const parseIso = (s: string | null): number => {
 	return Number.isFinite(t) ? t : Date.now();
 };
 
+// Strip HTML tags repeatedly until the input is a fixed point. A single
+// pass of `<[^>]+>` is bypassable when tags are nested: e.g.
+// `<scr<script>ipt>` becomes `<script>` after one replace and would still
+// be live HTML if downstream ever interpreted it. We're downstream-safe
+// already (output is markdown re-rendered through the allowlist), but
+// CodeQL flags the pattern regardless — and the fixed-point loop is the
+// canonical fix, costs O(n) per pass on already-clean strings.
+const stripTagsRepeatedly = (s: string): string => {
+	let prev: string;
+	let curr = s;
+	do {
+		prev = curr;
+		curr = prev.replace(/<[^>]+>/g, "");
+	} while (curr !== prev);
+	return curr;
+};
+
 export const disqusHtmlToMarkdown = (html: string): string => {
 	if (!html) return "";
 	let text = html;
@@ -109,14 +126,14 @@ export const disqusHtmlToMarkdown = (html: string): string => {
 		/<a\b[^>]*href\s*=\s*"([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi,
 		(_, href: string, inner: string) => {
 			const url = decodeEntities(href);
-			const label = decodeEntities(inner.replace(/<[^>]+>/g, "")).trim();
+			const label = decodeEntities(stripTagsRepeatedly(inner)).trim();
 			if (!/^https?:\/\//i.test(url)) return label;
 			return label && label !== url ? `[${label}](${url})` : url;
 		},
 	);
 	text = text.replace(/<br\s*\/?>/gi, "\n");
 	text = text.replace(/<\/p>/gi, "\n\n");
-	text = text.replace(/<[^>]+>/g, "");
+	text = stripTagsRepeatedly(text);
 	text = decodeEntities(text);
 	return text.trim();
 };

--- a/src/lib/disqus-import.ts
+++ b/src/lib/disqus-import.ts
@@ -1,0 +1,398 @@
+/**
+ * Disqus XML importer.
+ *
+ * Reads a Disqus comment-export XML file and converts it into Garrul's
+ * native shape:
+ *
+ *   <thread>         → posts.slug = derived from <link> or <id>
+ *   <post>           → comments.body_md (HTML stripped via the
+ *                       allowlist sanitizer, then converted to a flat
+ *                       paragraph of text — anything we can't render
+ *                       safely is dropped, not preserved as HTML)
+ *   <post>/<author>  → users.provider='anon', provider_id derived from
+ *                       the author identity, name = display name
+ *   <post>/<parent>  → comments.parent_id (resolved by Disqus dsq:id)
+ *
+ * Idempotency:
+ *   Every comment is inserted with import_source='disqus' and an
+ *   import_id derived from the Disqus dsq:id. The partial UNIQUE index
+ *   on (import_source, import_id) added by migration 0009 means a
+ *   re-run inserts zero new rows.
+ *
+ * Threading:
+ *   Disqus emits comments in document order, which is NOT necessarily a
+ *   parent-before-child order. We resolve in two passes: first pass
+ *   inserts every comment with `parent_id = NULL`, capturing the Disqus
+ *   parent reference; second pass updates the parent_id once every
+ *   native row has an ID assigned.
+ *
+ * Security:
+ *   * Document size is capped to abort runaway / malformed XML quickly.
+ *   * Comment bodies are stripped of HTML and re-rendered through the
+ *     existing markdown allowlist. Disqus' raw HTML is never stored.
+ *   * Ghost users created by the importer cannot authenticate (provider
+ *     is 'anon'; no OAuth identity).
+ */
+import { CURRENT_RENDERER_VERSION, renderMarkdown } from "./markdown";
+import { ulid } from "./ulid";
+
+export type DisqusThread = {
+	dsq_id: string;
+	link: string | null;
+	title: string | null;
+	created_at: number;
+};
+
+export type DisqusAuthor = {
+	name: string;
+	email: string | null;
+	is_anonymous: boolean;
+};
+
+export type DisqusPost = {
+	dsq_id: string;
+	thread_dsq_id: string;
+	parent_dsq_id: string | null;
+	created_at: number;
+	is_deleted: boolean;
+	is_spam: boolean;
+	message_html: string;
+	author: DisqusAuthor;
+};
+
+export type DisqusExport = {
+	threads: DisqusThread[];
+	posts: DisqusPost[];
+};
+
+const MAX_XML_BYTES = 50 * 1024 * 1024;
+
+const stripCdata = (s: string): string => {
+	const m = s.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
+	return m ? m[1]! : s;
+};
+
+const decodeEntities = (s: string): string =>
+	s
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&#(\d+);/g, (_, n: string) => String.fromCharCode(Number(n)))
+		.replace(/&amp;/g, "&");
+
+const innerText = (xml: string, tag: string): string | null => {
+	const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`);
+	const m = xml.match(re);
+	if (!m) return null;
+	return decodeEntities(stripCdata(m[1]!.trim()));
+};
+
+const attr = (xml: string, key: string): string | null => {
+	const re = new RegExp(`${key}\\s*=\\s*"([^"]*)"`);
+	const m = xml.match(re);
+	return m ? decodeEntities(m[1]!) : null;
+};
+
+const dsqId = (tag: string): string | null => attr(tag, "dsq:id");
+
+const parseIso = (s: string | null): number => {
+	if (!s) return Date.now();
+	const t = Date.parse(s);
+	return Number.isFinite(t) ? t : Date.now();
+};
+
+export const disqusHtmlToMarkdown = (html: string): string => {
+	if (!html) return "";
+	let text = html;
+	text = text.replace(
+		/<a\b[^>]*href\s*=\s*"([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi,
+		(_, href: string, inner: string) => {
+			const url = decodeEntities(href);
+			const label = decodeEntities(inner.replace(/<[^>]+>/g, "")).trim();
+			if (!/^https?:\/\//i.test(url)) return label;
+			return label && label !== url ? `[${label}](${url})` : url;
+		},
+	);
+	text = text.replace(/<br\s*\/?>/gi, "\n");
+	text = text.replace(/<\/p>/gi, "\n\n");
+	text = text.replace(/<[^>]+>/g, "");
+	text = decodeEntities(text);
+	return text.trim();
+};
+
+const findAll = (xml: string, tag: string): { open: string; inner: string }[] => {
+	// Match <tag ...>...</tag>. Disqus tags always close with the same name.
+	const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, "g");
+	const out: { open: string; inner: string }[] = [];
+	const matches = xml.matchAll(re);
+	for (const m of matches) {
+		const fullStart = m.index ?? 0;
+		const openEnd = xml.indexOf(">", fullStart);
+		const open = xml.slice(fullStart, openEnd + 1);
+		out.push({ open, inner: m[1]! });
+	}
+	return out;
+};
+
+export const parseDisqusXml = (xml: string): DisqusExport => {
+	if (xml.length > MAX_XML_BYTES) {
+		throw new Error(`disqus xml too large: ${xml.length} > ${MAX_XML_BYTES}`);
+	}
+
+	const threads: DisqusThread[] = [];
+	for (const { open, inner } of findAll(xml, "thread")) {
+		const id = dsqId(open);
+		if (!id) continue;
+		threads.push({
+			dsq_id: id,
+			link: innerText(inner, "link"),
+			title: innerText(inner, "title"),
+			created_at: parseIso(innerText(inner, "createdAt")),
+		});
+	}
+
+	const posts: DisqusPost[] = [];
+	for (const { open, inner } of findAll(xml, "post")) {
+		const id = dsqId(open);
+		if (!id) continue;
+		const threadMatch = inner.match(/<thread\b[^/>]*\/?>/);
+		const parentMatch = inner.match(/<parent\b[^/>]*\/?>/);
+		const thread_dsq_id = threadMatch ? dsqId(threadMatch[0]) : null;
+		if (!thread_dsq_id) continue;
+		const parent_dsq_id = parentMatch ? dsqId(parentMatch[0]) : null;
+
+		const message_html = innerText(inner, "message") ?? "";
+		const created_at = parseIso(innerText(inner, "createdAt"));
+		const isDeleted = innerText(inner, "isDeleted") === "true";
+		const isSpam = innerText(inner, "isSpam") === "true";
+
+		const authorBlock = inner.match(/<author\b[^>]*>([\s\S]*?)<\/author>/);
+		const author: DisqusAuthor = authorBlock
+			? {
+					name: innerText(authorBlock[1]!, "name") ?? "anonymous",
+					email: innerText(authorBlock[1]!, "email"),
+					is_anonymous:
+						innerText(authorBlock[1]!, "isAnonymous") === "true",
+				}
+			: { name: "anonymous", email: null, is_anonymous: true };
+
+		posts.push({
+			dsq_id: id,
+			thread_dsq_id,
+			parent_dsq_id,
+			created_at,
+			is_deleted: isDeleted,
+			is_spam: isSpam,
+			message_html,
+			author,
+		});
+	}
+
+	return { threads, posts };
+};
+
+export type ImportPlan = {
+	posts_total: number;
+	posts_skipped_deleted: number;
+	posts_skipped_spam: number;
+	threads_total: number;
+	new_posts: number;
+	new_users: number;
+	new_comments: number;
+};
+
+export type ImportOptions = {
+	dry_run?: boolean;
+	include_deleted?: boolean;
+	include_spam?: boolean;
+	slug_override?: string | null;
+};
+
+export const slugFromLink = (link: string | null, fallback: string): string => {
+	if (!link) return fallback;
+	try {
+		const u = new URL(link);
+		const path = u.pathname.replace(/^\/+|\/+$/g, "").replace(/\/+/g, "/");
+		return path || fallback;
+	} catch {
+		return fallback;
+	}
+};
+
+const authorKey = async (
+	author: DisqusAuthor,
+	secret: string,
+): Promise<string> => {
+	const seed = `${author.name}|${author.email ?? ""}`;
+	const enc = new TextEncoder();
+	const key = await crypto.subtle.importKey(
+		"raw",
+		enc.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const sig = await crypto.subtle.sign("HMAC", key, enc.encode(seed));
+	return Array.from(new Uint8Array(sig))
+		.slice(0, 16)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+};
+
+export const runDisqusImport = async (
+	db: D1Database,
+	xml: string,
+	secret: string,
+	opts: ImportOptions = {},
+): Promise<ImportPlan> => {
+	const parsed = parseDisqusXml(xml);
+	const plan: ImportPlan = {
+		posts_total: parsed.posts.length,
+		posts_skipped_deleted: 0,
+		posts_skipped_spam: 0,
+		threads_total: parsed.threads.length,
+		new_posts: 0,
+		new_users: 0,
+		new_comments: 0,
+	};
+
+	const threadBySlugCandidate = new Map<string, DisqusThread>();
+	const slugByThreadDsq = new Map<string, string>();
+	for (const t of parsed.threads) {
+		const slug = opts.slug_override ?? slugFromLink(t.link, `disqus-${t.dsq_id}`);
+		slugByThreadDsq.set(t.dsq_id, slug);
+		if (!threadBySlugCandidate.has(slug)) threadBySlugCandidate.set(slug, t);
+	}
+
+	for (const [slug, t] of threadBySlugCandidate) {
+		const existing = await db
+			.prepare(`SELECT slug FROM posts WHERE slug = ?`)
+			.bind(slug)
+			.first<{ slug: string }>();
+		if (existing) continue;
+		if (opts.dry_run) {
+			plan.new_posts += 1;
+			continue;
+		}
+		await db
+			.prepare(
+				`INSERT INTO posts (slug, title, url, created_at)
+				 VALUES (?, ?, ?, ?)`,
+			)
+			.bind(slug, t.title ?? slug, t.link ?? null, t.created_at)
+			.run();
+		plan.new_posts += 1;
+	}
+
+	const userIdByAuthorKey = new Map<string, string>();
+	const usersToInsert: { id: string; provider_id: string; name: string }[] = [];
+	for (const p of parsed.posts) {
+		if (!opts.include_deleted && p.is_deleted) continue;
+		if (!opts.include_spam && p.is_spam) continue;
+		const key = await authorKey(p.author, secret);
+		if (userIdByAuthorKey.has(key)) continue;
+
+		const existing = await db
+			.prepare(
+				`SELECT id FROM users WHERE provider = 'anon' AND provider_id = ?`,
+			)
+			.bind(key)
+			.first<{ id: string }>();
+		if (existing) {
+			userIdByAuthorKey.set(key, existing.id);
+			continue;
+		}
+		const id = ulid();
+		userIdByAuthorKey.set(key, id);
+		usersToInsert.push({ id, provider_id: key, name: p.author.name });
+	}
+
+	if (!opts.dry_run && usersToInsert.length > 0) {
+		const now = Date.now();
+		for (const u of usersToInsert) {
+			await db
+				.prepare(
+					`INSERT INTO users (id, provider, provider_id, name, email,
+					                    avatar_url, is_admin, is_banned, created_at,
+					                    import_source)
+					 VALUES (?, 'anon', ?, ?, NULL, NULL, 0, 0, ?, 'disqus')`,
+				)
+				.bind(u.id, u.provider_id, u.name, now)
+				.run();
+		}
+	}
+	plan.new_users = usersToInsert.length;
+
+	const nativeIdByDsq = new Map<string, string>();
+	for (const p of parsed.posts) {
+		if (!opts.include_deleted && p.is_deleted) {
+			plan.posts_skipped_deleted += 1;
+			continue;
+		}
+		if (!opts.include_spam && p.is_spam) {
+			plan.posts_skipped_spam += 1;
+			continue;
+		}
+		const slug = slugByThreadDsq.get(p.thread_dsq_id);
+		if (!slug) continue;
+		const key = await authorKey(p.author, secret);
+		const user_id = userIdByAuthorKey.get(key)!;
+
+		const existing = await db
+			.prepare(
+				`SELECT id FROM comments WHERE import_source = 'disqus' AND import_id = ?`,
+			)
+			.bind(p.dsq_id)
+			.first<{ id: string }>();
+		if (existing) {
+			nativeIdByDsq.set(p.dsq_id, existing.id);
+			continue;
+		}
+
+		const md = disqusHtmlToMarkdown(p.message_html);
+		const html = renderMarkdown(md);
+		const id = ulid();
+		nativeIdByDsq.set(p.dsq_id, id);
+		if (opts.dry_run) {
+			plan.new_comments += 1;
+			continue;
+		}
+		await db
+			.prepare(
+				`INSERT INTO comments (
+				   id, post_slug, parent_id, user_id, body_md, body_html,
+				   renderer_version, status, ip_hash, user_agent, created_at,
+				   import_source, import_id)
+				 VALUES (?, ?, NULL, ?, ?, ?, ?, 'approved', NULL, NULL, ?, ?, ?)`,
+			)
+			.bind(
+				id,
+				slug,
+				user_id,
+				md,
+				html,
+				CURRENT_RENDERER_VERSION,
+				p.created_at,
+				"disqus",
+				p.dsq_id,
+			)
+			.run();
+		plan.new_comments += 1;
+	}
+
+	if (!opts.dry_run) {
+		for (const p of parsed.posts) {
+			if (!p.parent_dsq_id) continue;
+			const child = nativeIdByDsq.get(p.dsq_id);
+			const parent = nativeIdByDsq.get(p.parent_dsq_id);
+			if (!child || !parent) continue;
+			await db
+				.prepare(`UPDATE comments SET parent_id = ? WHERE id = ?`)
+				.bind(parent, child)
+				.run();
+		}
+	}
+
+	return plan;
+};

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -51,6 +51,11 @@ export type TreeNode = {
 	 *  MAX_DEPTH) and the UI should show "@<flatten_from> ..." prefix. */
 	flatten_from: string | null;
 	reactions: ReactionCount[];
+	score_up: number;
+	score_down: number;
+	/** -1 / 0 / 1; only meaningful for the requesting viewer. Anonymous
+	 *  viewers always see 0 (and their list response is KV-cached). */
+	my_vote: -1 | 0 | 1;
 	replies: TreeNode[];
 };
 
@@ -133,6 +138,7 @@ const toNode = (
 	flatten_from: string | null,
 	usersById: Map<string, TreeAuthor>,
 	reactionsById: Map<string, ReactionCount[]>,
+	myVotes: Map<string, -1 | 1>,
 ): TreeNode => ({
 	id: row.id,
 	parent_id: row.parent_id,
@@ -145,6 +151,9 @@ const toNode = (
 	depth,
 	flatten_from,
 	reactions: reactionsById.get(row.id) ?? [],
+	score_up: row.score_up ?? 0,
+	score_down: row.score_down ?? 0,
+	my_vote: myVotes.get(row.id) ?? 0,
 	replies: [],
 });
 
@@ -161,13 +170,14 @@ const buildSubtree = (
 	usersById: Map<string, TreeAuthor>,
 	byId: Map<string, Comment>,
 	reactionsById: Map<string, ReactionCount[]>,
+	myVotes: Map<string, -1 | 1>,
 ): TreeNode[] => {
 	const kids = (children.get(parentId) ?? []).filter((k) => keep.has(k.id));
 	if (kids.length === 0) return [];
 	const out: TreeNode[] = [];
 	for (const k of kids) {
 		if (depth < MAX_DEPTH) {
-			const node = toNode(k, depth, null, usersById, reactionsById);
+			const node = toNode(k, depth, null, usersById, reactionsById, myVotes);
 			node.replies = buildSubtree(
 				k.id,
 				depth + 1,
@@ -176,6 +186,7 @@ const buildSubtree = (
 				usersById,
 				byId,
 				reactionsById,
+				myVotes,
 			);
 			out.push(node);
 		} else {
@@ -186,7 +197,7 @@ const buildSubtree = (
 				parentRow != null
 					? buildAuthor(usersById, parentRow.user_id).name
 					: null;
-			const node = toNode(k, MAX_DEPTH, parentAuthorName, usersById, reactionsById);
+			const node = toNode(k, MAX_DEPTH, parentAuthorName, usersById, reactionsById, myVotes);
 			out.push(node);
 			// Continue chasing the flattened descendants so nothing is dropped.
 			const descendants = buildSubtree(
@@ -197,6 +208,7 @@ const buildSubtree = (
 				usersById,
 				byId,
 				reactionsById,
+				myVotes,
 			);
 			for (const d of descendants) out.push(d);
 		}
@@ -212,6 +224,7 @@ export const buildTree = (
 	rows: Comment[],
 	usersById: Map<string, TreeAuthor>,
 	reactionsById: Map<string, ReactionCount[]> = new Map(),
+	myVotes: Map<string, -1 | 1> = new Map(),
 ): BuildResult => {
 	const byId = new Map<string, Comment>();
 	for (const r of rows) byId.set(r.id, r);
@@ -221,8 +234,8 @@ export const buildTree = (
 	const tops = (children.get(null) ?? []).filter((t) => keep.has(t.id));
 	const threads: TreeNode[] = [];
 	for (const t of tops) {
-		const node = toNode(t, 0, null, usersById, reactionsById);
-		node.replies = buildSubtree(t.id, 1, children, keep, usersById, byId, reactionsById);
+		const node = toNode(t, 0, null, usersById, reactionsById, myVotes);
+		node.replies = buildSubtree(t.id, 1, children, keep, usersById, byId, reactionsById, myVotes);
 		threads.push(node);
 	}
 	return { threads };

--- a/src/lib/url-safety.ts
+++ b/src/lib/url-safety.ts
@@ -1,0 +1,108 @@
+/**
+ * SSRF defense for outbound URLs the operator controls (webhook
+ * endpoints, future custom-receiver hooks).
+ *
+ * Cloudflare Workers' fetch resolves DNS for hostnames it dispatches, so
+ * an attacker-controlled hostname *can* resolve to a private IP at
+ * request time and this Worker can't intercept that. What we CAN do at
+ * configuration time:
+ *
+ *   1. Parse the URL and reject any literal IP in the RFC1918 / loopback
+ *      / link-local / IPv6 ULA ranges — the most common typo + the most
+ *      common naive attack.
+ *   2. Reject obviously-internal hostnames (localhost, *.local,
+ *      *.internal, host.docker.internal, *.cluster.local).
+ *   3. Require https:// unless the operator opts into http via
+ *      `allowHttp` (used for the legacy WEBHOOK_URL env var and for dev).
+ *
+ * This is a defense in depth — the operator is trusted to point this at
+ * a sane destination. We're catching misconfigurations and naive attacks,
+ * not a sophisticated adversary with control over DNS for an allowed
+ * hostname.
+ */
+
+const LOOPBACK_HOSTS = new Set([
+	"localhost",
+	"localhost.localdomain",
+	"ip6-localhost",
+	"ip6-loopback",
+	"host.docker.internal",
+]);
+
+const INTERNAL_TLDS = [".local", ".internal", ".localdomain", ".cluster.local"];
+
+const isPrivateIPv4 = (host: string): boolean => {
+	const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+	if (!m) return false;
+	const [a, b, c, d] = m.slice(1).map(Number) as [number, number, number, number];
+	if (a > 255 || b > 255 || c > 255 || d > 255) return true; // malformed → treat as unsafe
+	if (a === 10) return true;
+	if (a === 127) return true;
+	if (a === 0) return true;
+	if (a === 169 && b === 254) return true; // link-local
+	if (a === 172 && b >= 16 && b <= 31) return true;
+	if (a === 192 && b === 168) return true;
+	if (a === 192 && b === 0 && c === 2) return true; // TEST-NET-1
+	if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+	if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
+	if (a === 203 && b === 0 && c === 113) return true; // TEST-NET-3
+	if (a >= 224) return true; // multicast + reserved
+	return false;
+};
+
+const isPrivateIPv6 = (host: string): boolean => {
+	// Node's URL.hostname keeps the brackets ("[::1]"); strip them before
+	// matching. We don't parse the full address — match the obviously
+	// private prefixes literally. Anything we don't recognize is allowed.
+	let h = host.toLowerCase();
+	if (h.startsWith("[") && h.endsWith("]")) {
+		h = h.slice(1, -1);
+	}
+	if (h === "::" || h === "::1") return true;
+	if (h.startsWith("fc") || h.startsWith("fd")) return true; // ULA fc00::/7
+	if (h.startsWith("fe80")) return true; // link-local
+	if (h.startsWith("ff")) return true; // multicast
+	if (h.startsWith("::ffff:")) {
+		// IPv4-mapped IPv6 — reuse the v4 check on the trailing dotted-quad.
+		const v4 = h.slice("::ffff:".length);
+		if (v4.includes(".")) return isPrivateIPv4(v4);
+	}
+	return false;
+};
+
+export type UrlSafetyOptions = {
+	allowHttp?: boolean;
+};
+
+export type UrlSafetyResult =
+	| { ok: true; url: URL }
+	| { ok: false; reason: string };
+
+export const checkOutboundUrl = (
+	raw: string,
+	opts: UrlSafetyOptions = {},
+): UrlSafetyResult => {
+	let u: URL;
+	try {
+		u = new URL(raw);
+	} catch {
+		return { ok: false, reason: "invalid_url" };
+	}
+	if (u.protocol !== "https:" && !(opts.allowHttp && u.protocol === "http:")) {
+		return { ok: false, reason: "scheme_not_allowed" };
+	}
+	const host = u.hostname.toLowerCase();
+	if (!host) return { ok: false, reason: "empty_host" };
+	if (LOOPBACK_HOSTS.has(host)) {
+		return { ok: false, reason: "loopback_host" };
+	}
+	for (const tld of INTERNAL_TLDS) {
+		if (host.endsWith(tld)) return { ok: false, reason: "internal_tld" };
+	}
+	if (isPrivateIPv4(host)) return { ok: false, reason: "private_ipv4" };
+	if (isPrivateIPv6(host)) return { ok: false, reason: "private_ipv6" };
+	// Reject credentials in the URL — they'd be re-sent on every retry and
+	// leak into our delivery log if we kept the full URL there.
+	if (u.username || u.password) return { ok: false, reason: "url_credentials" };
+	return { ok: true, url: u };
+};

--- a/src/lib/webhook-adapters.ts
+++ b/src/lib/webhook-adapters.ts
@@ -80,10 +80,18 @@ const escapeSlackMentions = (s: string): string =>
 		.replace(/<#([A-Z0-9]+)>/g, "<#​$1>");
 
 // Slack body text needs &<> escaped per Slack's API docs.
+//
+// Order matters: mention-neutralization MUST run before HTML escaping.
+// Slack decodes &amp;/&lt;/&gt; before parsing mentions, so if we
+// HTML-escape first, `<!channel>` becomes `&lt;!channel&gt;`, the
+// mention regex finds nothing — and Slack happily decodes and pings
+// the channel. Inserting the ZWSP into the raw form means the
+// neutralizer survives the round trip.
 const escapeSlackText = (s: string): string =>
-	escapeSlackMentions(
-		s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
-	);
+	escapeSlackMentions(s)
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
 
 // Discord mentions: @everyone, @here, <@id>, <@!id>, <@&roleId>.
 // Inserting a zero-width space breaks the trigger while keeping the

--- a/src/lib/webhook-adapters.ts
+++ b/src/lib/webhook-adapters.ts
@@ -1,0 +1,118 @@
+/**
+ * Adapters that reshape the v1 WebhookPayload for non-generic
+ * destinations. Today: Slack and Discord incoming webhooks.
+ *
+ * Architecture note: the generic adapter is a pure JSON.stringify of
+ * the v1 payload. Slack/Discord need richer content (author name,
+ * comment snippet) than the v1 contract carries, so each adapter does
+ * its own DB lookup at render time. Once rendered, the resulting body
+ * is stored verbatim on the webhook_deliveries row — retries resend
+ * the same body, just with a fresh HMAC timestamp. We do NOT re-render
+ * on retry: by the time the 6-hour retry fires, the comment may have
+ * been edited or deleted, and we want the Slack/Discord channel to
+ * reflect what *was true at the event time*, not the now-stale state.
+ *
+ * Security posture:
+ *   - Snippets are truncated to platform limits BEFORE escaping, so a
+ *     long body can't bust the platform's hard 2000/4000-char cap.
+ *   - Mentions are neutralized so a comment body of "@everyone come
+ *     read this" cannot ping a whole Slack workspace or Discord guild.
+ *   - We send only `text` (Slack) / `content` (Discord) — no embeds,
+ *     no blocks. Keeps the attack surface small; embeds have their
+ *     own injection traps (markdown in titles, URL fields, etc.) we
+ *     don't need yet.
+ */
+import { getComment, getPost, getUser } from "../db/queries";
+import type { WebhookEvent, WebhookPayload } from "./webhook";
+
+type WebhookAdapterDb = Pick<D1Database, "prepare">;
+
+const EVENT_VERB: Record<WebhookEvent, string> = {
+	"comment.posted": "New comment",
+	"comment.edited": "Edited comment",
+	"comment.deleted": "Comment deleted",
+	"comment.approved": "Comment approved",
+	"comment.spam": "Comment marked spam",
+};
+
+// Cap snippet length pre-escape so the worst-case escaped output still
+// fits inside the platform body limit. 1500 raw chars + escape overhead
+// stays under Discord's 2000 and Slack's 3000.
+const SNIPPET_CAP = 1500;
+
+type Ctx = {
+	author: string;
+	post_title: string;
+	post_slug: string;
+	snippet: string;
+};
+
+const truncate = (s: string, max: number): string =>
+	s.length <= max ? s : `${s.slice(0, max)}…`;
+
+const loadContext = async (
+	db: WebhookAdapterDb,
+	payload: WebhookPayload,
+): Promise<Ctx> => {
+	// All three lookups can fail (row deleted, DB hiccup) without
+	// crashing the dispatch — the adapter degrades to ID-only.
+	const [comment, user, post] = await Promise.all([
+		getComment(db as D1Database, payload.comment_id).catch(() => null),
+		getUser(db as D1Database, payload.user_id).catch(() => null),
+		getPost(db as D1Database, payload.post_slug).catch(() => null),
+	]);
+	const author = user?.name ?? "anonymous";
+	const post_slug = comment?.post_slug ?? payload.post_slug;
+	const post_title = post?.title ?? post_slug;
+	const raw = comment?.body_md ?? "(no body available)";
+	const snippet = truncate(raw.replace(/\s+/g, " ").trim(), SNIPPET_CAP);
+	return { author, post_slug, post_title, snippet };
+};
+
+// Slack mentions: @everyone, @here, @channel, <!everyone>, <!here>,
+// <!channel>, <@U…>, <#C…>. Replace the `@` / `<!` with a literal
+// equivalent that won't trigger a notification.
+const escapeSlackMentions = (s: string): string =>
+	s
+		.replace(/@(everyone|here|channel)\b/gi, "@​$1")
+		.replace(/<!(everyone|here|channel)>/gi, "<!​$1>")
+		.replace(/<@([A-Z0-9]+)>/g, "<@​$1>")
+		.replace(/<#([A-Z0-9]+)>/g, "<#​$1>");
+
+// Slack body text needs &<> escaped per Slack's API docs.
+const escapeSlackText = (s: string): string =>
+	escapeSlackMentions(
+		s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
+	);
+
+// Discord mentions: @everyone, @here, <@id>, <@!id>, <@&roleId>.
+// Inserting a zero-width space breaks the trigger while keeping the
+// text legible.
+const escapeDiscordMentions = (s: string): string =>
+	s
+		.replace(/@(everyone|here)/gi, "@​$1")
+		.replace(/<@([!&]?\d+)>/g, "<@​$1>");
+
+export const renderSlackBody = async (
+	db: WebhookAdapterDb,
+	payload: WebhookPayload,
+): Promise<string> => {
+	const ctx = await loadContext(db, payload);
+	const text =
+		`*${EVENT_VERB[payload.event]}* by *${escapeSlackText(ctx.author)}* ` +
+		`on \`${escapeSlackText(ctx.post_title)}\`\n` +
+		`> ${escapeSlackText(ctx.snippet)}`;
+	return JSON.stringify({ text });
+};
+
+export const renderDiscordBody = async (
+	db: WebhookAdapterDb,
+	payload: WebhookPayload,
+): Promise<string> => {
+	const ctx = await loadContext(db, payload);
+	const content =
+		`**${EVENT_VERB[payload.event]}** by **${escapeDiscordMentions(ctx.author)}** ` +
+		`on \`${escapeDiscordMentions(ctx.post_title)}\`\n` +
+		`> ${escapeDiscordMentions(ctx.snippet)}`;
+	return JSON.stringify({ content });
+};

--- a/src/lib/webhook-sig.ts
+++ b/src/lib/webhook-sig.ts
@@ -1,0 +1,92 @@
+/**
+ * HMAC-SHA-256 signing for outbound webhooks. Stripe-style header:
+ *   X-Garrul-Signature: t=<ts>,v1=<hex(hmac_sha256(secret, ts + "." + body))>
+ *
+ * The timestamp is the (ms-epoch) moment we minted the signature, NOT
+ * the event timestamp. Receivers must reject signatures whose `t` is
+ * outside a small window relative to their own clock (we suggest ±5min)
+ * — without this check a captured request can be replayed indefinitely
+ * even though the HMAC is valid. Retries re-sign with a fresh `t` so a
+ * delivery hours after the event still passes the window check.
+ *
+ * Verification is exported for tests + future Garrul-receives-from-self
+ * scenarios; consumers in other languages implement the same algorithm
+ * (see docs/webhooks.md for the recipe).
+ */
+import { constantTimeEqual } from "./oauth";
+
+const encoder = new TextEncoder();
+
+const importHmacKey = async (secret: string): Promise<CryptoKey> =>
+	crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign", "verify"],
+	);
+
+const hexEncode = (buf: ArrayBuffer): string => {
+	const bytes = new Uint8Array(buf);
+	let out = "";
+	for (let i = 0; i < bytes.length; i++) {
+		const b = bytes[i];
+		if (b === undefined) continue;
+		out += b.toString(16).padStart(2, "0");
+	}
+	return out;
+};
+
+export const signWebhookBody = async (
+	secret: string,
+	body: string,
+	tsMs: number = Date.now(),
+): Promise<{ header: string; ts: number; signature: string }> => {
+	const key = await importHmacKey(secret);
+	const signed = `${tsMs}.${body}`;
+	const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(signed));
+	const signature = hexEncode(sig);
+	return {
+		header: `t=${tsMs},v1=${signature}`,
+		ts: tsMs,
+		signature,
+	};
+};
+
+type ParsedSig = { ts: number; v1: string };
+
+const parseSignatureHeader = (header: string): ParsedSig | null => {
+	let ts: number | null = null;
+	let v1: string | null = null;
+	for (const part of header.split(",")) {
+		const eq = part.indexOf("=");
+		if (eq < 1) continue;
+		const k = part.slice(0, eq).trim();
+		const v = part.slice(eq + 1).trim();
+		if (k === "t") {
+			const n = Number(v);
+			if (Number.isFinite(n)) ts = n;
+		} else if (k === "v1") {
+			// HMAC-SHA-256 hex output is exactly 64 chars. Reject obvious garbage
+			// to avoid feeding the constant-time compare arbitrary-length input.
+			if (/^[0-9a-f]{64}$/i.test(v)) v1 = v.toLowerCase();
+		}
+	}
+	if (ts == null || v1 == null) return null;
+	return { ts, v1 };
+};
+
+export const verifyWebhookSignature = async (
+	secret: string,
+	body: string,
+	header: string,
+	options: { toleranceMs?: number; now?: number } = {},
+): Promise<boolean> => {
+	const parsed = parseSignatureHeader(header);
+	if (!parsed) return false;
+	const tolerance = options.toleranceMs ?? 5 * 60 * 1000;
+	const now = options.now ?? Date.now();
+	if (Math.abs(now - parsed.ts) > tolerance) return false;
+	const expected = await signWebhookBody(secret, body, parsed.ts);
+	return constantTimeEqual(expected.signature, parsed.v1);
+};

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -172,6 +172,15 @@ const postOnce = async (
 
 const isDevEnv = (env: WebhookEnv): boolean => env.ENV === "dev";
 
+// The legacy WEBHOOK_URL env var allowed http:// in any environment.
+// Table-configured endpoints go through checkOutboundUrl on save, which
+// already rejects http:// outside dev — so the `_env` shim is the only
+// path that needs the relaxed scheme check at dispatch time. Without
+// this, operators upgrading with a prod `http://` WEBHOOK_URL silently
+// stop receiving deliveries.
+const allowHttpFor = (endpoint: WebhookEndpoint, env: WebhookEnv): boolean =>
+	endpoint.id === "_env" || isDevEnv(env);
+
 const dispatchToEndpoint = async (
 	env: WebhookEnv,
 	endpoint: WebhookEndpoint,
@@ -179,7 +188,7 @@ const dispatchToEndpoint = async (
 ): Promise<void> => {
 	if (!matchesEventFilter(endpoint, payload.event)) return;
 	const body = await renderBody(env.DB, endpoint.adapter, payload);
-	const result = await postOnce(endpoint, body, isDevEnv(env));
+	const result = await postOnce(endpoint, body, allowHttpFor(endpoint, env));
 	if (result.ok) {
 		if (endpoint.id !== "_env" && endpoint.fail_count > 0) {
 			await resetWebhookFailCount(env.DB, endpoint.id);
@@ -277,7 +286,11 @@ const retryDelivery = async (
 		);
 		return;
 	}
-	const result = await postOnce(endpoint, delivery.payload, isDevEnv(env));
+	const result = await postOnce(
+		endpoint,
+		delivery.payload,
+		allowHttpFor(endpoint, env),
+	);
 	if (result.ok) {
 		await markWebhookDelivered(env.DB, delivery.id);
 		if (endpoint.fail_count > 0) {

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -1,30 +1,59 @@
 /**
- * Outbound webhook for comment events.
+ * Outbound webhook dispatch — multi-endpoint, optionally signed, with a
+ * D1-backed retry queue.
  *
- * Operators set WEBHOOK_URL to a private endpoint (Slack incoming webhook,
- * Discord, custom audit log, etc.) and receive a JSON POST whenever a
- * comment is created, edited, deleted, or moderated.
+ * Endpoints live in `webhook_endpoints` (see migration 0006). Each
+ * endpoint has:
+ *   - a target URL (validated by checkOutboundUrl on save),
+ *   - an optional HMAC secret (signWebhookBody → X-Garrul-Signature),
+ *   - an event filter (NULL/empty = all events),
+ *   - an adapter that shapes the body for the destination (generic |
+ *     slack | discord; slack/discord land in Feature #3).
  *
- * Behavior:
- *   - Best-effort. A failed POST is logged via src/lib/log.ts and the
- *     user request completes regardless.
- *   - Callers MUST pass `c.executionCtx` so we can attach the POST to
- *     `waitUntil` — without it, the runtime can cancel the in-flight
- *     fetch once the response settles and the webhook is silently lost.
- *   - HMAC signing is intentionally deferred (v2 backlog). Operators who
- *     need it should put a reverse-proxy in front that adds the sig.
+ * Dispatch flow:
+ *   1. fireWebhook(c, payload) returns immediately and runs the dispatch
+ *      under ctx.waitUntil. Callers don't await.
+ *   2. dispatch loads the enabled endpoint list, filters by event, and
+ *      attempts an immediate POST per endpoint.
+ *   3. If the POST fails (network error / non-2xx), a webhook_deliveries
+ *      row is queued with next_attempt_at = now + RETRY_SCHEDULE[0]. The
+ *      scheduled handler in src/index.ts picks up due rows and retries
+ *      them, re-signing with a fresh timestamp each time so the receiver's
+ *      replay-window check still passes hours later.
  *
- * Payload shape (stable v1 contract):
+ * Backward compatibility:
+ *   - Operators with WEBHOOK_URL set and no table rows still get
+ *     deliveries — the env URL is synthesized into an in-memory endpoint
+ *     (adapter=generic, secret=null, events=null=all). The env shim does
+ *     NOT participate in the retry queue (no row to reference) — that's
+ *     the operator's nudge to migrate to a real endpoint row if they
+ *     want retries.
+ *
+ * Payload contract (v1, stable):
  *   {
- *     event: "comment.posted" | "comment.edited" | "comment.deleted"
- *          | "comment.approved" | "comment.spam",
- *     comment_id: string,
- *     post_slug: string,
- *     user_id: string,
- *     ts: number          // ms epoch
+ *     event: WebhookEvent,
+ *     comment_id, post_slug, user_id: string,
+ *     ts: number   // ms epoch of the EVENT, not the signature
  *   }
+ *   Receivers verify with the recipe in docs/webhooks.md.
  */
+import {
+	enqueueWebhookDelivery,
+	getWebhookEndpoint,
+	incrementWebhookFailCount,
+	listEnabledWebhookEndpoints,
+	listPendingWebhookDeliveries,
+	markWebhookDelivered,
+	markWebhookFailed,
+	pruneWebhookDeliveries,
+	resetWebhookFailCount,
+	type WebhookAdapter,
+	type WebhookDelivery,
+	type WebhookEndpoint,
+} from "../db/queries";
 import { log } from "./log";
+import { checkOutboundUrl } from "./url-safety";
+import { signWebhookBody } from "./webhook-sig";
 
 export type WebhookEvent =
 	| "comment.posted"
@@ -41,59 +70,170 @@ export type WebhookPayload = {
 	ts: number;
 };
 
-type WebhookCtx = {
+type WebhookEnv = {
+	DB: D1Database;
 	WEBHOOK_URL?: string;
+	ENV?: string;
 };
 
 const TIMEOUT_MS = 5000;
 
-export const sendWebhook = async (
-	env: WebhookCtx,
+// Exponential backoff schedule (ms). Index 0 is "first retry after the
+// initial inline failure". After we've exhausted this list we mark the
+// delivery 'giveup' and bump the endpoint's fail_count.
+export const RETRY_SCHEDULE_MS: readonly number[] = [
+	60_000,           // +1 min
+	5 * 60_000,       // +5 min
+	30 * 60_000,      // +30 min
+	2 * 60 * 60_000,  // +2 hr
+	6 * 60 * 60_000,  // +6 hr
+] as const;
+
+// After this many consecutive failures the endpoint auto-disables. The
+// operator sees `disabled_at` on the admin page and can investigate +
+// re-enable.
+const AUTO_DISABLE_THRESHOLD = 10;
+
+const renderGenericBody = (payload: WebhookPayload): string =>
+	JSON.stringify(payload);
+
+const renderBody = (
+	adapter: WebhookAdapter,
 	payload: WebhookPayload,
-): Promise<void> => {
-	const url = env.WEBHOOK_URL;
-	if (!url) return;
-	if (!/^https?:\/\//i.test(url)) return;
+): string => {
+	// slack/discord adapters land in Feature #3. Until then they fall
+	// through to the generic shape so existing endpoints with adapter=
+	// 'slack' (set ahead of the next release) don't 500.
+	if (adapter === "generic") return renderGenericBody(payload);
+	return renderGenericBody(payload);
+};
+
+const matchesEventFilter = (
+	endpoint: WebhookEndpoint,
+	event: WebhookEvent,
+): boolean => endpoint.events == null || endpoint.events.includes(event);
+
+const buildSyntheticEnvEndpoint = (url: string): WebhookEndpoint => {
+	const now = Date.now();
+	return {
+		id: "_env",
+		url,
+		secret: null,
+		events: null,
+		adapter: "generic",
+		enabled: true,
+		fail_count: 0,
+		disabled_at: null,
+		created_at: now,
+		updated_at: now,
+	};
+};
+
+const buildHeaders = async (
+	endpoint: WebhookEndpoint,
+	body: string,
+): Promise<HeadersInit> => {
+	const headers: Record<string, string> = {
+		"content-type": "application/json",
+		"user-agent": "Garrul-Webhook/2.0",
+	};
+	if (endpoint.secret) {
+		const sig = await signWebhookBody(endpoint.secret, body);
+		headers["x-garrul-signature"] = sig.header;
+	}
+	return headers;
+};
+
+const postOnce = async (
+	endpoint: WebhookEndpoint,
+	body: string,
+	allowHttp: boolean,
+): Promise<{ ok: boolean; status: number; error?: string }> => {
+	const safe = checkOutboundUrl(endpoint.url, { allowHttp });
+	if (!safe.ok) return { ok: false, status: 0, error: `url:${safe.reason}` };
 
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 	try {
-		const res = await fetch(url, {
+		const headers = await buildHeaders(endpoint, body);
+		const res = await fetch(endpoint.url, {
 			method: "POST",
-			headers: {
-				"content-type": "application/json",
-				"user-agent": "Garrul-Webhook/1.0",
-			},
-			body: JSON.stringify(payload),
+			headers,
+			body,
 			signal: controller.signal,
 		});
-		if (!res.ok) {
-			log.warn("webhook.non_ok", {
-				event: payload.event,
-				comment_id: payload.comment_id,
-				status: res.status,
-			});
-		}
+		return { ok: res.ok, status: res.status };
 	} catch (err) {
-		log.warn("webhook.failed", {
-			event: payload.event,
-			comment_id: payload.comment_id,
-			error: String(err),
-		});
+		return { ok: false, status: 0, error: String(err) };
 	} finally {
 		clearTimeout(timer);
 	}
 };
 
-/**
- * Fire-and-forget convenience. `executionCtx` is required: every HTTP
- * request handler in this worker already has `c.executionCtx`, and
- * without `waitUntil` the runtime can cancel the in-flight POST once
- * the response settles. If a caller genuinely has no context, log and
- * skip — better a missed webhook than a misleading "delivered" status.
- */
+const isDevEnv = (env: WebhookEnv): boolean => env.ENV === "dev";
+
+const dispatchToEndpoint = async (
+	env: WebhookEnv,
+	endpoint: WebhookEndpoint,
+	payload: WebhookPayload,
+): Promise<void> => {
+	if (!matchesEventFilter(endpoint, payload.event)) return;
+	const body = renderBody(endpoint.adapter, payload);
+	const result = await postOnce(endpoint, body, isDevEnv(env));
+	if (result.ok) {
+		if (endpoint.id !== "_env" && endpoint.fail_count > 0) {
+			await resetWebhookFailCount(env.DB, endpoint.id);
+		}
+		return;
+	}
+	const errorTag = result.error ?? `http_${result.status}`;
+	log.warn("webhook.failed", {
+		endpoint_id: endpoint.id,
+		event: payload.event,
+		comment_id: payload.comment_id,
+		status: result.status,
+		error: errorTag,
+	});
+	// Synthetic env endpoint has no row to queue against — legacy fire-
+	// and-forget semantics. Real endpoints get a delivery row for retry.
+	if (endpoint.id === "_env") return;
+	await enqueueWebhookDelivery(
+		env.DB,
+		endpoint.id,
+		payload.event,
+		body,
+		Date.now() + (RETRY_SCHEDULE_MS[0] ?? 60_000),
+	);
+};
+
+const loadEndpoints = async (env: WebhookEnv): Promise<WebhookEndpoint[]> => {
+	const rows = await listEnabledWebhookEndpoints(env.DB);
+	if (env.WEBHOOK_URL && rows.length === 0) {
+		// Legacy single-URL operator. Synthesize so they still get
+		// deliveries during the upgrade window; admin UI will flag it.
+		return [buildSyntheticEnvEndpoint(env.WEBHOOK_URL)];
+	}
+	return rows;
+};
+
+export const dispatchWebhook = async (
+	env: WebhookEnv,
+	payload: WebhookPayload,
+): Promise<void> => {
+	let endpoints: WebhookEndpoint[];
+	try {
+		endpoints = await loadEndpoints(env);
+	} catch (err) {
+		log.error("webhook.load_endpoints", { error: String(err) });
+		return;
+	}
+	await Promise.all(
+		endpoints.map((e) => dispatchToEndpoint(env, e, payload)),
+	);
+};
+
 export const fireWebhook = (
-	env: WebhookCtx,
+	env: WebhookEnv,
 	executionCtx: { waitUntil(p: Promise<unknown>): void } | undefined,
 	payload: WebhookPayload,
 ): void => {
@@ -104,5 +244,87 @@ export const fireWebhook = (
 		});
 		return;
 	}
-	executionCtx.waitUntil(sendWebhook(env, payload));
+	executionCtx.waitUntil(dispatchWebhook(env, payload));
+};
+
+// -------------------------- retry handler -----------------------------------
+
+const RETRY_BATCH = 25;
+const PRUNE_AFTER_MS = 30 * 24 * 60 * 60_000; // 30 days
+
+const nextBackoffMs = (attempts: number): number | null => {
+	// `attempts` here is the count BEFORE this run (post-increment is
+	// done by markWebhookFailed). After RETRY_SCHEDULE_MS.length total
+	// retries we give up.
+	if (attempts >= RETRY_SCHEDULE_MS.length) return null;
+	return RETRY_SCHEDULE_MS[attempts] ?? null;
+};
+
+const retryDelivery = async (
+	env: WebhookEnv,
+	delivery: WebhookDelivery,
+): Promise<void> => {
+	const endpoint = await getWebhookEndpoint(env.DB, delivery.endpoint_id);
+	if (!endpoint || !endpoint.enabled) {
+		// Endpoint was deleted or paused between the enqueue and this run.
+		// Mark the delivery as giveup so it stops cycling and doesn't show
+		// up in next_attempt_at scans forever.
+		await markWebhookFailed(
+			env.DB,
+			delivery.id,
+			null,
+			endpoint ? "endpoint_disabled" : "endpoint_deleted",
+		);
+		return;
+	}
+	const result = await postOnce(endpoint, delivery.payload, isDevEnv(env));
+	if (result.ok) {
+		await markWebhookDelivered(env.DB, delivery.id);
+		if (endpoint.fail_count > 0) {
+			await resetWebhookFailCount(env.DB, endpoint.id);
+		}
+		return;
+	}
+	const errorTag = result.error ?? `http_${result.status}`;
+	const next = nextBackoffMs(delivery.attempts + 1);
+	const giveup = next == null;
+	await markWebhookFailed(
+		env.DB,
+		delivery.id,
+		giveup ? null : Date.now() + next,
+		errorTag,
+	);
+	if (giveup) {
+		const newCount = endpoint.fail_count + 1;
+		await incrementWebhookFailCount(
+			env.DB,
+			endpoint.id,
+			newCount >= AUTO_DISABLE_THRESHOLD ? Date.now() : null,
+		);
+	}
+};
+
+export const runWebhookRetries = async (env: WebhookEnv): Promise<void> => {
+	const now = Date.now();
+	const due = await listPendingWebhookDeliveries(env.DB, now, RETRY_BATCH);
+	if (due.length === 0) return;
+	// Sequential rather than Promise.all: a single failing receiver can
+	// soak up the timeout budget; running serial means one stuck endpoint
+	// can't starve the others by exhausting the worker's wallclock cap.
+	// 25 deliveries × 5s timeout = 125s max, well under the cron's 30s
+	// CPU budget because most calls return in <1s. Adjust if real-world
+	// traffic shows a long tail.
+	for (const delivery of due) {
+		try {
+			await retryDelivery(env, delivery);
+		} catch (err) {
+			log.error("webhook.retry_crash", {
+				delivery_id: delivery.id,
+				error: String(err),
+			});
+		}
+	}
+	await pruneWebhookDeliveries(env.DB, Date.now() - PRUNE_AFTER_MS).catch(
+		(err) => log.warn("webhook.prune_failed", { error: String(err) }),
+	);
 };

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -53,6 +53,7 @@ import {
 } from "../db/queries";
 import { log } from "./log";
 import { checkOutboundUrl } from "./url-safety";
+import { renderDiscordBody, renderSlackBody } from "./webhook-adapters";
 import { signWebhookBody } from "./webhook-sig";
 
 export type WebhookEvent =
@@ -97,14 +98,13 @@ const AUTO_DISABLE_THRESHOLD = 10;
 const renderGenericBody = (payload: WebhookPayload): string =>
 	JSON.stringify(payload);
 
-const renderBody = (
+const renderBody = async (
+	db: D1Database,
 	adapter: WebhookAdapter,
 	payload: WebhookPayload,
-): string => {
-	// slack/discord adapters land in Feature #3. Until then they fall
-	// through to the generic shape so existing endpoints with adapter=
-	// 'slack' (set ahead of the next release) don't 500.
-	if (adapter === "generic") return renderGenericBody(payload);
+): Promise<string> => {
+	if (adapter === "slack") return renderSlackBody(db, payload);
+	if (adapter === "discord") return renderDiscordBody(db, payload);
 	return renderGenericBody(payload);
 };
 
@@ -178,7 +178,7 @@ const dispatchToEndpoint = async (
 	payload: WebhookPayload,
 ): Promise<void> => {
 	if (!matchesEventFilter(endpoint, payload.event)) return;
-	const body = renderBody(endpoint.adapter, payload);
+	const body = await renderBody(env.DB, endpoint.adapter, payload);
 	const result = await postOnce(endpoint, body, isDevEnv(env));
 	if (result.ok) {
 		if (endpoint.id !== "_env" && endpoint.fail_count > 0) {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -85,7 +85,14 @@ const wantsHtml = (c: Ctx): boolean => {
 	return accept.includes("text/html");
 };
 
-const requireAdmin = async (c: Ctx): Promise<User | Response> => {
+// Gate the admin-area pages and APIs. `level: "admin"` is the historical
+// behavior — only users with role='admin' (equivalently is_admin=1) pass.
+// `level: "mod"` is the new gate for moderation endpoints: role='mod' OR
+// role='admin'. Banned users never pass either gate.
+const requireRole = async (
+	c: Ctx,
+	level: "admin" | "mod",
+): Promise<User | Response> => {
 	const session = await readSession(c);
 	if (!session) {
 		if (wantsHtml(c)) {
@@ -97,10 +104,16 @@ const requireAdmin = async (c: Ctx): Promise<User | Response> => {
 		return c.json({ error: "not_authenticated" }, 401);
 	}
 	const user = await getUser(c.env.DB, session.user_id);
-	if (!user || !user.is_admin) {
+	const allowed =
+		!!user &&
+		!user.is_banned &&
+		(level === "mod"
+			? user.role === "mod" || user.role === "admin"
+			: user.role === "admin");
+	if (!allowed) {
 		if (wantsHtml(c)) {
 			return c.html(
-				accessDeniedHtml(403, "Your account is not an admin on this instance."),
+				accessDeniedHtml(403, "Your account does not have access to this area."),
 				403,
 			);
 		}
@@ -108,6 +121,11 @@ const requireAdmin = async (c: Ctx): Promise<User | Response> => {
 	}
 	return user;
 };
+
+const requireAdmin = (c: Ctx): Promise<User | Response> =>
+	requireRole(c, "admin");
+
+const requireMod = (c: Ctx): Promise<User | Response> => requireRole(c, "mod");
 
 admin.use("*", async (c, next) => {
 	c.header("content-security-policy", ADMIN_CSP);
@@ -132,7 +150,7 @@ admin.use("*", async (c, next) => {
 admin.use("*", versionCheckMiddleware());
 
 admin.get("/", async (c) => {
-	const user = await requireAdmin(c);
+	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const db = c.env.DB;
 	const [stats, timeline, topPosts, topCommenters, oldestPending, spamRate, updateInfo] =
@@ -169,7 +187,7 @@ const parseDateMs = (raw: string | undefined): number | null => {
 };
 
 admin.get("/queue", async (c) => {
-	const user = await requireAdmin(c);
+	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const statusParam = c.req.query("status") ?? "pending";
 	const status: CommentStatus | "all" =
@@ -245,7 +263,7 @@ admin.get("/queue", async (c) => {
 });
 
 admin.get("/comments/:id", async (c) => {
-	const user = await requireAdmin(c);
+	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const id = c.req.param("id");
 	const detail = await adminGetCommentDetail(c.env.DB, id);
@@ -501,7 +519,7 @@ admin.get("/settings", async (c) => {
 });
 
 admin.get("/about", async (c) => {
-	const user = await requireAdmin(c);
+	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const [updateInfo, releases] = await Promise.all([
 		peekCachedLatestVersion(c.env),
@@ -513,7 +531,7 @@ admin.get("/about", async (c) => {
 type CommentAction = "approve" | "spam" | "delete" | "restore";
 
 admin.post("/api/comments/:id", async (c) => {
-	const user = await requireAdmin(c);
+	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const id = c.req.param("id");
 	const body = await c.req
@@ -573,7 +591,7 @@ admin.post("/api/comments/:id", async (c) => {
 const BULK_ACTION_LIMIT = 100;
 
 admin.post("/api/comments/bulk", async (c) => {
-	const user = await requireAdmin(c);
+	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const body = await c.req
 		.json<{ ids?: unknown; action?: string }>()

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -695,7 +695,7 @@ admin.post("/api/users/:id", async (c) => {
 	return c.json({ ok: true, id, banned: body.banned });
 });
 
-const roleAuditAction = (
+export const roleAuditAction = (
 	from: UserRole,
 	to: UserRole,
 ): AdminAction | null => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -113,6 +113,7 @@ import {
 	type SubscriptionsFilters,
 } from "../admin-ui/pages/subscriptions";
 import { CURRENT_RENDERER_VERSION, renderMarkdown } from "../lib/markdown";
+import { runDisqusImport } from "../lib/disqus-import";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
 import { runSeedDemo } from "../db/seed-demo";
 import { renderConfirmEmailHtml } from "../lib/digest";
@@ -1473,6 +1474,64 @@ admin.post("/api/ops/rerender", async (c) => {
 		processed: result.processed,
 		next_cursor: result.next_cursor,
 	});
+});
+
+// ---------------------------- Disqus import --------------------------------
+//
+// Admin-only. Accepts a Disqus comment-export XML in the request body
+// (raw text/xml or application/xml). Idempotent — re-uploading the same
+// file inserts zero new rows. Capped at 50 MB to keep a hostile / huge
+// payload from running away inside the Worker; larger imports should go
+// through the CLI (`npm run import-disqus`).
+
+const MAX_IMPORT_BYTES = 50 * 1024 * 1024;
+
+admin.post("/api/ops/import-disqus", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+
+	const contentLength = Number(c.req.header("content-length") ?? "0");
+	if (contentLength > MAX_IMPORT_BYTES) {
+		return c.json({ error: "too_large" }, 413);
+	}
+	const xml = await c.req.text();
+	if (xml.length === 0) return c.json({ error: "empty_body" }, 400);
+	if (xml.length > MAX_IMPORT_BYTES) {
+		return c.json({ error: "too_large" }, 413);
+	}
+	// Lightweight format sanity check before we hit the parser. Reject
+	// non-XML uploads up front so an operator who picks the wrong file
+	// gets a clear error rather than a parser stack trace.
+	if (!/<disqus\b|<thread\b|<post\b/i.test(xml.slice(0, 4096))) {
+		return c.json({ error: "not_disqus_xml" }, 400);
+	}
+
+	const dryRun = c.req.header("x-dry-run") === "1";
+	const includeDeleted = c.req.header("x-include-deleted") === "1";
+	const includeSpam = c.req.header("x-include-spam") === "1";
+
+	// Reuse IP_HASH_SECRET for the importer's HMAC-derived ghost
+	// provider_id. Same secret rotation rules apply.
+	const secret = c.env.IP_HASH_SECRET;
+	if (!secret) return c.json({ error: "ip_hash_secret_missing" }, 500);
+
+	try {
+		const plan = await runDisqusImport(c.env.DB, xml, secret, {
+			dry_run: dryRun,
+			include_deleted: includeDeleted,
+			include_spam: includeSpam,
+		});
+		await adminInsertAudit(c.env.DB, {
+			admin_id: user.id,
+			action: "import.disqus",
+			target_kind: "system",
+			target_id: null,
+			meta: { dry_run: dryRun, ...plan },
+		});
+		return c.json({ ok: true, dry_run: dryRun, plan });
+	} catch (err) {
+		return c.json({ error: `import_failed:${(err as Error).message}` }, 400);
+	}
 });
 
 admin.post("/api/ops/seed-demo", async (c) => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -41,13 +41,16 @@ import {
 	getComment,
 	getPost,
 	getUser,
+	isUserRole,
 	markSubscriptionUnsubscribed,
 	setUserBanned,
+	setUserRole,
 	updateCommentStatus,
 	type AdminAction,
 	type AuditTargetKind,
 	type CommentStatus,
 	type User,
+	type UserRole,
 } from "../db/queries";
 import { fireWebhook, type WebhookEvent } from "../lib/webhook";
 import {
@@ -690,6 +693,54 @@ admin.post("/api/users/:id", async (c) => {
 		meta: { target_name: target.name },
 	});
 	return c.json({ ok: true, id, banned: body.banned });
+});
+
+const roleAuditAction = (
+	from: UserRole,
+	to: UserRole,
+): AdminAction | null => {
+	if (from === to) return null;
+	if (to === "admin") return "role.grant_admin";
+	if (from === "admin") return "role.revoke_admin";
+	if (to === "mod") return "role.grant_mod";
+	return "role.revoke_mod";
+};
+
+admin.post("/api/users/:id/role", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const body = await c.req
+		.json<{ role?: unknown; reason?: string }>()
+		.catch(() => null);
+	if (!body || !isUserRole(body.role)) {
+		return c.json({ error: "invalid_role" }, 400);
+	}
+	// Self-demotion would leave the instance without an admin if this is the
+	// last one. Block self role changes entirely — operators must promote a
+	// peer to admin first and have them demote, or use the DB CLI for the
+	// emergency case. Same defense-in-depth as ban: easy to misclick.
+	if (id === user.id) {
+		return c.json({ error: "cannot_change_own_role" }, 400);
+	}
+	const target = await getUser(c.env.DB, id);
+	if (!target) return c.json({ error: "not_found" }, 404);
+	const action = roleAuditAction(target.role, body.role);
+	if (!action) return c.json({ ok: true, id, role: target.role });
+	await setUserRole(c.env.DB, id, body.role);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action,
+		target_kind: "user",
+		target_id: id,
+		reason: body.reason ?? null,
+		meta: {
+			target_name: target.name,
+			from: target.role,
+			to: body.role,
+		},
+	});
+	return c.json({ ok: true, id, role: body.role });
 });
 
 const randomToken = (): string => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -38,6 +38,7 @@ import {
 	adminTimeline,
 	adminTopCommenters,
 	adminTopPosts,
+	countAdmins,
 	createWebhookEndpoint,
 	deleteWebhookEndpoint,
 	getComment,
@@ -1330,6 +1331,19 @@ admin.post("/api/users/:id/role", async (c) => {
 	if (!target) return c.json({ error: "not_found" }, 404);
 	const action = roleAuditAction(target.role, body.role);
 	if (!action) return c.json({ ok: true, id, role: target.role });
+	// Refuse a demotion that would leave the instance with zero admins.
+	// Self-change is already blocked above; this catches the parallel
+	// case where two admins simultaneously demote each other. The check
+	// is intentionally NOT a transaction with setUserRole — a true race
+	// here would require both requests to read count=2 before either
+	// writes, which is a narrow window and the worst case is a recovery
+	// via the DB CLI, not silent state corruption.
+	if (target.role === "admin" && body.role !== "admin") {
+		const admins = await countAdmins(c.env.DB);
+		if (admins <= 1) {
+			return c.json({ error: "last_admin" }, 400);
+		}
+	}
 	await setUserRole(c.env.DB, id, body.role);
 	await adminInsertAudit(c.env.DB, {
 		admin_id: user.id,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -38,18 +38,27 @@ import {
 	adminTimeline,
 	adminTopCommenters,
 	adminTopPosts,
+	createWebhookEndpoint,
+	deleteWebhookEndpoint,
 	getComment,
 	getPost,
 	getUser,
+	getWebhookEndpoint,
+	isWebhookAdapter,
+	listWebhookEndpoints,
 	markSubscriptionUnsubscribed,
 	setUserBanned,
 	updateCommentStatus,
+	updateWebhookEndpoint,
 	type AdminAction,
 	type AuditTargetKind,
 	type CommentStatus,
 	type User,
+	type WebhookAdapter,
+	type WebhookEndpoint,
 } from "../db/queries";
 import { fireWebhook, type WebhookEvent } from "../lib/webhook";
+import { checkOutboundUrl } from "../lib/url-safety";
 import {
 	peekCachedLatestVersion,
 	peekCachedRecentReleases,
@@ -66,6 +75,11 @@ import { renderUserDetail } from "../admin-ui/pages/user-detail";
 import { renderUsers } from "../admin-ui/pages/users";
 import { renderOperator } from "../admin-ui/pages/operator";
 import { renderSettings } from "../admin-ui/pages/settings";
+import {
+	renderWebhookForm,
+	renderWebhooksList,
+	type WebhookFormData,
+} from "../admin-ui/pages/webhooks";
 import {
 	renderSubscriptions,
 	type SubscriptionsFilters,
@@ -508,6 +522,221 @@ admin.get("/about", async (c) => {
 		peekCachedRecentReleases(c.env),
 	]);
 	return c.html(layout("About", renderAbout(releases), user, updateInfo));
+});
+
+// -------------------------- webhook endpoints -------------------------------
+//
+// Operator-only CRUD for /webhook_endpoints rows. Mods don't see this; webhook
+// configuration is operator territory (secrets, outbound URLs).
+//
+// The env-shim banner is driven by a stale `WEBHOOK_URL` env var coexisting
+// with a populated table — that's the misconfiguration that buys the user
+// the legacy unsigned-no-retry semantics. If the table is empty, the shim is
+// the only delivery surface and the banner reminds the operator to migrate.
+
+const isEnvShimActive = (env: Bindings, endpoints: WebhookEndpoint[]): boolean =>
+	Boolean(env.WEBHOOK_URL) && endpoints.length === 0;
+
+admin.get("/webhooks", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	const endpoints = await listWebhookEndpoints(c.env.DB);
+	return c.html(
+		layout(
+			"Webhooks",
+			renderWebhooksList(endpoints, {
+				active: isEnvShimActive(c.env, endpoints),
+				url: c.env.WEBHOOK_URL ?? "",
+			}),
+			user,
+			updateInfo,
+		),
+	);
+});
+
+admin.get("/webhooks/new", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	const data: WebhookFormData = { endpoint: null, error: null };
+	return c.html(
+		layout("Add webhook", renderWebhookForm(data), user, updateInfo),
+	);
+});
+
+admin.get("/webhooks/:id", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const endpoint = await getWebhookEndpoint(c.env.DB, id);
+	if (!endpoint) {
+		return c.html(
+			accessDeniedHtml(404, "That webhook endpoint no longer exists."),
+			404,
+		);
+	}
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	const data: WebhookFormData = { endpoint, error: null };
+	return c.html(
+		layout("Edit webhook", renderWebhookForm(data), user, updateInfo),
+	);
+});
+
+// Validation helpers used by both POST and PATCH. Centralized so an
+// operator who PATCHes a URL gets the same SSRF/scheme checks as a
+// fresh create.
+type WebhookBody = {
+	url?: unknown;
+	secret?: unknown;
+	events?: unknown;
+	adapter?: unknown;
+	enabled?: unknown;
+};
+
+type WebhookFields = {
+	url: string;
+	secret: string | null;
+	events: string[] | null;
+	adapter: WebhookAdapter;
+	enabled: boolean;
+};
+
+const VALID_EVENTS = [
+	"comment.posted",
+	"comment.edited",
+	"comment.deleted",
+	"comment.approved",
+	"comment.spam",
+] as const;
+
+const isValidEvent = (v: unknown): v is (typeof VALID_EVENTS)[number] =>
+	typeof v === "string" &&
+	(VALID_EVENTS as readonly string[]).includes(v);
+
+const parseWebhookBody = (
+	body: WebhookBody,
+	env: Bindings,
+): { ok: true; fields: WebhookFields } | { ok: false; error: string } => {
+	if (typeof body.url !== "string" || body.url.length === 0) {
+		return { ok: false, error: "url_required" };
+	}
+	// allowHttp only in dev — production endpoints must be https to make
+	// the signing+secret guarantees meaningful end-to-end.
+	const safe = checkOutboundUrl(body.url, { allowHttp: env.ENV === "dev" });
+	if (!safe.ok) return { ok: false, error: `url:${safe.reason}` };
+
+	let secret: string | null = null;
+	if (body.secret !== undefined && body.secret !== null && body.secret !== "") {
+		if (typeof body.secret !== "string") {
+			return { ok: false, error: "secret_invalid" };
+		}
+		// 16 bytes of entropy minimum — anything shorter is unsafe for HMAC
+		// signing and almost certainly a typo (admin meant "no secret").
+		if (body.secret.length < 16) {
+			return { ok: false, error: "secret_too_short" };
+		}
+		if (body.secret.length > 256) {
+			return { ok: false, error: "secret_too_long" };
+		}
+		secret = body.secret;
+	}
+
+	let events: string[] | null = null;
+	if (body.events !== undefined && body.events !== null) {
+		if (!Array.isArray(body.events)) {
+			return { ok: false, error: "events_invalid" };
+		}
+		const filtered = body.events.filter(isValidEvent);
+		if (filtered.length !== body.events.length) {
+			return { ok: false, error: "events_unknown" };
+		}
+		// All five events selected = "no filter"; store NULL so receivers
+		// see future events too without a re-save.
+		events = filtered.length === VALID_EVENTS.length ? null : filtered;
+	}
+
+	const adapter = body.adapter ?? "generic";
+	if (!isWebhookAdapter(adapter)) {
+		return { ok: false, error: "adapter_invalid" };
+	}
+
+	const enabled = body.enabled !== false; // default true
+
+	return {
+		ok: true,
+		fields: { url: body.url, secret, events, adapter, enabled },
+	};
+};
+
+admin.post("/api/webhooks", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const body = await c.req.json<WebhookBody>().catch(() => null);
+	if (!body) return c.json({ error: "invalid_body" }, 400);
+	const parsed = parseWebhookBody(body, c.env);
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const created = await createWebhookEndpoint(c.env.DB, parsed.fields);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "webhook.create",
+		target_kind: "webhook",
+		target_id: created.id,
+		// Never write the secret to the audit log — just whether one is set.
+		meta: {
+			url: created.url,
+			adapter: created.adapter,
+			enabled: created.enabled,
+			has_secret: created.secret != null,
+			events: created.events,
+		},
+	});
+	return c.json({ ok: true, id: created.id });
+});
+
+admin.patch("/api/webhooks/:id", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const existing = await getWebhookEndpoint(c.env.DB, id);
+	if (!existing) return c.json({ error: "not_found" }, 404);
+	const body = await c.req.json<WebhookBody>().catch(() => null);
+	if (!body) return c.json({ error: "invalid_body" }, 400);
+	const parsed = parseWebhookBody(body, c.env);
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	await updateWebhookEndpoint(c.env.DB, id, parsed.fields);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "webhook.update",
+		target_kind: "webhook",
+		target_id: id,
+		meta: {
+			url: parsed.fields.url,
+			adapter: parsed.fields.adapter,
+			enabled: parsed.fields.enabled,
+			has_secret: parsed.fields.secret != null,
+			secret_rotated: parsed.fields.secret !== existing.secret,
+			events: parsed.fields.events,
+		},
+	});
+	return c.json({ ok: true, id });
+});
+
+admin.delete("/api/webhooks/:id", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const existing = await getWebhookEndpoint(c.env.DB, id);
+	if (!existing) return c.json({ error: "not_found" }, 404);
+	await deleteWebhookEndpoint(c.env.DB, id);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "webhook.delete",
+		target_kind: "webhook",
+		target_id: id,
+		meta: { url: existing.url, adapter: existing.adapter },
+	});
+	return c.json({ ok: true, id });
 });
 
 type CommentAction = "approve" | "spam" | "delete" | "restore";

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -63,6 +63,7 @@ import {
 	peekCachedLatestVersion,
 	peekCachedRecentReleases,
 	versionCheckMiddleware,
+	type UpdateInfo,
 } from "../lib/version-check";
 import { accessDeniedHtml, layout } from "../admin-ui/layout";
 import { ADMIN_CSP } from "../admin-ui/styles";
@@ -81,6 +82,16 @@ import {
 	type WebhookFormData,
 } from "../admin-ui/pages/webhooks";
 import {
+	renderUsageDashboard,
+	renderUsageSetup,
+	renderUsageTokenError,
+} from "../admin-ui/pages/usage";
+import {
+	fetchUsageSnapshot,
+	isUsageConfigured,
+	verifyToken,
+} from "../lib/cf-usage";
+import {
 	renderSubscriptions,
 	type SubscriptionsFilters,
 } from "../admin-ui/pages/subscriptions";
@@ -98,6 +109,21 @@ const wantsHtml = (c: Ctx): boolean => {
 	const accept = c.req.header("accept") ?? "";
 	return accept.includes("text/html");
 };
+
+// Thin wrapper so every admin layout call computes the same env-derived
+// nav opts (currently just whether the optional usage dashboard is wired
+// up). Centralized so adding a future env-gated link doesn't require
+// touching ~17 callsites.
+const renderPage = (
+	c: Ctx,
+	title: string,
+	body: string,
+	user: User,
+	updateInfo: UpdateInfo | null,
+): string =>
+	layout(title, body, user, updateInfo, {
+		usage_link: isUsageConfigured(c.env),
+	});
 
 const requireAdmin = async (c: Ctx): Promise<User | Response> => {
 	const session = await readSession(c);
@@ -170,7 +196,7 @@ admin.get("/", async (c) => {
 		},
 		c.env,
 	);
-	return c.html(layout("Dashboard", body, user, updateInfo));
+	return c.html(renderPage(c, "Dashboard", body, user, updateInfo));
 });
 
 // Parse a YYYY-MM-DD string into a ms-epoch timestamp at the start of UTC day.
@@ -249,7 +275,7 @@ admin.get("/queue", async (c) => {
 		to: toRaw ?? "",
 	};
 	return c.html(
-		layout(
+		renderPage(c, 
 			"Queue",
 			renderQueue(trimmed, filters, nextCursor, latestAudit),
 			user,
@@ -268,7 +294,7 @@ admin.get("/comments/:id", async (c) => {
 	}
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout(`Comment ${id.slice(0, 8)}`, renderCommentDetail(detail), user, updateInfo),
+		renderPage(c, `Comment ${id.slice(0, 8)}`, renderCommentDetail(detail), user, updateInfo),
 	);
 });
 
@@ -298,7 +324,7 @@ admin.get("/users", async (c) => {
 		rows.length > 50 && last ? `${last.created_at}|${last.id}` : null;
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout("Users", renderUsers(trimmed, q, nextCursor), user, updateInfo),
+		renderPage(c, "Users", renderUsers(trimmed, q, nextCursor), user, updateInfo),
 	);
 });
 
@@ -335,7 +361,7 @@ admin.get("/users/:id", async (c) => {
 	}
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout(detail.user.name, renderUserDetail(detail), user, updateInfo),
+		renderPage(c, detail.user.name, renderUserDetail(detail), user, updateInfo),
 	);
 });
 
@@ -410,7 +436,7 @@ admin.get("/audit", async (c) => {
 	};
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout(
+		renderPage(c, 
 			"Audit",
 			renderAudit(trimmed, filters, nextCursor, ADMIN_ACTIONS),
 			user,
@@ -474,7 +500,7 @@ admin.get("/subscriptions", async (c) => {
 	};
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout(
+		renderPage(c, 
 			"Subscriptions",
 			renderSubscriptions(rows, filters, nextCursor),
 			user,
@@ -495,7 +521,7 @@ admin.get("/operator", async (c) => {
 	const stats = await rerenderStats(c.env.DB);
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout(
+		renderPage(c, 
 			"Operator",
 			renderOperator({
 				rerender: stats,
@@ -511,7 +537,7 @@ admin.get("/settings", async (c) => {
 	const user = await requireAdmin(c);
 	if (user instanceof Response) return user;
 	const updateInfo = await peekCachedLatestVersion(c.env);
-	return c.html(layout("Settings", renderSettings(c.env), user, updateInfo));
+	return c.html(renderPage(c, "Settings", renderSettings(c.env), user, updateInfo));
 });
 
 admin.get("/about", async (c) => {
@@ -521,7 +547,7 @@ admin.get("/about", async (c) => {
 		peekCachedLatestVersion(c.env),
 		peekCachedRecentReleases(c.env),
 	]);
-	return c.html(layout("About", renderAbout(releases), user, updateInfo));
+	return c.html(renderPage(c, "About", renderAbout(releases), user, updateInfo));
 });
 
 // -------------------------- webhook endpoints -------------------------------
@@ -543,7 +569,7 @@ admin.get("/webhooks", async (c) => {
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	const endpoints = await listWebhookEndpoints(c.env.DB);
 	return c.html(
-		layout(
+		renderPage(c, 
 			"Webhooks",
 			renderWebhooksList(endpoints, {
 				active: isEnvShimActive(c.env, endpoints),
@@ -561,7 +587,7 @@ admin.get("/webhooks/new", async (c) => {
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	const data: WebhookFormData = { endpoint: null, error: null };
 	return c.html(
-		layout("Add webhook", renderWebhookForm(data), user, updateInfo),
+		renderPage(c, "Add webhook", renderWebhookForm(data), user, updateInfo),
 	);
 });
 
@@ -579,7 +605,7 @@ admin.get("/webhooks/:id", async (c) => {
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	const data: WebhookFormData = { endpoint, error: null };
 	return c.html(
-		layout("Edit webhook", renderWebhookForm(data), user, updateInfo),
+		renderPage(c, "Edit webhook", renderWebhookForm(data), user, updateInfo),
 	);
 });
 
@@ -720,6 +746,41 @@ admin.patch("/api/webhooks/:id", async (c) => {
 		},
 	});
 	return c.json({ ok: true, id });
+});
+
+// -------------------------- Cloudflare usage dashboard ----------------------
+//
+// Optional feature. When CF_API_TOKEN + CF_ACCOUNT_ID are unset, the page
+// shows a setup guide instead of charts and the nav link is hidden by
+// layout.ts. We never throw a 500 here just because the operator hasn't
+// configured the token — graceful degradation per spec.
+
+admin.get("/usage", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	if (!isUsageConfigured(c.env)) {
+		return c.html(renderPage(c, "Usage", renderUsageSetup(), user, updateInfo));
+	}
+	// Verify the token before hitting GraphQL — surfaces revoked / wrong-
+	// scope tokens with a clear error instead of cryptic GraphQL failures.
+	const tokenOk = await verifyToken(c.env.CF_API_TOKEN as string);
+	if (!tokenOk.ok || tokenOk.status !== "active") {
+		const errMsg = tokenOk.ok ? `status:${tokenOk.status}` : tokenOk.error;
+		return c.html(
+			renderPage(c, "Usage", renderUsageTokenError(errMsg), user, updateInfo),
+		);
+	}
+	try {
+		const snapshot = await fetchUsageSnapshot(c.env);
+		return c.html(
+			renderPage(c, "Usage", renderUsageDashboard(snapshot), user, updateInfo),
+		);
+	} catch (err) {
+		return c.html(
+			renderPage(c, "Usage", renderUsageTokenError(String(err)), user, updateInfo),
+		);
+	}
 });
 
 admin.delete("/api/webhooks/:id", async (c) => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -342,7 +342,7 @@ admin.get("/users/:id", async (c) => {
 	}
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		layout(detail.user.name, renderUserDetail(detail), user, updateInfo),
+		layout(detail.user.name, renderUserDetail(detail, user), user, updateInfo),
 	);
 });
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -43,18 +43,28 @@ import {
 	getComment,
 	getPost,
 	getUser,
+	getUsersByIds,
+	getSavedReply,
 	getWebhookEndpoint,
+	insertComment,
+	insertSavedReply,
+	isSavedReplyScope,
 	isUserRole,
 	isWebhookAdapter,
+	listSavedRepliesForUser,
 	listWebhookEndpoints,
 	markSubscriptionUnsubscribed,
 	setUserBanned,
 	setUserRole,
 	updateCommentStatus,
+	updateSavedReply,
+	deleteSavedReply,
 	updateWebhookEndpoint,
 	type AdminAction,
 	type AuditTargetKind,
 	type CommentStatus,
+	type SavedReply,
+	type SavedReplyScope,
 	type User,
 	type UserRole,
 	type WebhookAdapter,
@@ -75,6 +85,10 @@ import { renderDashboard } from "../admin-ui/pages/dashboard";
 import { renderAudit, type AuditFilters } from "../admin-ui/pages/audit";
 import { renderCommentDetail } from "../admin-ui/pages/comment-detail";
 import { renderQueue, type QueueFilters } from "../admin-ui/pages/queue";
+import {
+	renderSavedRepliesList,
+	renderSavedReplyForm,
+} from "../admin-ui/pages/saved-replies";
 import { renderUserDetail } from "../admin-ui/pages/user-detail";
 import { renderUsers } from "../admin-ui/pages/users";
 import { renderOperator } from "../admin-ui/pages/operator";
@@ -98,6 +112,7 @@ import {
 	renderSubscriptions,
 	type SubscriptionsFilters,
 } from "../admin-ui/pages/subscriptions";
+import { CURRENT_RENDERER_VERSION, renderMarkdown } from "../lib/markdown";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
 import { runSeedDemo } from "../db/seed-demo";
 import { renderConfirmEmailHtml } from "../lib/digest";
@@ -819,6 +834,303 @@ admin.delete("/api/webhooks/:id", async (c) => {
 		meta: { url: existing.url, adapter: existing.adapter },
 	});
 	return c.json({ ok: true, id });
+});
+
+// ---------------------------- Saved replies --------------------------------
+//
+// Pre-written moderator replies. A mod authors a markdown body; we never
+// store rendered HTML — every post goes through renderMarkdown at post time
+// so a renderer-version bump always applies (matches comments).
+//
+// Visibility:
+//   - 'private' replies are visible only to the owner.
+//   - 'shared' replies are visible to every mod + admin.
+//
+// Mutation:
+//   - Only the owner can edit or delete (enforced in SQL via owner_id WHERE).
+//     Even an admin can't modify another mod's reply through the API — they
+//     can sign in as that user via OAuth if they really need to.
+//
+// Post-as-reply:
+//   - POST /admin/api/saved-replies/:id/post with { comment_id } posts a
+//     top-level reply on the same post as the target comment, authored by
+//     the mod's own user, status=approved (bypassing Turnstile/spam — the
+//     mod has already vouched for the content). Body is the saved reply's
+//     markdown, optionally edited.
+
+const SAVED_REPLY_TITLE_MAX = 120;
+const SAVED_REPLY_BODY_MAX = 8000;
+
+type SavedReplyBody = {
+	title?: unknown;
+	body_md?: unknown;
+	scope?: unknown;
+};
+
+type SavedReplyFields = {
+	title: string;
+	body_md: string;
+	scope: SavedReplyScope;
+};
+
+const parseSavedReplyBody = (
+	body: SavedReplyBody,
+): { ok: true; fields: SavedReplyFields } | { ok: false; error: string } => {
+	if (typeof body.title !== "string" || body.title.trim().length === 0) {
+		return { ok: false, error: "title_required" };
+	}
+	if (body.title.length > SAVED_REPLY_TITLE_MAX) {
+		return { ok: false, error: "title_too_long" };
+	}
+	if (typeof body.body_md !== "string" || body.body_md.trim().length === 0) {
+		return { ok: false, error: "body_required" };
+	}
+	if (body.body_md.length > SAVED_REPLY_BODY_MAX) {
+		return { ok: false, error: "body_too_long" };
+	}
+	if (!isSavedReplyScope(body.scope)) {
+		return { ok: false, error: "scope_invalid" };
+	}
+	return {
+		ok: true,
+		fields: {
+			title: body.title.trim(),
+			body_md: body.body_md,
+			scope: body.scope,
+		},
+	};
+};
+
+admin.get("/saved-replies", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	const replies = await listSavedRepliesForUser(c.env.DB, user.id);
+	const ownerIds = Array.from(new Set(replies.map((r) => r.owner_id)));
+	const owners = await getUsersByIds(c.env.DB, ownerIds);
+	const ownersById = new Map<string, string>();
+	for (const [id, u] of owners) ownersById.set(id, u.name);
+	return c.html(
+		renderPage(
+			c,
+			"Saved replies",
+			renderSavedRepliesList(replies, user, ownersById),
+			user,
+			updateInfo,
+		),
+	);
+});
+
+admin.get("/saved-replies/new", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	return c.html(
+		renderPage(
+			c,
+			"New saved reply",
+			renderSavedReplyForm({ existing: null, error: null }),
+			user,
+			updateInfo,
+		),
+	);
+});
+
+admin.get("/saved-replies/:id", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const reply = await getSavedReply(c.env.DB, id);
+	if (!reply) {
+		return c.html(
+			accessDeniedHtml(404, "That saved reply no longer exists."),
+			404,
+		);
+	}
+	// Read visibility: owner can always see it; non-owners only if shared.
+	// Private replies are not enumerable across mods.
+	if (reply.owner_id !== user.id && reply.scope !== "shared") {
+		return c.html(
+			accessDeniedHtml(404, "That saved reply no longer exists."),
+			404,
+		);
+	}
+	const updateInfo = await peekCachedLatestVersion(c.env);
+	return c.html(
+		renderPage(
+			c,
+			"Edit saved reply",
+			renderSavedReplyForm({ existing: reply, error: null }),
+			user,
+			updateInfo,
+		),
+	);
+});
+
+// JSON list for the queue's Reply picker. Same visibility rules as
+// /admin/saved-replies — owner-private OR scope=shared.
+admin.get("/api/saved-replies", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const replies = await listSavedRepliesForUser(c.env.DB, user.id);
+	return c.json({
+		replies: replies.map((r) => ({
+			id: r.id,
+			title: r.title,
+			body_md: r.body_md,
+			scope: r.scope,
+			owner_id: r.owner_id,
+		})),
+	});
+});
+
+admin.post("/api/saved-replies", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const body = await c.req.json<SavedReplyBody>().catch(() => null);
+	if (!body) return c.json({ error: "invalid_body" }, 400);
+	const parsed = parseSavedReplyBody(body);
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const created = await insertSavedReply(c.env.DB, {
+		owner_id: user.id,
+		title: parsed.fields.title,
+		body_md: parsed.fields.body_md,
+		scope: parsed.fields.scope,
+	});
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "saved_reply.create",
+		target_kind: "saved_reply",
+		target_id: created.id,
+		meta: { title: created.title, scope: created.scope },
+	});
+	return c.json({ ok: true, id: created.id });
+});
+
+admin.patch("/api/saved-replies/:id", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const existing = await getSavedReply(c.env.DB, id);
+	if (!existing) return c.json({ error: "not_found" }, 404);
+	// Owner-only mutation. Even an admin cannot edit another mod's private
+	// reply through the API — the WHERE clause in updateSavedReply enforces
+	// this in SQL too, but we 403 cleanly here for a better error.
+	if (existing.owner_id !== user.id) {
+		return c.json({ error: "not_owner" }, 403);
+	}
+	const body = await c.req.json<SavedReplyBody>().catch(() => null);
+	if (!body) return c.json({ error: "invalid_body" }, 400);
+	const parsed = parseSavedReplyBody(body);
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const changed = await updateSavedReply(c.env.DB, id, user.id, parsed.fields);
+	if (!changed) return c.json({ error: "not_found" }, 404);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "saved_reply.update",
+		target_kind: "saved_reply",
+		target_id: id,
+		meta: {
+			title: parsed.fields.title,
+			scope: parsed.fields.scope,
+			scope_changed: existing.scope !== parsed.fields.scope,
+		},
+	});
+	return c.json({ ok: true, id });
+});
+
+admin.delete("/api/saved-replies/:id", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const existing = await getSavedReply(c.env.DB, id);
+	if (!existing) return c.json({ error: "not_found" }, 404);
+	if (existing.owner_id !== user.id) {
+		return c.json({ error: "not_owner" }, 403);
+	}
+	const deleted = await deleteSavedReply(c.env.DB, id, user.id);
+	if (!deleted) return c.json({ error: "not_found" }, 404);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "saved_reply.delete",
+		target_kind: "saved_reply",
+		target_id: id,
+		meta: { title: existing.title, scope: existing.scope },
+	});
+	return c.json({ ok: true, id });
+});
+
+// Post a saved reply as a top-level reply on a comment. Body is the
+// saved reply's markdown by default; the mod can override (`body_md`) to
+// tweak before sending. Always re-rendered through renderMarkdown — we
+// never trust stored HTML.
+admin.post("/api/saved-replies/:id/post", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const reply = await getSavedReply(c.env.DB, id);
+	if (!reply) return c.json({ error: "not_found" }, 404);
+	// Visibility check mirrors the GET — only the owner or shared replies.
+	if (reply.owner_id !== user.id && reply.scope !== "shared") {
+		return c.json({ error: "not_found" }, 404);
+	}
+	const body = await c.req
+		.json<{ comment_id?: unknown; body_md?: unknown }>()
+		.catch(() => null);
+	if (!body || typeof body.comment_id !== "string") {
+		return c.json({ error: "invalid_body" }, 400);
+	}
+	const target = await getComment(c.env.DB, body.comment_id);
+	if (!target) return c.json({ error: "comment_not_found" }, 404);
+	if (target.status === "deleted") {
+		return c.json({ error: "comment_deleted" }, 400);
+	}
+	// Allow the mod to override the body before posting.
+	const rawBody =
+		typeof body.body_md === "string" && body.body_md.trim().length > 0
+			? body.body_md
+			: reply.body_md;
+	if (rawBody.length > SAVED_REPLY_BODY_MAX) {
+		return c.json({ error: "body_too_long" }, 400);
+	}
+	const body_html = renderMarkdown(rawBody);
+	const inserted = await insertComment(c.env.DB, {
+		post_slug: target.post_slug,
+		parent_id: target.id,
+		user_id: user.id,
+		body_md: rawBody,
+		body_html,
+		renderer_version: CURRENT_RENDERER_VERSION,
+		status: "approved",
+		ip_hash: null,
+		user_agent: null,
+	});
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "saved_reply.post",
+		target_kind: "comment",
+		target_id: inserted.id,
+		meta: {
+			from_saved_reply: true,
+			saved_reply_id: reply.id,
+			parent_id: target.id,
+			post_slug: target.post_slug,
+		},
+	});
+	// Bust the post's tree caches so the new reply is visible immediately.
+	await Promise.all([
+		c.env.TREE_CACHE.delete(`tree:${target.post_slug}:first:new`),
+		c.env.TREE_CACHE.delete(`tree:${target.post_slug}:first:top`),
+		c.env.TREE_CACHE.delete(`tree:${target.post_slug}:first`),
+	]);
+	fireWebhook(c.env, c.executionCtx, {
+		event: "comment.posted",
+		comment_id: inserted.id,
+		post_slug: target.post_slug,
+		user_id: user.id,
+		ts: Date.now(),
+	});
+	return c.json({ ok: true, id: inserted.id });
 });
 
 type CommentAction = "approve" | "spam" | "delete" | "restore";

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -860,8 +860,10 @@ admin.delete("/api/webhooks/:id", async (c) => {
 //     mod has already vouched for the content). Body is the saved reply's
 //     markdown, optionally edited.
 
-const SAVED_REPLY_TITLE_MAX = 120;
-const SAVED_REPLY_BODY_MAX = 8000;
+// Exported so tests can assert the parser against the real values
+// instead of pinning literal numbers that would silently drift.
+export const SAVED_REPLY_TITLE_MAX = 120;
+export const SAVED_REPLY_BODY_MAX = 8000;
 
 type SavedReplyBody = {
 	title?: unknown;
@@ -875,7 +877,7 @@ type SavedReplyFields = {
 	scope: SavedReplyScope;
 };
 
-const parseSavedReplyBody = (
+export const parseSavedReplyBody = (
 	body: SavedReplyBody,
 ): { ok: true; fields: SavedReplyFields } | { ok: false; error: string } => {
 	if (typeof body.title !== "string" || body.title.trim().length === 0) {

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -26,6 +26,7 @@ import {
 	getOrCreateGhost,
 	getComment,
 	getPost,
+	getUserVotesOnPost,
 	insertComment,
 	listActiveSubscriptionsForPost,
 	listCommentsForPost,
@@ -437,7 +438,13 @@ comments.post("/", async (c) => {
 	// Bust the cached first page. Older pages bypass cache, so there's
 	// nothing else to invalidate. Pending comments don't appear in the
 	// public tree but the cache key is the same; busting is still correct.
-	await c.env.TREE_CACHE.delete(`tree:${slug}:first`);
+	await Promise.all([
+		c.env.TREE_CACHE.delete(`tree:${slug}:first:new`),
+		c.env.TREE_CACHE.delete(`tree:${slug}:first:top`),
+		// Legacy key from before the sort-keyed cache split. Drop after
+		// one release cycle when prod caches have rotated.
+		c.env.TREE_CACHE.delete(`tree:${slug}:first`),
+	]);
 
 	// Persist whichever spam signals ran. Fire-and-forget so a slow D1
 	// write never adds latency to the user-visible POST. Mirror the
@@ -545,14 +552,18 @@ comments.get("/", async (c) => {
 	if (!slug) return c.json({ error: t("err.post.required") }, 400);
 	if (!SLUG_RE.test(slug)) return c.json({ error: t("err.post.invalid") }, 400);
 
+	const sortParam = (c.req.query("sort") ?? "new").trim();
+	const sort: "new" | "top" = sortParam === "top" ? "top" : "new";
+
 	const cursor = decodeCursor(c.req.query("before") ?? null);
 	const session = await readSession(c);
 
-	// Fast path: first page is cached in KV for anonymous viewers only.
-	// Signed-in viewers see per-user "mine" flags on reactions, so they
-	// bypass the cache. (KV cache hit-rate stays high on the public reader
-	// path, which dominates traffic.)
-	const cacheKey = `tree:${slug}:first`;
+	// Fast path: first page is cached in KV for anonymous viewers only,
+	// keyed by sort so `top` and `new` don't poison each other.
+	// Signed-in viewers see per-user my_vote / mine flags so they bypass
+	// the cache. KV cache hit-rate stays high on the public reader path,
+	// which dominates traffic.
+	const cacheKey = `tree:${slug}:first:${sort}`;
 	if (!cursor && !session) {
 		const cached = await c.env.TREE_CACHE.get(cacheKey, "json");
 		if (cached) return c.json(cached);
@@ -577,11 +588,27 @@ comments.get("/", async (c) => {
 		reactionsById.set(r.comment_id, list);
 	}
 
-	const { threads: allThreads } = buildTree(rows, authors, reactionsById);
+	const myVotes = session
+		? await getUserVotesOnPost(c.env.DB, slug, session.user_id)
+		: new Map<string, -1 | 1>();
 
-	// Newest-first top-level ordering. The tree builder returns ASC so we
-	// reverse here; the widget pages with ?before=<oldest_id_on_page>.
-	allThreads.reverse();
+	const { threads: allThreads } = buildTree(rows, authors, reactionsById, myVotes);
+
+	if (sort === "top") {
+		// Top-level only — replies stay in created_at ASC so threaded
+		// conversation reads top-down. Tie-break on newer-first so a
+		// fresh comment with the same score floats above an old one.
+		allThreads.sort((a, b) => {
+			const sa = a.score_up - a.score_down;
+			const sb = b.score_up - b.score_down;
+			if (sb !== sa) return sb - sa;
+			return b.created_at - a.created_at;
+		});
+	} else {
+		// Newest-first top-level ordering. The tree builder returns ASC so
+		// we reverse here; widget pages with ?before=<oldest_id_on_page>.
+		allThreads.reverse();
+	}
 
 	// Apply cursor: slice threads with id < cursor.
 	const startIdx = cursor
@@ -635,7 +662,11 @@ comments.patch("/:id", async (c) => {
 		body_html,
 		CURRENT_RENDERER_VERSION,
 	);
-	await c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`);
+	await Promise.all([
+		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:new`),
+		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:top`),
+		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`),
+	]);
 	writeEvent(c.env.ANALYTICS, "comment.edited", { post_slug: existing.post_slug });
 	fireWebhook(c.env, c.executionCtx, {
 		event: "comment.edited",
@@ -682,7 +713,11 @@ comments.delete("/:id", async (c) => {
 	}
 
 	await softDeleteComment(c.env.DB, id);
-	await c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`);
+	await Promise.all([
+		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:new`),
+		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:top`),
+		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`),
+	]);
 	writeEvent(c.env.ANALYTICS, "comment.deleted", { post_slug: existing.post_slug });
 	fireWebhook(c.env, c.executionCtx, {
 		event: "comment.deleted",

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -561,7 +561,13 @@ comments.get("/", async (c) => {
 	const sortParam = (c.req.query("sort") ?? "new").trim();
 	const sort: "new" | "top" = sortParam === "top" ? "top" : "new";
 
-	const cursor = decodeCursor(c.req.query("before") ?? null);
+	// The cursor format (`id < cursor`) only makes sense for the time-DESC
+	// `new` ordering — applying it to score-sorted results would skip or
+	// duplicate threads as scores shift. `top` returns a single page; any
+	// supplied ?before is ignored.
+	const cursor = sort === "top"
+		? null
+		: decodeCursor(c.req.query("before") ?? null);
 	const session = await readSession(c);
 
 	// Fast path: first page is cached in KV for anonymous viewers only,
@@ -622,7 +628,9 @@ comments.get("/", async (c) => {
 		: 0;
 	const sliceFrom = startIdx < 0 ? allThreads.length : startIdx;
 	const page = allThreads.slice(sliceFrom, sliceFrom + TOP_LEVEL_PAGE);
-	const more = allThreads.length > sliceFrom + TOP_LEVEL_PAGE;
+	// `top` is a single page (see cursor-decoding note above) so callers
+	// shouldn't get a next_cursor that would lead to ill-defined paging.
+	const more = sort === "new" && allThreads.length > sliceFrom + TOP_LEVEL_PAGE;
 	const next_cursor = more ? (page[page.length - 1]?.id ?? null) : null;
 
 	const payload: ListPayload = { post, threads: page, next_cursor };

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -28,6 +28,7 @@ import {
 	getPost,
 	getUserVotesOnPost,
 	insertComment,
+	isUserRole,
 	listActiveSubscriptionsForPost,
 	listCommentsForPost,
 	listReactionsForPost,
@@ -76,15 +77,20 @@ type SessionVars = {
 // D1 stores booleans as 0/1 INTEGER; we widen to a row type for `.first<…>()`
 // and `.all<…>()` callsites that hit the users table directly, then convert
 // at the boundary. (db/queries.ts has its own copy for its internal use.)
-type UserRow = Omit<User, "is_admin" | "is_banned"> & {
+// `role` is widened to `string` because D1 returns the raw column value;
+// we re-narrow at the boundary via isUserRole, falling back to "user" so a
+// stale row with an unknown role can't crash the request.
+type UserRow = Omit<User, "is_admin" | "is_banned" | "role"> & {
 	is_admin: number;
 	is_banned: number;
+	role: string;
 };
 
 const rowToUser = (row: UserRow): User => ({
 	...row,
 	is_admin: row.is_admin === 1,
 	is_banned: row.is_banned === 1,
+	role: isUserRole(row.role) ? row.role : "user",
 });
 
 const comments = new Hono<{ Bindings: Bindings; Variables: SessionVars }>();
@@ -367,7 +373,7 @@ comments.post("/", async (c) => {
 		const u = await c.env.DB
 			.prepare(
 				`SELECT id, provider, provider_id, name, email, avatar_url,
-				        is_admin, is_banned, created_at
+				        is_admin, is_banned, role, created_at
 				 FROM users WHERE id = ?`,
 			)
 			.bind(session.user_id)
@@ -509,7 +515,7 @@ const loadAuthors = async (
 	const result = await db
 		.prepare(
 			`SELECT id, provider, provider_id, name, email, avatar_url,
-			        is_admin, is_banned, created_at
+			        is_admin, is_banned, role, created_at
 			 FROM users WHERE id IN (${placeholders})`,
 		)
 		.bind(...userIds)
@@ -680,7 +686,7 @@ comments.patch("/:id", async (c) => {
 	const authorRow = await c.env.DB
 		.prepare(
 			`SELECT id, provider, provider_id, name, email, avatar_url,
-			        is_admin, is_banned, created_at
+			        is_admin, is_banned, role, created_at
 			 FROM users WHERE id = ?`,
 		)
 		.bind(updated.user_id)

--- a/src/routes/api.config.ts
+++ b/src/routes/api.config.ts
@@ -24,6 +24,18 @@ const config = new Hono<{ Bindings: Bindings }>();
 const isTruthy = (v: string | undefined): boolean =>
 	v === "1" || v?.toLowerCase() === "true";
 
+// Defaults-on flag: present + falsy → off; absent → on. Mirrors the
+// VOTING_ENABLED / DOWNVOTES_ENABLED semantics in api.votes.ts so the
+// widget renders consistently with what the server will accept.
+const isBoolishOn = (v: string | undefined): boolean => {
+	if (v == null) return true;
+	const norm = v.trim().toLowerCase();
+	if (norm === "0" || norm === "false" || norm === "no" || norm === "off") {
+		return false;
+	}
+	return true;
+};
+
 config.get("/", (c) => {
 	const minutes = Number.parseInt(c.env.EDIT_WINDOW_MINUTES, 10);
 	const edit_window_minutes =
@@ -32,11 +44,16 @@ config.get("/", (c) => {
 		const cfg = PROVIDERS[p];
 		return !!c.env[cfg.client_id_env] && !!c.env[cfg.client_secret_env];
 	});
+	const voting_enabled = isBoolishOn(c.env.VOTING_ENABLED);
 	return c.json({
 		turnstile_site_key: c.env.TURNSTILE_SITE_KEY || null,
 		edit_window_minutes,
 		providers,
 		branding_hidden: isTruthy(c.env.BRANDING_HIDDEN),
+		voting_enabled,
+		// Downvotes implicitly off when voting itself is off (saves the
+		// widget a second conditional).
+		downvotes_enabled: voting_enabled && isBoolishOn(c.env.DOWNVOTES_ENABLED),
 	});
 });
 

--- a/src/routes/api.reactions.ts
+++ b/src/routes/api.reactions.ts
@@ -66,7 +66,11 @@ reactions.post("/", async (c) => {
 	const result = await toggleReaction(c.env.DB, comment_id, userId, kind);
 
 	// Bust the cached first page so reaction counts reflect immediately.
-	await c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first`);
+	await Promise.all([
+		c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first:new`),
+		c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first:top`),
+		c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first`),
+	]);
 
 	writeEvent(c.env.ANALYTICS, "reaction.toggled", {
 		post_slug: comment.post_slug,

--- a/src/routes/api.votes.ts
+++ b/src/routes/api.votes.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/v1/votes
+ *   { comment_id, value: -1 | 0 | 1 }
+ *
+ * value=1 upvotes, value=-1 downvotes, value=0 clears the calling user's
+ * vote. Same row can be flipped any number of times — the (comment_id,
+ * user_id) PK enforces strict single-vote-per-user.
+ *
+ * Identity rules match reactions: authed users vote with their session
+ * user_id; anonymous viewers vote as the ip_hash-keyed ghost user. The
+ * per-IP rate-limit bucket is shared with comments/reactions so a
+ * scripted clicker can't grind the counters.
+ *
+ * Cache: a successful vote does NOT bust the per-post tree cache —
+ * authed viewers already bypass the cache (their list response carries
+ * per-user my_vote), and the widget patches the DOM with the returned
+ * counters so anonymous-viewer pages converge on the next comment write.
+ * This keeps a noisy thread from burning KV writes on every click.
+ */
+import { Hono } from "hono";
+import type { Bindings } from "../index";
+import {
+	castVote,
+	getComment,
+	getOrCreateGhost,
+	type VoteValue,
+} from "../db/queries";
+import { clientIp, hashIp } from "../lib/ip-hash";
+import { checkRateLimit } from "../lib/ratelimit";
+import { readSession } from "../lib/session";
+import { writeEvent } from "../lib/analytics";
+import { t } from "../i18n";
+
+const votes = new Hono<{ Bindings: Bindings }>();
+
+type VoteBody = {
+	comment_id?: string;
+	value?: unknown;
+};
+
+const isBoolish = (raw: string | undefined, defaultOn: boolean): boolean => {
+	if (raw == null) return defaultOn;
+	const v = raw.trim().toLowerCase();
+	if (v === "0" || v === "false" || v === "no" || v === "off") return false;
+	return true;
+};
+
+const normalizeValue = (raw: unknown): VoteValue | null => {
+	if (raw === 1 || raw === -1 || raw === 0) return raw;
+	if (typeof raw === "string") {
+		if (raw === "1") return 1;
+		if (raw === "-1") return -1;
+		if (raw === "0") return 0;
+	}
+	return null;
+};
+
+votes.post("/", async (c) => {
+	if (!isBoolish(c.env.VOTING_ENABLED, true)) {
+		return c.json({ error: "voting_disabled" }, 403);
+	}
+
+	const body = await c.req.json<VoteBody>().catch(() => null);
+	if (!body) return c.json({ error: t("err.internal") }, 400);
+
+	const comment_id = (body.comment_id ?? "").trim();
+	if (!comment_id) return c.json({ error: t("err.not_found") }, 400);
+
+	const value = normalizeValue(body.value);
+	if (value === null) return c.json({ error: "invalid_value" }, 400);
+
+	// Optional site-wide brigading mitigation. We reject downvotes outright
+	// — telling the client value=-1 is not allowed is a more honest UX than
+	// silently clamping to 0.
+	if (value === -1 && !isBoolish(c.env.DOWNVOTES_ENABLED, true)) {
+		return c.json({ error: "downvotes_disabled" }, 403);
+	}
+
+	const comment = await getComment(c.env.DB, comment_id);
+	if (!comment) return c.json({ error: t("err.not_found") }, 404);
+	if (comment.status === "deleted") {
+		return c.json({ error: t("err.not_found") }, 404);
+	}
+
+	const ipHash = await hashIp(clientIp(c.req.raw), c.env.IP_HASH_SECRET);
+	const rl = await checkRateLimit(c.env, ipHash);
+	if (!rl.ok) {
+		writeEvent(c.env.ANALYTICS, "ratelimit.hit", {
+			outcome: rl.reason ?? null,
+			post_slug: comment.post_slug,
+		});
+		return c.json({ error: t("err.ratelimit") }, 429);
+	}
+
+	const session = await readSession(c);
+	let userId: string;
+	if (session) {
+		userId = session.user_id;
+	} else {
+		const ghost = await getOrCreateGhost(c.env.DB, ipHash, "anon");
+		userId = ghost.id;
+	}
+
+	const result = await castVote(c.env.DB, comment_id, userId, value);
+
+	writeEvent(c.env.ANALYTICS, "vote.cast", {
+		post_slug: comment.post_slug,
+		outcome: value === 0 ? "cleared" : value === 1 ? "up" : "down",
+	});
+
+	return c.json({
+		ok: true,
+		comment_id,
+		score_up: result.score_up,
+		score_down: result.score_down,
+		my_vote: result.my_vote,
+	});
+});
+
+export { votes };

--- a/src/routes/api.votes.ts
+++ b/src/routes/api.votes.ts
@@ -101,6 +101,14 @@ votes.post("/", async (c) => {
 		userId = ghost.id;
 	}
 
+	// Authors can't vote on their own comment. Works for both authenticated
+	// users (session user_id) and anonymous viewers (IP-hash ghost) because
+	// comments.user_id is whichever identity posted. Without this guard a
+	// self-upvote silently floats your own thread under sort=top.
+	if (userId === comment.user_id) {
+		return c.json({ error: "vote_self_forbidden" }, 403);
+	}
+
 	const result = await castVote(c.env.DB, comment_id, userId, value);
 
 	writeEvent(c.env.ANALYTICS, "vote.cast", {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -319,7 +319,7 @@ auth.get("/me", async (c) => {
 	if (!session) return c.json({ user: null });
 	const u = await c.env.DB
 		.prepare(
-			`SELECT id, provider, name, email, avatar_url, is_admin
+			`SELECT id, provider, name, email, avatar_url, is_admin, role
 			 FROM users WHERE id = ?`,
 		)
 		.bind(session.user_id)
@@ -330,8 +330,11 @@ auth.get("/me", async (c) => {
 			email: string | null;
 			avatar_url: string | null;
 			is_admin: number;
+			role: string | null;
 		}>();
 	if (!u) return c.json({ user: null });
+	const role: "user" | "mod" | "admin" =
+		u.role === "mod" || u.role === "admin" ? u.role : "user";
 	return c.json({
 		user: {
 			id: u.id,
@@ -340,6 +343,7 @@ auth.get("/me", async (c) => {
 			email: u.email,
 			avatar_url: u.avatar_url,
 			is_admin: u.is_admin === 1,
+			role,
 		},
 	});
 });

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -513,6 +513,16 @@ const buildVotes = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	const wrap = el("div", "gr-votes");
 	const score = n.score_up - n.score_down;
 
+	// Self-voting is blocked server-side (vote_self_forbidden) and the
+	// anonymous case can't be detected client-side without leaking ghost
+	// identities. For signed-in viewers, render a read-only score so the
+	// author still sees who's reacting to their comment, just without the
+	// affordance to game it.
+	if (ctx.me && ctx.me.id === n.author.id) {
+		wrap.appendChild(el("span", "gr-vote-score", String(score)));
+		return wrap;
+	}
+
 	const up = el("button", "gr-vote");
 	up.type = "button";
 	up.setAttribute("aria-label", "Upvote");

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -53,8 +53,21 @@ type TreeNode = {
 	depth: number;
 	flatten_from: string | null;
 	reactions: ReactionCount[];
+	score_up: number;
+	score_down: number;
+	my_vote: -1 | 0 | 1;
 	replies: TreeNode[];
 };
+
+type VoteResponse = {
+	ok: boolean;
+	comment_id: string;
+	score_up: number;
+	score_down: number;
+	my_vote: -1 | 0 | 1;
+};
+
+type SortKey = "new" | "top";
 
 type ListResponse = {
 	post: unknown;
@@ -166,6 +179,39 @@ const STYLE_CSS = `
 	border-color: var(--garrul-accent, #2563eb);
 }
 .gr-reaction-count { margin-left: 0.25em; font-variant-numeric: tabular-nums; }
+.gr-votes { display: flex; align-items: center; gap: 0.3rem; margin-top: 0.4rem; font-size: 0.85em; }
+.gr-vote {
+	font: inherit;
+	background: var(--garrul-input-bg, #fff);
+	color: var(--garrul-muted, #6b7280);
+	border: 1px solid var(--garrul-border, #d0d3d8);
+	border-radius: 999px;
+	width: 1.8em;
+	height: 1.8em;
+	padding: 0;
+	line-height: 1;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.gr-vote:hover { color: var(--garrul-link, #2563eb); }
+.gr-vote[data-mine="1"] {
+	background: var(--garrul-badge-bg, #e0e7ff);
+	color: var(--garrul-badge-fg, #1e3a8a);
+	border-color: var(--garrul-accent, #2563eb);
+}
+.gr-vote[disabled] { opacity: 0.6; cursor: progress; }
+.gr-vote-score { font-variant-numeric: tabular-nums; min-width: 1.2em; text-align: center; }
+.gr-sort { display: flex; gap: 0.4rem; align-items: center; font-size: 0.85em; color: var(--garrul-muted, #6b7280); margin-top: 0.5rem; }
+.gr-sort select {
+	font: inherit;
+	background: var(--garrul-input-bg, #fff);
+	color: var(--garrul-fg, #1a1a1a);
+	border: 1px solid var(--garrul-border, #d0d3d8);
+	border-radius: var(--garrul-radius, 6px);
+	padding: 0.2rem 0.4rem;
+}
 .gr-reply-form { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
 .gr-reply-form textarea { min-height: 4em; }
 .gr-reply-form .gr-reply-actions { display: flex; gap: 0.5rem; }
@@ -303,6 +349,8 @@ type WidgetCtx = {
 	me: Me;
 	editWindowMs: number;
 	turnstileSiteKey: string | null;
+	votingEnabled: boolean;
+	downvotesEnabled: boolean;
 	reload: () => void;
 };
 
@@ -453,6 +501,75 @@ const reactionsByKind = (rs: ReactionCount[]): Map<string, ReactionCount> => {
 	const m = new Map<string, ReactionCount>();
 	for (const r of rs) m.set(r.kind, r);
 	return m;
+};
+
+// Vote up/down buttons. Anonymous viewers can vote — the server hashes
+// their IP into a ghost user (same identity rules as anonymous comments
+// and reactions). On click we POST and patch the local TreeNode + DOM
+// rather than reloading the whole list: the vote endpoint does not bust
+// the tree cache by design, so a reload would just re-fetch the stale
+// counters until the next comment-write triggers invalidation.
+const buildVotes = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
+	const wrap = el("div", "gr-votes");
+	const score = n.score_up - n.score_down;
+
+	const up = el("button", "gr-vote");
+	up.type = "button";
+	up.setAttribute("aria-label", "Upvote");
+	up.appendChild(document.createTextNode("▲"));
+	if (n.my_vote === 1) up.dataset.mine = "1";
+
+	const scoreEl = el("span", "gr-vote-score", String(score));
+
+	const down = el("button", "gr-vote");
+	down.type = "button";
+	down.setAttribute("aria-label", "Downvote");
+	down.appendChild(document.createTextNode("▼"));
+	if (n.my_vote === -1) down.dataset.mine = "1";
+
+	const cast = async (value: -1 | 0 | 1): Promise<void> => {
+		up.disabled = true;
+		down.disabled = true;
+		try {
+			const res = await fetch(`${ctx.apiBase}/api/v1/votes`, {
+				method: "POST",
+				credentials: "include",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ comment_id: n.id, value }),
+			});
+			if (!res.ok) return;
+			const body = (await res.json()) as VoteResponse;
+			// Mutate the node so a later re-render (Load more, reload) reflects
+			// the new state, and patch the DOM directly so the user sees the
+			// change without a full list reload.
+			n.score_up = body.score_up;
+			n.score_down = body.score_down;
+			n.my_vote = body.my_vote;
+			scoreEl.textContent = String(body.score_up - body.score_down);
+			if (body.my_vote === 1) up.dataset.mine = "1";
+			else delete up.dataset.mine;
+			if (body.my_vote === -1) down.dataset.mine = "1";
+			else delete down.dataset.mine;
+		} catch {
+			// Network/parse failure: leave UI untouched; user can retry.
+		} finally {
+			up.disabled = false;
+			down.disabled = false;
+		}
+	};
+
+	up.addEventListener("click", () => {
+		void cast(n.my_vote === 1 ? 0 : 1);
+	});
+	down.addEventListener("click", () => {
+		void cast(n.my_vote === -1 ? 0 : -1);
+	});
+
+	wrap.append(up, scoreEl, down);
+	// Hide the downvote button when downvotes are disabled site-wide. The
+	// flag is exposed via /api/v1/config; we read it once on widget mount.
+	if (!ctx.downvotesEnabled) down.hidden = true;
+	return wrap;
 };
 
 const buildReactions = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
@@ -773,6 +890,7 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	main.append(meta, body);
 
 	if (n.status !== "deleted") {
+		if (ctx.votingEnabled) main.appendChild(buildVotes(n, ctx));
 		main.appendChild(buildReactions(n, ctx));
 	}
 	main.appendChild(buildActions(n, ctx, main));
@@ -1028,9 +1146,11 @@ const fetchPage = async (
 	apiBase: string,
 	slug: string,
 	cursor: string | null,
+	sort: SortKey = "new",
 ): Promise<ListResponse> => {
 	const qs = new URLSearchParams({ slug });
 	if (cursor) qs.set("before", cursor);
+	if (sort !== "new") qs.set("sort", sort);
 	const res = await fetch(`${apiBase}/api/v1/comments?${qs.toString()}`, {
 		credentials: "include",
 	});
@@ -1063,9 +1183,11 @@ const fetchMe = async (apiBase: string): Promise<Me> => {
 // second one is requested (e.g. the user reacts and submits quickly), we
 // just flag a follow-up and re-run once after the current one finishes.
 // Prevents two concurrent root.replaceChildren() calls racing each other.
+// `sort` is sticky across reloads on the same mount so an in-flight reload
+// triggered by a reply doesn't drop the user's "Top" selection.
 const loadState = new WeakMap<
 	ShadowRoot,
-	{ running: boolean; queued: boolean }
+	{ running: boolean; queued: boolean; sort: SortKey }
 >();
 
 const load = async (
@@ -1076,7 +1198,7 @@ const load = async (
 ): Promise<void> => {
 	let st = loadState.get(root);
 	if (!st) {
-		st = { running: false, queued: false };
+		st = { running: false, queued: false, sort: "new" };
 		loadState.set(root, st);
 	}
 	if (st.running) {
@@ -1085,7 +1207,7 @@ const load = async (
 	}
 	st.running = true;
 	try {
-		await loadOnce(root, slug, apiBase, host);
+		await loadOnce(root, slug, apiBase, host, st.sort);
 	} finally {
 		st.running = false;
 		if (st.queued) {
@@ -1095,16 +1217,24 @@ const load = async (
 	}
 };
 
+const setSort = (root: ShadowRoot, sort: SortKey): void => {
+	const st = loadState.get(root);
+	if (st) st.sort = sort;
+};
+
 const loadOnce = async (
 	root: ShadowRoot,
 	slug: string,
 	apiBase: string,
 	host: HTMLElement,
+	sort: SortKey,
 ) => {
 	let siteKey: string | null = null;
 	let editWindowMinutes = 5;
 	let providers: ReadonlyArray<"github" | "google"> = [];
 	let brandingHidden = false;
+	let votingEnabled = true;
+	let downvotesEnabled = true;
 	try {
 		const cfgRes = await fetch(`${apiBase}/api/v1/config`, {
 			credentials: "include",
@@ -1115,6 +1245,8 @@ const loadOnce = async (
 				edit_window_minutes?: number;
 				providers?: string[];
 				branding_hidden?: boolean;
+				voting_enabled?: boolean;
+				downvotes_enabled?: boolean;
 			};
 			siteKey = cfg.turnstile_site_key ?? null;
 			editWindowMinutes = cfg.edit_window_minutes ?? 5;
@@ -1122,6 +1254,8 @@ const loadOnce = async (
 				(p): p is "github" | "google" => p === "github" || p === "google",
 			);
 			brandingHidden = cfg.branding_hidden === true;
+			votingEnabled = cfg.voting_enabled !== false;
+			downvotesEnabled = cfg.downvotes_enabled !== false;
 		}
 	} catch {
 		// /api/v1/config is optional; the widget still renders without Turnstile
@@ -1130,7 +1264,7 @@ const loadOnce = async (
 
 	const [me, dataResult] = await Promise.all([
 		fetchMe(apiBase),
-		fetchPage(apiBase, slug, null).catch((err: unknown) => err),
+		fetchPage(apiBase, slug, null, sort).catch((err: unknown) => err),
 	]);
 	if (dataResult instanceof Error) {
 		renderError(root, String(dataResult));
@@ -1154,6 +1288,8 @@ const loadOnce = async (
 		me,
 		editWindowMs: editWindowMinutes * 60_000,
 		turnstileSiteKey: siteKey,
+		votingEnabled,
+		downvotesEnabled,
 		reload,
 	};
 	const authBlock = buildAuthBlock(me, apiBase, providers, reload, reload);
@@ -1168,7 +1304,32 @@ const loadOnce = async (
 		appendThreads(list, data.threads, ctx);
 	}
 	if (authBlock) wrap.appendChild(authBlock);
-	wrap.append(form, list);
+	wrap.append(form);
+
+	// Sort selector only when voting is on (no scores to rank without it).
+	if (votingEnabled) {
+		const sortWrap = el("div", "gr-sort");
+		const label = el("label", undefined, "Sort: ");
+		const sel = el("select") as HTMLSelectElement;
+		const newOpt = el("option") as HTMLOptionElement;
+		newOpt.value = "new";
+		newOpt.textContent = "Newest";
+		const topOpt = el("option") as HTMLOptionElement;
+		topOpt.value = "top";
+		topOpt.textContent = "Top";
+		sel.append(newOpt, topOpt);
+		sel.value = sort;
+		label.appendChild(sel);
+		sortWrap.appendChild(label);
+		sel.addEventListener("change", () => {
+			const v = sel.value === "top" ? "top" : "new";
+			setSort(root, v);
+			reload();
+		});
+		wrap.appendChild(sortWrap);
+	}
+
+	wrap.appendChild(list);
 
 	if (data.next_cursor) {
 		const more = el("button", "gr-loadmore", "Load older comments");
@@ -1178,7 +1339,7 @@ const loadOnce = async (
 			if (!cursor) return;
 			more.disabled = true;
 			try {
-				const page = await fetchPage(apiBase, slug, cursor);
+				const page = await fetchPage(apiBase, slug, cursor, sort);
 				appendThreads(list, page.threads, ctx);
 				cursor = page.next_cursor;
 				if (cursor) {

--- a/tests/admin-webhooks-render.test.ts
+++ b/tests/admin-webhooks-render.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Render-correctness tests for the webhooks admin pages. Pure
+ * string-template functions — no D1, no env. Anything HTML-escape-
+ * adjacent here is user-visible.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	renderWebhooksList,
+	renderWebhookForm,
+} from "../src/admin-ui/pages/webhooks";
+import type { WebhookEndpoint } from "../src/db/queries";
+
+const makeEndpoint = (over: Partial<WebhookEndpoint> = {}): WebhookEndpoint => ({
+	id: "01HWH000000000000000000001",
+	url: "https://example.com/hook",
+	secret: "whsec_test_test_test_test",
+	events: null,
+	adapter: "generic",
+	enabled: true,
+	fail_count: 0,
+	disabled_at: null,
+	created_at: 1_700_000_000_000,
+	updated_at: 1_700_000_000_000,
+	...over,
+});
+
+describe("renderWebhooksList", () => {
+	it("shows the empty-state row when there are no endpoints", () => {
+		const html = renderWebhooksList([], { active: false, url: "" });
+		expect(html).toContain("No webhook endpoints configured");
+	});
+
+	it("renders signed pill for an endpoint with a secret", () => {
+		const html = renderWebhooksList([makeEndpoint()], {
+			active: false,
+			url: "",
+		});
+		expect(html).toContain("pill approved");
+		expect(html).toContain(">signed<");
+	});
+
+	it("renders unsigned pill for an endpoint without a secret", () => {
+		const html = renderWebhooksList(
+			[makeEndpoint({ secret: null })],
+			{ active: false, url: "" },
+		);
+		expect(html).toContain(">unsigned<");
+	});
+
+	it("shows the env-shim warning only when active is true", () => {
+		const off = renderWebhooksList([], { active: false, url: "" });
+		expect(off).not.toContain("Legacy <code>WEBHOOK_URL</code>");
+
+		const on = renderWebhooksList([], {
+			active: true,
+			url: "https://example.com/legacy",
+		});
+		expect(on).toContain("Legacy <code>WEBHOOK_URL</code>");
+		expect(on).toContain("https://example.com/legacy");
+	});
+
+	it("escapes a malicious URL in the env-shim banner", () => {
+		const html = renderWebhooksList([], {
+			active: true,
+			url: 'https://x" onload="alert(1)',
+		});
+		expect(html).not.toContain('" onload="alert(1)');
+		expect(html).toContain("&quot;");
+	});
+
+	it("escapes a malicious URL in an endpoint row", () => {
+		const html = renderWebhooksList(
+			[makeEndpoint({ url: '<img src=x onerror=alert(1)>' })],
+			{ active: false, url: "" },
+		);
+		expect(html).not.toContain("<img src=x");
+		expect(html).toContain("&lt;img src=x");
+	});
+
+	it("renders the auto-paused note when disabled_at is set", () => {
+		const html = renderWebhooksList(
+			[
+				makeEndpoint({
+					enabled: false,
+					disabled_at: 1_700_000_500_000,
+					fail_count: 10,
+				}),
+			],
+			{ active: false, url: "" },
+		);
+		expect(html).toContain("auto-paused");
+		expect(html).toContain("after 10 fails");
+	});
+
+	it("lists each subscribed event when events is non-null", () => {
+		const html = renderWebhooksList(
+			[makeEndpoint({ events: ["comment.posted", "comment.spam"] })],
+			{ active: false, url: "" },
+		);
+		expect(html).toContain("comment.posted, comment.spam");
+	});
+
+	it("shows 'all events' label when events is null", () => {
+		const html = renderWebhooksList(
+			[makeEndpoint({ events: null })],
+			{ active: false, url: "" },
+		);
+		expect(html).toContain("all events");
+	});
+});
+
+describe("renderWebhookForm", () => {
+	it("uses the create action and POST when endpoint is null", () => {
+		const html = renderWebhookForm({ endpoint: null, error: null });
+		expect(html).toContain(">Add webhook endpoint<");
+		// x-data attribute is HTML-escaped, so literal quotes become &quot;.
+		expect(html).toContain("&quot;/admin/api/webhooks&quot;");
+		expect(html).toContain("&quot;POST&quot;");
+		expect(html).toContain(">Create endpoint<");
+	});
+
+	it("uses the patch action and PATCH when endpoint is provided", () => {
+		const e = makeEndpoint();
+		const html = renderWebhookForm({ endpoint: e, error: null });
+		expect(html).toContain(">Edit webhook endpoint<");
+		expect(html).toContain(`/admin/api/webhooks/${e.id}`);
+		expect(html).toContain("&quot;PATCH&quot;");
+		expect(html).toContain(">Save changes<");
+	});
+
+	it("prefills the URL and secret in edit mode", () => {
+		const e = makeEndpoint({
+			url: "https://example.org/h",
+			secret: "whsec_abcdef0123456789",
+		});
+		const html = renderWebhookForm({ endpoint: e, error: null });
+		expect(html).toContain('value="https://example.org/h"');
+		expect(html).toContain('value="whsec_abcdef0123456789"');
+	});
+
+	it("renders all five known events as checkboxes", () => {
+		const html = renderWebhookForm({ endpoint: null, error: null });
+		for (const ev of [
+			"comment.posted",
+			"comment.edited",
+			"comment.deleted",
+			"comment.approved",
+			"comment.spam",
+		]) {
+			expect(html).toContain(`name="event_${ev}"`);
+		}
+	});
+
+	it("checks every event by default in new mode", () => {
+		const html = renderWebhookForm({ endpoint: null, error: null });
+		// Five checkboxes, all checked.
+		const checkedCount = (html.match(/type="checkbox" name="event_/g) ?? [])
+			.length;
+		const checkedAttrCount = (
+			html.match(/type="checkbox" name="event_[^"]+" checked/g) ?? []
+		).length;
+		expect(checkedCount).toBe(5);
+		expect(checkedAttrCount).toBe(5);
+	});
+
+	it("checks only the selected events in edit mode", () => {
+		const e = makeEndpoint({ events: ["comment.posted", "comment.spam"] });
+		const html = renderWebhookForm({ endpoint: e, error: null });
+		expect(html).toContain('name="event_comment.posted" checked');
+		expect(html).toContain('name="event_comment.spam" checked');
+		expect(html).not.toContain('name="event_comment.edited" checked');
+		expect(html).not.toContain('name="event_comment.deleted" checked');
+		expect(html).not.toContain('name="event_comment.approved" checked');
+	});
+
+	it("renders the error block when supplied", () => {
+		const html = renderWebhookForm({
+			endpoint: null,
+			error: "url:private_ipv4",
+		});
+		expect(html).toContain("url:private_ipv4");
+	});
+
+	it("escapes a malicious error message", () => {
+		const html = renderWebhookForm({
+			endpoint: null,
+			error: '<img src=x onerror=alert(1)>',
+		});
+		expect(html).not.toContain("<img src=x");
+		expect(html).toContain("&lt;img src=x");
+	});
+
+	it("shows the adapter options and pre-selects the saved one", () => {
+		const html = renderWebhookForm({
+			endpoint: makeEndpoint({ adapter: "discord" }),
+			error: null,
+		});
+		expect(html).toContain('value="generic"');
+		expect(html).toContain('value="slack"');
+		expect(html).toContain('value="discord" selected');
+	});
+});

--- a/tests/disqus-import.test.ts
+++ b/tests/disqus-import.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Disqus importer tests cover:
+ *
+ *   1. XML parsing — threads, posts, parent threading, CDATA / entity
+ *      decoding, malformed input handling.
+ *   2. HTML → markdown stripping — every Disqus tag is stripped, raw
+ *      <script> / onerror attempts never survive, plain text and links
+ *      are preserved.
+ *   3. Idempotency — running the import twice over the same XML inserts
+ *      zero new rows on the second run (the partial UNIQUE index on
+ *      (import_source, import_id) does the work; we mock the existence
+ *      check).
+ *   4. Threading — second-pass parent_id assignment handles
+ *      out-of-document-order replies.
+ *
+ * No Miniflare. Hand-rolled D1 stub with capture so tests assert SQL
+ * directly.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	disqusHtmlToMarkdown,
+	parseDisqusXml,
+	runDisqusImport,
+	slugFromLink,
+} from "../src/lib/disqus-import";
+
+type Captured = { sql: string; binds: unknown[] };
+
+// One DB stub that pretends every "SELECT ... WHERE id =" misses (so
+// inserts always proceed) and records every statement.
+const makeFreshDb = () => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => {
+		const stmt = {
+			_sql: sql,
+			_binds: [] as unknown[],
+			bind(...args: unknown[]) {
+				this._binds = args;
+				return this;
+			},
+			async first() {
+				captured.push({ sql, binds: this._binds });
+				return null;
+			},
+			async all() {
+				captured.push({ sql, binds: this._binds });
+				return { results: [] };
+			},
+			async run() {
+				captured.push({ sql, binds: this._binds });
+				return { meta: { changes: 1 } };
+			},
+		};
+		return stmt;
+	};
+	const db = {
+		prepare(sql: string) {
+			return chain(sql);
+		},
+	};
+	return { db, captured };
+};
+
+// A stub where the comment-existence check always returns a row (i.e.
+// every dsq_id was previously imported). Used for the idempotency test.
+const makeAlreadyImportedDb = () => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => {
+		const stmt = {
+			_sql: sql,
+			_binds: [] as unknown[],
+			bind(...args: unknown[]) {
+				this._binds = args;
+				return this;
+			},
+			async first() {
+				captured.push({ sql, binds: this._binds });
+				if (sql.includes("FROM comments WHERE import_source")) {
+					return { id: "01HX0000000000000000000001" };
+				}
+				if (sql.includes("FROM posts WHERE slug")) {
+					return { slug: "blog/hello" };
+				}
+				if (sql.includes("FROM users WHERE provider")) {
+					return { id: "01HU0000000000000000000001" };
+				}
+				return null;
+			},
+			async all() {
+				captured.push({ sql, binds: this._binds });
+				return { results: [] };
+			},
+			async run() {
+				captured.push({ sql, binds: this._binds });
+				return { meta: { changes: 1 } };
+			},
+		};
+		return stmt;
+	};
+	return {
+		db: { prepare: (s: string) => chain(s) },
+		captured,
+	};
+};
+
+const SAMPLE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<disqus xmlns:dsq="http://disqus.com/disqus-internals">
+  <thread dsq:id="t100">
+    <id>blog-hello</id>
+    <link>https://example.com/blog/hello</link>
+    <title><![CDATA[Hello, world]]></title>
+    <createdAt>2023-04-01T10:00:00Z</createdAt>
+  </thread>
+  <post dsq:id="p1">
+    <message><![CDATA[<p>First!</p>]]></message>
+    <createdAt>2023-04-01T10:05:00Z</createdAt>
+    <isDeleted>false</isDeleted>
+    <isSpam>false</isSpam>
+    <author>
+      <name>Ada</name>
+      <email>ada@example.com</email>
+      <isAnonymous>false</isAnonymous>
+    </author>
+    <thread dsq:id="t100" />
+  </post>
+  <post dsq:id="p2">
+    <message><![CDATA[<p>Reply!</p>]]></message>
+    <createdAt>2023-04-01T10:10:00Z</createdAt>
+    <isDeleted>false</isDeleted>
+    <isSpam>false</isSpam>
+    <author>
+      <name>Bob</name>
+      <email>bob@example.com</email>
+      <isAnonymous>false</isAnonymous>
+    </author>
+    <thread dsq:id="t100" />
+    <parent dsq:id="p1" />
+  </post>
+</disqus>`;
+
+// --------------------------- parseDisqusXml --------------------------------
+
+describe("parseDisqusXml", () => {
+	it("extracts threads with id, link, title, created_at", () => {
+		const out = parseDisqusXml(SAMPLE_XML);
+		expect(out.threads).toHaveLength(1);
+		expect(out.threads[0]).toMatchObject({
+			dsq_id: "t100",
+			link: "https://example.com/blog/hello",
+			title: "Hello, world",
+		});
+		expect(out.threads[0]!.created_at).toBe(Date.parse("2023-04-01T10:00:00Z"));
+	});
+
+	it("extracts posts with author, thread + parent dsq_id", () => {
+		const out = parseDisqusXml(SAMPLE_XML);
+		expect(out.posts).toHaveLength(2);
+		expect(out.posts[0]).toMatchObject({
+			dsq_id: "p1",
+			thread_dsq_id: "t100",
+			parent_dsq_id: null,
+		});
+		expect(out.posts[1]).toMatchObject({
+			dsq_id: "p2",
+			thread_dsq_id: "t100",
+			parent_dsq_id: "p1",
+		});
+		expect(out.posts[0]!.author.name).toBe("Ada");
+	});
+
+	it("rejects an oversized document", () => {
+		const huge = "<disqus>" + "x".repeat(51 * 1024 * 1024) + "</disqus>";
+		expect(() => parseDisqusXml(huge)).toThrow(/too large/);
+	});
+
+	it("survives malformed posts without a thread reference (skips them)", () => {
+		const bad = `<disqus>
+		  <post dsq:id="p_bad">
+		    <message>orphan</message>
+		    <author><name>X</name></author>
+		  </post>
+		</disqus>`;
+		const out = parseDisqusXml(bad);
+		expect(out.posts).toHaveLength(0);
+	});
+});
+
+// ----------------------- disqusHtmlToMarkdown ------------------------------
+
+describe("disqusHtmlToMarkdown", () => {
+	it("strips raw <script> tags", () => {
+		const out = disqusHtmlToMarkdown(`<p>hi <script>alert(1)</script></p>`);
+		expect(out).not.toContain("<script>");
+		expect(out).not.toContain("</script>");
+	});
+
+	it("strips <img onerror=...> attempts", () => {
+		const out = disqusHtmlToMarkdown(`<p><img src=x onerror="alert(1)"></p>`);
+		expect(out).not.toContain("onerror");
+		expect(out).not.toContain("<img");
+	});
+
+	it("preserves plain text", () => {
+		const out = disqusHtmlToMarkdown(`<p>Hello there, friend.</p>`);
+		expect(out).toBe("Hello there, friend.");
+	});
+
+	it("rewrites anchor tags to markdown links", () => {
+		const out = disqusHtmlToMarkdown(
+			`<p>see <a href="https://example.com">my blog</a></p>`,
+		);
+		expect(out).toContain("[my blog](https://example.com)");
+	});
+
+	it("drops javascript: anchor URLs", () => {
+		const out = disqusHtmlToMarkdown(
+			`<p><a href="javascript:alert(1)">click</a></p>`,
+		);
+		expect(out).not.toContain("javascript:");
+		// Label remains as inert text — no executable handler can reach it.
+		expect(out).toContain("click");
+	});
+
+	it("decodes entities in the surviving text", () => {
+		const out = disqusHtmlToMarkdown(`<p>5 &lt; 10 &amp; counting</p>`);
+		expect(out).toContain("5 < 10 & counting");
+	});
+});
+
+// ------------------------------ slugFromLink -------------------------------
+
+describe("slugFromLink", () => {
+	it("strips host + leading/trailing slashes", () => {
+		expect(slugFromLink("https://x.com/blog/hello/", "fallback")).toBe(
+			"blog/hello",
+		);
+	});
+
+	it("falls back when link is null", () => {
+		expect(slugFromLink(null, "fallback")).toBe("fallback");
+	});
+
+	it("falls back on malformed URLs", () => {
+		expect(slugFromLink("not a url", "fallback")).toBe("fallback");
+	});
+
+	it("uses fallback when the link is just the host", () => {
+		expect(slugFromLink("https://x.com/", "fallback")).toBe("fallback");
+	});
+});
+
+// ------------------------------ runDisqusImport ----------------------------
+
+describe("runDisqusImport", () => {
+	it("dry-run reports counts without issuing INSERTs", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runDisqusImport(db, SAMPLE_XML, "secret", {
+			dry_run: true,
+		});
+		expect(plan.threads_total).toBe(1);
+		expect(plan.posts_total).toBe(2);
+		expect(plan.new_comments).toBe(2);
+		expect(plan.new_posts).toBe(1);
+
+		const inserts = captured.filter((c) =>
+			/^INSERT INTO (comments|users|posts)\b/.test(c.sql),
+		);
+		expect(inserts).toHaveLength(0);
+	});
+
+	it("inserts posts, ghost users, and comments on a fresh DB", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runDisqusImport(db, SAMPLE_XML, "secret", {});
+		expect(plan.new_posts).toBe(1);
+		expect(plan.new_users).toBe(2);
+		expect(plan.new_comments).toBe(2);
+
+		const commentInserts = captured.filter((c) =>
+			c.sql.startsWith("INSERT INTO comments"),
+		);
+		expect(commentInserts).toHaveLength(2);
+		// import_source + import_id are bound on every insert.
+		for (const ins of commentInserts) {
+			// Bind order ends with (..., 'disqus', dsq_id) at positions
+			// [-2] and [-1].
+			expect(ins.binds[ins.binds.length - 2]).toBe("disqus");
+			expect(ins.binds[ins.binds.length - 1]).toMatch(/^p[12]$/);
+		}
+	});
+
+	it("is idempotent — re-run on already-imported XML inserts zero comments", async () => {
+		const { db, captured } = makeAlreadyImportedDb();
+		const plan = await runDisqusImport(db, SAMPLE_XML, "secret", {});
+		// Plan still reports the totals it saw, but the new_* counters
+		// stay at 0 because every existence check returned a row.
+		expect(plan.new_comments).toBe(0);
+		expect(plan.new_users).toBe(0);
+		expect(plan.new_posts).toBe(0);
+
+		const inserts = captured.filter((c) =>
+			c.sql.startsWith("INSERT INTO comments"),
+		);
+		expect(inserts).toHaveLength(0);
+	});
+
+	it("re-parents replies via the second pass UPDATE", async () => {
+		const { db, captured } = makeFreshDb();
+		await runDisqusImport(db, SAMPLE_XML, "secret", {});
+		const reparents = captured.filter((c) =>
+			c.sql.startsWith("UPDATE comments SET parent_id"),
+		);
+		// Only p2 has a parent. p1 stays NULL.
+		expect(reparents).toHaveLength(1);
+	});
+
+	it("skips deleted/spam by default and counts them in the plan", async () => {
+		const xml = `<disqus>
+		  <thread dsq:id="t1"><link>https://x.com/a</link></thread>
+		  <post dsq:id="p1">
+		    <message>visible</message>
+		    <isDeleted>false</isDeleted><isSpam>false</isSpam>
+		    <author><name>A</name></author>
+		    <thread dsq:id="t1" />
+		  </post>
+		  <post dsq:id="p2">
+		    <message>removed</message>
+		    <isDeleted>true</isDeleted><isSpam>false</isSpam>
+		    <author><name>B</name></author>
+		    <thread dsq:id="t1" />
+		  </post>
+		  <post dsq:id="p3">
+		    <message>spammy</message>
+		    <isDeleted>false</isDeleted><isSpam>true</isSpam>
+		    <author><name>C</name></author>
+		    <thread dsq:id="t1" />
+		  </post>
+		</disqus>`;
+		const { db } = makeFreshDb();
+		const plan = await runDisqusImport(db, xml, "secret", {});
+		expect(plan.new_comments).toBe(1);
+		expect(plan.posts_skipped_deleted).toBe(1);
+		expect(plan.posts_skipped_spam).toBe(1);
+	});
+
+	it("imported comment body is sanitized through the markdown allowlist", async () => {
+		const xml = `<disqus>
+		  <thread dsq:id="t1"><link>https://x.com/a</link></thread>
+		  <post dsq:id="p1">
+		    <message><![CDATA[<p>hello <script>alert(1)</script> there</p>]]></message>
+		    <author><name>A</name></author>
+		    <thread dsq:id="t1" />
+		  </post>
+		</disqus>`;
+		const { db, captured } = makeFreshDb();
+		await runDisqusImport(db, xml, "secret", {});
+		const comment = captured.find((c) =>
+			c.sql.startsWith("INSERT INTO comments"),
+		);
+		// Bind order: id, post_slug, user_id, body_md, body_html, ...
+		const bodyHtml = comment!.binds[4] as string;
+		expect(bodyHtml).not.toContain("<script>");
+		expect(bodyHtml).not.toContain("</script>");
+	});
+});

--- a/tests/role-gating.test.ts
+++ b/tests/role-gating.test.ts
@@ -16,6 +16,7 @@ import { roleAuditAction } from "../src/routes/admin";
 import { renderUserDetail } from "../src/admin-ui/pages/user-detail";
 import { renderUsers } from "../src/admin-ui/pages/users";
 import { layout } from "../src/admin-ui/layout";
+import { countAdmins } from "../src/db/queries";
 import type {
 	AdminUserDetail,
 	User,
@@ -181,5 +182,46 @@ describe("admin layout role-aware nav", () => {
 		const html = layout("test", "<p>x</p>", plain, null);
 		expect(html).not.toContain('pill admin">admin</span>');
 		expect(html).not.toContain('pill mod">mod</span>');
+	});
+});
+
+describe("countAdmins", () => {
+	it("counts users WHERE role = 'admin' (not is_admin)", async () => {
+		let captured: { sql: string; binds: unknown[] } | null = null;
+		const db = {
+			prepare(sql: string) {
+				return {
+					bind(...args: unknown[]) {
+						captured = { sql, binds: args };
+						return this;
+					},
+					async first() {
+						captured = captured ?? { sql, binds: [] };
+						return { n: 2 };
+					},
+				};
+			},
+		};
+		const n = await countAdmins(db as unknown as D1Database);
+		expect(n).toBe(2);
+		expect(captured).not.toBeNull();
+		expect(captured!.sql).toContain("FROM users WHERE role = 'admin'");
+	});
+
+	it("returns 0 when no row comes back (defensive default)", async () => {
+		const db = {
+			prepare(_sql: string) {
+				return {
+					bind() {
+						return this;
+					},
+					async first() {
+						return null;
+					},
+				};
+			},
+		};
+		const n = await countAdmins(db as unknown as D1Database);
+		expect(n).toBe(0);
 	});
 });

--- a/tests/role-gating.test.ts
+++ b/tests/role-gating.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure-logic and render tests for the moderator-role feature.
+ *
+ * D1-routed gating (requireMod vs requireAdmin on actual HTTP routes) is
+ * not exercised here — that needs the Workers pool + Miniflare. What is
+ * covered:
+ *   - roleAuditAction produces the right audit verb for every transition.
+ *   - renderUserDetail shows the role-management UI only when the viewer
+ *     is an admin and not viewing themselves.
+ *   - renderUsers renders the new "mod" pill alongside the existing
+ *     "admin" pill, and no pill for role='user'.
+ *   - The admin layout hides admin-only nav links from non-admin viewers.
+ */
+import { describe, it, expect } from "vitest";
+import { roleAuditAction } from "../src/routes/admin";
+import { renderUserDetail } from "../src/admin-ui/pages/user-detail";
+import { renderUsers } from "../src/admin-ui/pages/users";
+import { layout } from "../src/admin-ui/layout";
+import type {
+	AdminUserDetail,
+	User,
+	UserRole,
+} from "../src/db/queries";
+
+const makeUser = (over: Partial<User> = {}): User => ({
+	id: "01HUSR000000000000000000A",
+	provider: "github",
+	provider_id: "u1",
+	name: "Test User",
+	email: null,
+	avatar_url: null,
+	is_admin: false,
+	is_banned: false,
+	role: "user",
+	created_at: 1_700_000_000_000,
+	...over,
+});
+
+const makeDetail = (user: User): AdminUserDetail => ({
+	user,
+	comments: [],
+	next_cursor: null,
+	reactions_received: 0,
+	audit: [],
+});
+
+describe("roleAuditAction", () => {
+	it("returns null on a no-op transition", () => {
+		const cases: UserRole[] = ["user", "mod", "admin"];
+		for (const r of cases) {
+			expect(roleAuditAction(r, r)).toBeNull();
+		}
+	});
+
+	it("classifies promotions correctly", () => {
+		expect(roleAuditAction("user", "mod")).toBe("role.grant_mod");
+		expect(roleAuditAction("user", "admin")).toBe("role.grant_admin");
+		expect(roleAuditAction("mod", "admin")).toBe("role.grant_admin");
+	});
+
+	it("classifies demotions correctly", () => {
+		expect(roleAuditAction("admin", "mod")).toBe("role.revoke_admin");
+		expect(roleAuditAction("admin", "user")).toBe("role.revoke_admin");
+		expect(roleAuditAction("mod", "user")).toBe("role.revoke_mod");
+	});
+});
+
+describe("renderUserDetail role controls", () => {
+	const admin = makeUser({
+		id: "01HADMIN000000000000000001",
+		role: "admin",
+		is_admin: true,
+		name: "Admin",
+	});
+	const mod = makeUser({
+		id: "01HMOD0000000000000000001",
+		role: "mod",
+		name: "Mod",
+	});
+	const plainUser = makeUser({
+		id: "01HPLAIN0000000000000000A",
+		role: "user",
+		name: "Plain",
+	});
+
+	it("shows promote/demote buttons when admin views another user", () => {
+		const html = renderUserDetail(makeDetail(plainUser), admin);
+		expect(html).toContain(">Make mod<");
+		expect(html).toContain(">Make admin<");
+		expect(html).toContain(">Demote to user<");
+		expect(html).toContain("/admin/api/users/01HPLAIN0000000000000000A/role");
+	});
+
+	it("hides role controls when admin views their own page", () => {
+		const html = renderUserDetail(makeDetail(admin), admin);
+		expect(html).not.toContain(">Make mod<");
+		expect(html).not.toContain(">Make admin<");
+		expect(html).not.toContain(">Demote to user<");
+	});
+
+	it("hides role controls when a mod views any user", () => {
+		const html = renderUserDetail(makeDetail(plainUser), mod);
+		expect(html).not.toContain(">Make mod<");
+		expect(html).not.toContain(">Make admin<");
+		expect(html).not.toContain(">Demote to user<");
+	});
+
+	it("renders the mod pill in the user header for role='mod'", () => {
+		const html = renderUserDetail(makeDetail(mod), admin);
+		expect(html).toContain('pill mod">mod</span>');
+		expect(html).not.toContain('pill admin">admin</span>');
+	});
+
+	it("renders the admin pill in the user header for role='admin'", () => {
+		const html = renderUserDetail(makeDetail(admin), admin);
+		expect(html).toContain('pill admin">admin</span>');
+		expect(html).not.toContain('pill mod">mod</span>');
+	});
+
+	it("renders no role pill for role='user'", () => {
+		const html = renderUserDetail(makeDetail(plainUser), admin);
+		expect(html).not.toContain('pill admin">admin</span>');
+		expect(html).not.toContain('pill mod">mod</span>');
+	});
+});
+
+describe("renderUsers role pills", () => {
+	it("emits the right pill per role and links the name to detail", () => {
+		const users: User[] = [
+			makeUser({ id: "01HU00000000000000000000A", name: "Plain", role: "user" }),
+			makeUser({ id: "01HU00000000000000000000B", name: "Modder", role: "mod" }),
+			makeUser({
+				id: "01HU00000000000000000000C",
+				name: "Operator",
+				role: "admin",
+				is_admin: true,
+			}),
+		];
+		const html = renderUsers(users, "", null);
+		expect(html).toContain('pill mod">mod</span>');
+		expect(html).toContain('pill admin">admin</span>');
+		expect(html).toContain('href="/admin/users/01HU00000000000000000000A"');
+		expect(html).toContain('href="/admin/users/01HU00000000000000000000B"');
+	});
+});
+
+describe("admin layout role-aware nav", () => {
+	const adminLinks = [
+		"/admin/users",
+		"/admin/audit",
+		"/admin/subscriptions",
+		"/admin/operator",
+		"/admin/settings",
+	];
+
+	it("hides admin-only nav links from a mod viewer", () => {
+		const mod = makeUser({ role: "mod", name: "Mod" });
+		const html = layout("test", "<p>x</p>", mod, null);
+		for (const link of adminLinks) {
+			expect(html).not.toContain(`href="${link}"`);
+		}
+		// Mod still sees the queue + about.
+		expect(html).toContain('href="/admin/queue"');
+		expect(html).toContain('href="/admin/about"');
+		expect(html).toContain('pill mod">mod</span>');
+	});
+
+	it("shows admin-only nav links to an admin viewer", () => {
+		const admin = makeUser({ role: "admin", is_admin: true, name: "Admin" });
+		const html = layout("test", "<p>x</p>", admin, null);
+		for (const link of adminLinks) {
+			expect(html).toContain(`href="${link}"`);
+		}
+		expect(html).toContain('pill admin">admin</span>');
+	});
+
+	it("renders no role pill for a plain user that somehow reaches the layout", () => {
+		// The route guards prevent this in practice, but the layout should
+		// degrade gracefully rather than emit a stray admin pill.
+		const plain = makeUser({ role: "user" });
+		const html = layout("test", "<p>x</p>", plain, null);
+		expect(html).not.toContain('pill admin">admin</span>');
+		expect(html).not.toContain('pill mod">mod</span>');
+	});
+});

--- a/tests/saved-replies-render.test.ts
+++ b/tests/saved-replies-render.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Render-correctness tests for the saved-replies admin pages. Pure
+ * string-template functions — no D1, no env.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	renderSavedRepliesList,
+	renderSavedReplyForm,
+} from "../src/admin-ui/pages/saved-replies";
+import type { SavedReply, User } from "../src/db/queries";
+
+const mkUser = (over: Partial<User> = {}): User => ({
+	id: "u_alice",
+	provider: "github",
+	provider_id: "1",
+	name: "Alice",
+	email: "a@example.com",
+	avatar_url: null,
+	is_admin: 0,
+	role: "mod",
+	is_banned: 0,
+	created_at: 1_700_000_000_000,
+	...over,
+});
+
+const mkReply = (over: Partial<SavedReply> = {}): SavedReply => ({
+	id: "01HWH000000000000000000001",
+	owner_id: "u_alice",
+	title: "Welcome",
+	body_md: "Hi there!",
+	scope: "private",
+	created_at: 1_700_000_000_000,
+	updated_at: 1_700_000_000_000,
+	...over,
+});
+
+describe("renderSavedRepliesList", () => {
+	it("shows the empty-state row", () => {
+		const html = renderSavedRepliesList([], mkUser(), new Map());
+		expect(html).toContain("No saved replies yet.");
+	});
+
+	it("shows 'you' for the viewer's own reply", () => {
+		const html = renderSavedRepliesList(
+			[mkReply()],
+			mkUser(),
+			new Map([["u_alice", "Alice"]]),
+		);
+		expect(html).toContain(">you<");
+	});
+
+	it("hides the Edit button for replies owned by someone else", () => {
+		const html = renderSavedRepliesList(
+			[mkReply({ owner_id: "u_bob", scope: "shared" })],
+			mkUser(),
+			new Map([["u_bob", "Bob"]]),
+		);
+		expect(html).toContain("read-only");
+		expect(html).not.toMatch(/\/admin\/saved-replies\/01HWH/);
+	});
+
+	it("shows scope pills correctly", () => {
+		const privateHtml = renderSavedRepliesList(
+			[mkReply({ scope: "private" })],
+			mkUser(),
+			new Map(),
+		);
+		expect(privateHtml).toContain(">private<");
+
+		const sharedHtml = renderSavedRepliesList(
+			[mkReply({ scope: "shared" })],
+			mkUser(),
+			new Map(),
+		);
+		expect(sharedHtml).toContain(">shared<");
+	});
+
+	it("escapes a malicious title", () => {
+		const html = renderSavedRepliesList(
+			[mkReply({ title: "<img src=x onerror=alert(1)>" })],
+			mkUser(),
+			new Map([["u_alice", "Alice"]]),
+		);
+		expect(html).not.toContain("<img src=x");
+		expect(html).toContain("&lt;img");
+	});
+
+	it("renders 'deleted user' when owner is unknown to the map", () => {
+		const html = renderSavedRepliesList(
+			[mkReply({ owner_id: "u_ghost", scope: "shared" })],
+			mkUser(),
+			new Map(),
+		);
+		expect(html).toContain("deleted user");
+	});
+});
+
+describe("renderSavedReplyForm", () => {
+	it("renders the new-reply form when existing is null", () => {
+		const html = renderSavedReplyForm({ existing: null, error: null });
+		expect(html).toContain("New saved reply");
+		expect(html).toContain("method: 'POST'");
+		expect(html).toContain("/admin/api/saved-replies");
+		// No Delete button on create.
+		expect(html).not.toContain("Delete saved reply");
+	});
+
+	it("renders the edit-reply form when existing is set", () => {
+		const html = renderSavedReplyForm({ existing: mkReply(), error: null });
+		expect(html).toContain("Edit saved reply");
+		expect(html).toContain("method: 'PATCH'");
+		expect(html).toContain("/admin/api/saved-replies/01HWH");
+		expect(html).toContain("Delete saved reply");
+	});
+
+	it("escapes a malicious existing title in the input value", () => {
+		const html = renderSavedReplyForm({
+			existing: mkReply({ title: '" onload="alert(1)' }),
+			error: null,
+		});
+		expect(html).not.toContain('" onload="alert(1)');
+		expect(html).toContain("&quot;");
+	});
+
+	it("escapes a malicious body inside textarea", () => {
+		const html = renderSavedReplyForm({
+			existing: mkReply({ body_md: "</textarea><script>alert(1)</script>" }),
+			error: null,
+		});
+		expect(html).not.toContain("</textarea><script>");
+		expect(html).toContain("&lt;/textarea&gt;");
+	});
+
+	it("renders an error banner when error is set", () => {
+		const html = renderSavedReplyForm({
+			existing: null,
+			error: "title_required",
+		});
+		expect(html).toContain("title_required");
+		expect(html).toContain("Error:");
+	});
+
+	it("preselects the scope of the existing reply", () => {
+		const sharedHtml = renderSavedReplyForm({
+			existing: mkReply({ scope: "shared" }),
+			error: null,
+		});
+		expect(sharedHtml).toMatch(/value="shared" selected/);
+
+		const privateHtml = renderSavedReplyForm({
+			existing: mkReply({ scope: "private" }),
+			error: null,
+		});
+		expect(privateHtml).toMatch(/value="private" selected/);
+	});
+});

--- a/tests/saved-replies.test.ts
+++ b/tests/saved-replies.test.ts
@@ -24,6 +24,11 @@ import {
 	updateSavedReply,
 } from "../src/db/queries";
 import { renderMarkdown } from "../src/lib/markdown";
+import {
+	SAVED_REPLY_BODY_MAX,
+	SAVED_REPLY_TITLE_MAX,
+	parseSavedReplyBody,
+} from "../src/routes/admin";
 
 type Captured = { sql: string; binds: unknown[] };
 
@@ -202,21 +207,82 @@ describe("saved reply body sanitization", () => {
 });
 
 // --------------------- input validation parser -----------------------------
-//
-// We import the parser through the admin route module's behavior rather
-// than re-exporting it. Instead, we lock the validation rules in a small
-// table-driven check on the renderMarkdown side + the route-level checks
-// are exercised in admin-render tests already (next file).
 
-describe("validation thresholds", () => {
-	it("title cap is 120 chars", () => {
-		// matches SAVED_REPLY_TITLE_MAX in src/routes/admin.ts — if you
-		// change one, change the other.
-		expect(120).toBe(120);
+describe("parseSavedReplyBody — title length bound", () => {
+	it("accepts a title at the cap", () => {
+		const r = parseSavedReplyBody({
+			title: "x".repeat(SAVED_REPLY_TITLE_MAX),
+			body_md: "ok",
+			scope: "private",
+		});
+		expect(r.ok).toBe(true);
 	});
 
-	it("body cap is 8000 chars", () => {
-		// matches SAVED_REPLY_BODY_MAX in src/routes/admin.ts
-		expect(8000).toBe(8000);
+	it("rejects a title one char over the cap with title_too_long", () => {
+		const r = parseSavedReplyBody({
+			title: "x".repeat(SAVED_REPLY_TITLE_MAX + 1),
+			body_md: "ok",
+			scope: "private",
+		});
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBe("title_too_long");
+	});
+});
+
+describe("parseSavedReplyBody — body length bound", () => {
+	it("accepts a body at the cap", () => {
+		const r = parseSavedReplyBody({
+			title: "t",
+			body_md: "x".repeat(SAVED_REPLY_BODY_MAX),
+			scope: "private",
+		});
+		expect(r.ok).toBe(true);
+	});
+
+	it("rejects a body one char over the cap with body_too_long", () => {
+		const r = parseSavedReplyBody({
+			title: "t",
+			body_md: "x".repeat(SAVED_REPLY_BODY_MAX + 1),
+			scope: "private",
+		});
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBe("body_too_long");
+	});
+});
+
+describe("parseSavedReplyBody — other rules", () => {
+	it("rejects a missing title with title_required", () => {
+		const r = parseSavedReplyBody({ title: "  ", body_md: "ok", scope: "private" });
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBe("title_required");
+	});
+
+	it("rejects a missing body with body_required", () => {
+		const r = parseSavedReplyBody({ title: "t", body_md: "  ", scope: "private" });
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBe("body_required");
+	});
+
+	it("rejects an unknown scope with scope_invalid", () => {
+		const r = parseSavedReplyBody({
+			title: "t",
+			body_md: "ok",
+			scope: "team",
+		});
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBe("scope_invalid");
+	});
+
+	it("trims the title but preserves body whitespace", () => {
+		const r = parseSavedReplyBody({
+			title: "  hello  ",
+			body_md: "  body  ",
+			scope: "shared",
+		});
+		expect(r.ok).toBe(true);
+		if (r.ok) {
+			expect(r.fields.title).toBe("hello");
+			expect(r.fields.body_md).toBe("  body  ");
+		}
 	});
 });

--- a/tests/saved-replies.test.ts
+++ b/tests/saved-replies.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Saved-replies tests cover:
+ *
+ *   1. The query layer's SQL semantics — that listSavedRepliesForUser
+ *      honors the (owner OR shared) visibility rule and that
+ *      updateSavedReply / deleteSavedReply enforce owner_id in the WHERE
+ *      clause (defense even from a crafted request).
+ *   2. The route layer's role gating — requireMod must accept mod/admin
+ *      and reject anonymous/user roles cleanly.
+ *   3. Input validation — title/body bounds, scope allowlist.
+ *   4. The post-as-reply path — re-renders through renderMarkdown (no
+ *      stored HTML trusted), audits with from_saved_reply=true.
+ *   5. The XSS-attempt fuzz — markdown body containing a <script> tag is
+ *      stripped at post time, never persisted as html.
+ *
+ * No Miniflare. Hand-rolled D1 stub with capture so tests can assert
+ * SQL shape directly.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	deleteSavedReply,
+	insertSavedReply,
+	listSavedRepliesForUser,
+	updateSavedReply,
+} from "../src/db/queries";
+import { renderMarkdown } from "../src/lib/markdown";
+
+type Captured = { sql: string; binds: unknown[] };
+
+const makeDb = (config: {
+	listResult?: unknown[];
+	updateChanges?: number;
+	deleteChanges?: number;
+	getRow?: Record<string, unknown> | null;
+} = {}) => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => {
+		const stmt = {
+			_sql: sql,
+			_binds: [] as unknown[],
+			bind(...args: unknown[]) {
+				this._binds = args;
+				return this;
+			},
+			async first() {
+				captured.push({ sql, binds: this._binds });
+				if (sql.includes("FROM saved_replies WHERE id")) {
+					return config.getRow ?? null;
+				}
+				return null;
+			},
+			async all() {
+				captured.push({ sql, binds: this._binds });
+				return { results: config.listResult ?? [] };
+			},
+			async run() {
+				captured.push({ sql, binds: this._binds });
+				if (sql.startsWith("UPDATE saved_replies")) {
+					return { meta: { changes: config.updateChanges ?? 0 } };
+				}
+				if (sql.startsWith("DELETE FROM saved_replies")) {
+					return { meta: { changes: config.deleteChanges ?? 0 } };
+				}
+				return { meta: { changes: 1 } };
+			},
+		};
+		return stmt;
+	};
+	const db = {
+		prepare(sql: string) {
+			return chain(sql);
+		},
+	};
+	return { db, captured };
+};
+
+// ---------------------- query layer SQL semantics --------------------------
+
+describe("listSavedRepliesForUser", () => {
+	it("issues a SELECT with (owner_id = ? OR scope = 'shared')", async () => {
+		const { db, captured } = makeDb({ listResult: [] });
+		await listSavedRepliesForUser(db as unknown as D1Database, "u_alice");
+		const select = captured.find((c) => c.sql.includes("FROM saved_replies"));
+		expect(select).toBeDefined();
+		expect(select!.sql).toContain("owner_id = ?");
+		expect(select!.sql).toContain("scope = 'shared'");
+		expect(select!.binds).toEqual(["u_alice"]);
+	});
+});
+
+describe("insertSavedReply", () => {
+	it("binds the owner_id, scope, and a generated ulid in column order", async () => {
+		const { db, captured } = makeDb();
+		const r = await insertSavedReply(db as unknown as D1Database, {
+			owner_id: "u_alice",
+			title: "Welcome",
+			body_md: "Hi!",
+			scope: "private",
+		});
+		const insert = captured.find((c) => c.sql.includes("INSERT INTO saved_replies"));
+		expect(insert).toBeDefined();
+		// Bind order: id, owner_id, title, body_md, scope, created_at, updated_at
+		expect(insert!.binds[1]).toBe("u_alice");
+		expect(insert!.binds[2]).toBe("Welcome");
+		expect(insert!.binds[3]).toBe("Hi!");
+		expect(insert!.binds[4]).toBe("private");
+		expect(r.id).toBeTruthy();
+		expect(r.created_at).toBe(r.updated_at);
+	});
+});
+
+describe("updateSavedReply", () => {
+	it("requires owner_id in WHERE (defense even from crafted request)", async () => {
+		const { db, captured } = makeDb({ updateChanges: 1 });
+		await updateSavedReply(
+			db as unknown as D1Database,
+			"r_1",
+			"u_alice",
+			{ title: "x", body_md: "y", scope: "shared" },
+		);
+		const upd = captured.find((c) => c.sql.startsWith("UPDATE saved_replies"));
+		expect(upd).toBeDefined();
+		expect(upd!.sql).toContain("WHERE id = ? AND owner_id = ?");
+		// Bind order: title, body_md, scope, updated_at, id, owner_id
+		expect(upd!.binds[4]).toBe("r_1");
+		expect(upd!.binds[5]).toBe("u_alice");
+	});
+
+	it("returns false when changes=0 (id+owner_id didn't match)", async () => {
+		const { db } = makeDb({ updateChanges: 0 });
+		const ok = await updateSavedReply(
+			db as unknown as D1Database,
+			"r_other",
+			"u_alice",
+			{ title: "x", body_md: "y", scope: "shared" },
+		);
+		expect(ok).toBe(false);
+	});
+
+	it("returns true when changes>0", async () => {
+		const { db } = makeDb({ updateChanges: 1 });
+		const ok = await updateSavedReply(
+			db as unknown as D1Database,
+			"r_1",
+			"u_alice",
+			{ title: "x", body_md: "y", scope: "shared" },
+		);
+		expect(ok).toBe(true);
+	});
+});
+
+describe("deleteSavedReply", () => {
+	it("requires owner_id in WHERE", async () => {
+		const { db, captured } = makeDb({ deleteChanges: 1 });
+		await deleteSavedReply(db as unknown as D1Database, "r_1", "u_alice");
+		const del = captured.find((c) => c.sql.startsWith("DELETE FROM saved_replies"));
+		expect(del).toBeDefined();
+		expect(del!.sql).toContain("WHERE id = ? AND owner_id = ?");
+		expect(del!.binds).toEqual(["r_1", "u_alice"]);
+	});
+
+	it("returns false when owner_id mismatch (admin cannot delete other mod's private reply)", async () => {
+		// Even an admin's user.id passed in here will NOT remove a row that
+		// belongs to a different owner — D1 reports changes=0.
+		const { db } = makeDb({ deleteChanges: 0 });
+		const ok = await deleteSavedReply(
+			db as unknown as D1Database,
+			"r_1",
+			"u_admin",
+		);
+		expect(ok).toBe(false);
+	});
+});
+
+// ----------------- markdown sanitization at post time ----------------------
+
+describe("saved reply body sanitization", () => {
+	it("strips raw <script> from markdown body when re-rendered", () => {
+		const malicious = `Hi <script>alert(1)</script> there`;
+		const html = renderMarkdown(malicious);
+		// The tag must not survive; the text content inside is allowed to
+		// remain as inert text (no executable handler).
+		expect(html).not.toContain("<script>");
+		expect(html).not.toContain("</script>");
+	});
+
+	it("strips raw <img onerror=..> from markdown body when re-rendered", () => {
+		const malicious = `<img src=x onerror="alert(1)">`;
+		const html = renderMarkdown(malicious);
+		expect(html).not.toContain("onerror");
+		expect(html).not.toContain("<img");
+	});
+
+	it("preserves the allowed markdown subset", () => {
+		const md = `**bold** *em* [link](https://example.com)`;
+		const html = renderMarkdown(md);
+		expect(html).toContain("<strong>bold</strong>");
+		expect(html).toContain("<em>em</em>");
+		expect(html).toContain('href="https://example.com"');
+		expect(html).toContain('rel="nofollow ugc');
+	});
+});
+
+// --------------------- input validation parser -----------------------------
+//
+// We import the parser through the admin route module's behavior rather
+// than re-exporting it. Instead, we lock the validation rules in a small
+// table-driven check on the renderMarkdown side + the route-level checks
+// are exercised in admin-render tests already (next file).
+
+describe("validation thresholds", () => {
+	it("title cap is 120 chars", () => {
+		// matches SAVED_REPLY_TITLE_MAX in src/routes/admin.ts — if you
+		// change one, change the other.
+		expect(120).toBe(120);
+	});
+
+	it("body cap is 8000 chars", () => {
+		// matches SAVED_REPLY_BODY_MAX in src/routes/admin.ts
+		expect(8000).toBe(8000);
+	});
+});

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -42,6 +42,8 @@ const mk = (
 	ip_hash: null,
 	user_agent: null,
 	created_at,
+	score_up: 0,
+	score_down: 0,
 });
 
 describe("buildTree — basic shape and order", () => {

--- a/tests/url-safety.test.ts
+++ b/tests/url-safety.test.ts
@@ -1,0 +1,97 @@
+/**
+ * SSRF blocklist coverage for src/lib/url-safety.ts.
+ *
+ * This is configuration-time defense — the operator types a URL, we
+ * reject obvious mistakes. We can't intercept DNS resolution that
+ * Workers' fetch does at request time, so a hostname that resolves to a
+ * private IP at fetch time is still reachable. See the module docstring
+ * for the trust boundary.
+ */
+import { describe, it, expect } from "vitest";
+import { checkOutboundUrl } from "../src/lib/url-safety";
+
+const reject = (raw: string, opts?: { allowHttp?: boolean }): string => {
+	const r = checkOutboundUrl(raw, opts);
+	if (r.ok) throw new Error(`expected reject, got ok for ${raw}`);
+	return r.reason;
+};
+
+describe("checkOutboundUrl scheme handling", () => {
+	it("accepts https://", () => {
+		const r = checkOutboundUrl("https://hooks.slack.com/services/T/B/X");
+		expect(r.ok).toBe(true);
+	});
+
+	it("rejects http:// by default", () => {
+		expect(reject("http://example.com/hook")).toBe("scheme_not_allowed");
+	});
+
+	it("accepts http:// when allowHttp=true (legacy WEBHOOK_URL path)", () => {
+		const r = checkOutboundUrl("http://example.com/hook", { allowHttp: true });
+		expect(r.ok).toBe(true);
+	});
+
+	it("rejects non-http schemes", () => {
+		expect(reject("ftp://example.com/")).toBe("scheme_not_allowed");
+		expect(reject("file:///etc/passwd")).toBe("scheme_not_allowed");
+		expect(reject("javascript:alert(1)")).toBe("scheme_not_allowed");
+		expect(reject("gopher://example.com/")).toBe("scheme_not_allowed");
+	});
+
+	it("rejects malformed URLs", () => {
+		expect(reject("not-a-url")).toBe("invalid_url");
+		expect(reject("https://")).toBe("invalid_url");
+	});
+});
+
+describe("checkOutboundUrl SSRF blocklist", () => {
+	const cases: Array<[string, string]> = [
+		["https://localhost/hook", "loopback_host"],
+		["https://Localhost:8080/", "loopback_host"],
+		["https://host.docker.internal/x", "loopback_host"],
+		["https://ip6-localhost/", "loopback_host"],
+		["https://server.local/x", "internal_tld"],
+		["https://kafka.internal/x", "internal_tld"],
+		["https://kube-dns.cluster.local/x", "internal_tld"],
+		["https://127.0.0.1/hook", "private_ipv4"],
+		["https://10.0.0.5/hook", "private_ipv4"],
+		["https://172.16.0.1/hook", "private_ipv4"],
+		["https://172.20.0.1/hook", "private_ipv4"],
+		["https://172.31.255.254/hook", "private_ipv4"],
+		["https://192.168.1.1/hook", "private_ipv4"],
+		["https://169.254.169.254/latest/meta-data/", "private_ipv4"], // EC2 IMDS
+		["https://0.0.0.0/hook", "private_ipv4"],
+		["https://224.0.0.1/hook", "private_ipv4"],
+		["https://[::1]/hook", "private_ipv6"],
+		["https://[fe80::1]/hook", "private_ipv6"],
+		["https://[fd00::1]/hook", "private_ipv6"],
+		["https://[fc00::1]/hook", "private_ipv6"],
+		["https://[ff02::1]/hook", "private_ipv6"],
+		["https://user:pass@example.com/hook", "url_credentials"],
+	];
+	for (const [url, reason] of cases) {
+		it(`rejects ${url} → ${reason}`, () => {
+			expect(reject(url)).toBe(reason);
+		});
+	}
+
+	it("accepts a normal external HTTPS URL", () => {
+		const cases = [
+			"https://hooks.slack.com/services/T0/B0/X",
+			"https://discord.com/api/webhooks/123/abc",
+			"https://example.com/webhooks/garrul",
+			"https://172.32.0.1/hook", // just outside RFC1918
+		];
+		for (const u of cases) {
+			const r = checkOutboundUrl(u);
+			expect(r.ok).toBe(true);
+		}
+	});
+
+	it("rejects 172.16/12 boundary correctly (172.15 ok, 172.32 ok, 172.16-31 blocked)", () => {
+		expect(checkOutboundUrl("https://172.15.0.1/").ok).toBe(true);
+		expect(checkOutboundUrl("https://172.32.0.1/").ok).toBe(true);
+		expect(reject("https://172.16.0.0/")).toBe("private_ipv4");
+		expect(reject("https://172.31.0.0/")).toBe("private_ipv4");
+	});
+});

--- a/tests/usage-render.test.ts
+++ b/tests/usage-render.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Renderer + isUsageConfigured tests. These don't hit the GraphQL API —
+ * that's an integration concern. We're testing graceful-degradation
+ * paths (setup view, token-error view), the bar coloring thresholds,
+ * and the per-panel error fallback.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	renderUsageDashboard,
+	renderUsageSetup,
+	renderUsageTokenError,
+} from "../src/admin-ui/pages/usage";
+import { isUsageConfigured } from "../src/lib/cf-usage";
+import type { UsageSnapshot } from "../src/lib/cf-usage";
+
+describe("isUsageConfigured", () => {
+	it("returns false when neither env var is set", () => {
+		expect(isUsageConfigured({})).toBe(false);
+	});
+
+	it("returns false when only the token is set", () => {
+		expect(isUsageConfigured({ CF_API_TOKEN: "tok" })).toBe(false);
+	});
+
+	it("returns false when only the account ID is set", () => {
+		expect(isUsageConfigured({ CF_ACCOUNT_ID: "acct" })).toBe(false);
+	});
+
+	it("returns true when both are set", () => {
+		expect(
+			isUsageConfigured({ CF_API_TOKEN: "tok", CF_ACCOUNT_ID: "acct" }),
+		).toBe(true);
+	});
+
+	it("returns false on empty strings", () => {
+		expect(
+			isUsageConfigured({ CF_API_TOKEN: "", CF_ACCOUNT_ID: "" }),
+		).toBe(false);
+	});
+});
+
+describe("renderUsageSetup", () => {
+	it("shows the three required token scopes", () => {
+		const html = renderUsageSetup();
+		expect(html).toContain("Account Analytics");
+		expect(html).toContain("D1");
+		expect(html).toContain("Workers KV Storage");
+	});
+
+	it("shows both wrangler secret put commands", () => {
+		const html = renderUsageSetup();
+		expect(html).toContain("wrangler secret put CF_API_TOKEN");
+		expect(html).toContain("wrangler secret put CF_ACCOUNT_ID");
+	});
+
+	it("explains the token never leaves the worker", () => {
+		const html = renderUsageSetup();
+		expect(html).toContain("never leaves the Worker");
+	});
+});
+
+describe("renderUsageTokenError", () => {
+	it("renders the error message verbatim and escapes HTML", () => {
+		const html = renderUsageTokenError("status:expired");
+		expect(html).toContain("status:expired");
+	});
+
+	it("escapes malicious error content", () => {
+		const html = renderUsageTokenError('<img src=x onerror=alert(1)>');
+		expect(html).not.toContain("<img src=x");
+		expect(html).toContain("&lt;img src=x");
+	});
+});
+
+const okSnapshot = (
+	over: Partial<UsageSnapshot> = {},
+): UsageSnapshot => ({
+	asOf: Date.parse("2026-05-25T12:00:00Z"),
+	workers: { ok: true, data: { today: 12_345, last30d: 250_000 } },
+	d1: {
+		ok: true,
+		data: {
+			reads_today: 50_000,
+			writes_today: 25_000,
+			storage_bytes: null,
+		},
+	},
+	kv: {
+		ok: true,
+		data: {
+			reads_today: 8_000,
+			writes_today: 200,
+			storage_bytes: null,
+		},
+	},
+	...over,
+});
+
+describe("renderUsageDashboard", () => {
+	it("renders all three panels when all queries succeed", () => {
+		const html = renderUsageDashboard(okSnapshot());
+		expect(html).toContain("Workers requests");
+		expect(html).toContain("D1 database");
+		expect(html).toContain("KV namespaces");
+	});
+
+	it("shows the cached-snapshot timestamp", () => {
+		const html = renderUsageDashboard(okSnapshot());
+		expect(html).toContain("2026-05-25 12:00 UTC");
+	});
+
+	it("formats large numbers with thousands separators", () => {
+		const html = renderUsageDashboard(okSnapshot());
+		expect(html).toContain("12,345");
+		expect(html).toContain("250,000");
+	});
+
+	it("renders a fallback card per panel on per-query error", () => {
+		const html = renderUsageDashboard(
+			okSnapshot({
+				workers: { ok: false, error: "http_403" },
+				d1: { ok: false, error: "graphql_scope_missing" },
+			}),
+		);
+		expect(html).toContain("Couldn't fetch this metric");
+		expect(html).toContain("http_403");
+		expect(html).toContain("graphql_scope_missing");
+		// The kv panel still succeeded — bar still rendered.
+		expect(html).toContain("Reads (today)");
+	});
+
+	it("colors bars green / yellow / red at 0/75/90%", () => {
+		const html = renderUsageDashboard(
+			okSnapshot({
+				workers: { ok: true, data: { today: 50_000, last30d: 0 } },
+				d1: {
+					ok: true,
+					data: {
+						reads_today: 3_900_000,
+						writes_today: 95_000,
+						storage_bytes: null,
+					},
+				},
+				kv: {
+					ok: true,
+					data: {
+						reads_today: 200,
+						writes_today: 100,
+						storage_bytes: null,
+					},
+				},
+			}),
+		);
+		// 50%, 78% — yellow somewhere
+		expect(html).toContain("var(--warn)");
+		// 95% — red somewhere
+		expect(html).toContain("var(--bad)");
+		// 0.2%, 10% — green somewhere
+		expect(html).toContain("var(--ok)");
+	});
+
+	it("clamps the bar to 100% even when usage exceeds the ceiling", () => {
+		const html = renderUsageDashboard(
+			okSnapshot({
+				workers: { ok: true, data: { today: 9_999_999, last30d: 0 } },
+			}),
+		);
+		// Bar SVG x-positions are computed as p*2 where p is capped at 100,
+		// so the rect width must be at most 200.
+		const widths = [...html.matchAll(/<rect[^>]*width="([\d.]+)"/g)].map(
+			(m) => Number(m[1]),
+		);
+		for (const w of widths) {
+			expect(w).toBeLessThanOrEqual(200);
+		}
+		// The label should show 100.0% in that case.
+		expect(html).toContain("100.0%");
+	});
+
+	it("escapes the timestamp before embedding it in an HTML attribute", () => {
+		// asOf is a number, so HTML injection through that field is not
+		// possible — but the percentage label IS embedded into a
+		// SVG aria-label attribute. Spot-check the escape is happening.
+		const html = renderUsageDashboard(okSnapshot());
+		expect(html).toContain('aria-label="Today: ');
+	});
+});

--- a/tests/votes.test.ts
+++ b/tests/votes.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Voting tests cover three concerns:
+ *
+ *   1. Route-level input validation — accepting only -1/0/1, rejecting
+ *      malformed payloads with 400, honoring the VOTING_ENABLED and
+ *      DOWNVOTES_ENABLED env flags.
+ *   2. castVote() SQL semantics — that we emit a batch with the right
+ *      writes (DELETE vs UPSERT) and the counter recomputation lands.
+ *   3. Tree rendering — vote scores propagate via buildTree.
+ *
+ * No Miniflare here: the route hits a hand-rolled D1 stub. Integration
+ * against real D1 is covered by `npm run dev` end-to-end testing on the
+ * dogfood instance (per project convention).
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { votes } from "../src/routes/api.votes";
+import { castVote } from "../src/db/queries";
+
+type Row = Record<string, unknown> | null;
+
+const ULID_OK = "01HC000000000000000000ABCD";
+
+// Tracks every SQL stmt issued; lets a test prove that castVote(value=0)
+// emits a DELETE while castVote(value=1) emits an INSERT … UPSERT.
+type Captured = { sql: string; binds: unknown[] };
+
+const makeDb = (config: {
+	comment?: Row;
+	scoresAfter?: { score_up: number; score_down: number; my_vote: number };
+}) => {
+	const captured: Captured[] = [];
+	const batches: Captured[][] = [];
+	const chain = (sql: string, binds: unknown[] = []) => {
+		const stmt = {
+			_sql: sql,
+			_binds: binds,
+			bind(...args: unknown[]) {
+				this._binds = args;
+				return this;
+			},
+			async first() {
+				captured.push({ sql, binds: this._binds });
+				if (sql.includes("SELECT c.score_up")) {
+					return config.scoresAfter ?? null;
+				}
+				if (sql.includes("FROM comments WHERE id")) {
+					return config.comment ?? null;
+				}
+				if (sql.includes("FROM users")) {
+					return {
+						id: "01HU000000000000000000",
+						provider: "anon",
+						provider_id: null,
+						name: "anon",
+						email: null,
+						avatar_url: null,
+						is_admin: 0,
+						is_banned: 0,
+						created_at: 1_700_000_000_000,
+					};
+				}
+				return null;
+			},
+			async all() {
+				captured.push({ sql, binds: this._binds });
+				return { results: [] };
+			},
+			async run() {
+				captured.push({ sql, binds: this._binds });
+				return { meta: { changes: 1 } };
+			},
+		};
+		return stmt;
+	};
+	const db = {
+		prepare(sql: string) {
+			return chain(sql);
+		},
+		async batch(stmts: { _sql: string; _binds: unknown[] }[]) {
+			const group: Captured[] = stmts.map((s) => ({
+				sql: s._sql,
+				binds: s._binds,
+			}));
+			batches.push(group);
+			for (const c of group) captured.push(c);
+			return [];
+		},
+	};
+	return { db, captured, batches };
+};
+
+// -- castVote SQL semantics --------------------------------------------------
+
+describe("castVote", () => {
+	it("issues an UPSERT + counter recompute for value=1", async () => {
+		const { db, batches } = makeDb({
+			scoresAfter: { score_up: 1, score_down: 0, my_vote: 1 },
+		});
+		const result = await castVote(
+			db as unknown as D1Database,
+			ULID_OK,
+			"01HU000000000000000000",
+			1,
+		);
+		expect(batches).toHaveLength(1);
+		expect(batches[0]).toHaveLength(2);
+		expect(batches[0]![0]!.sql).toContain("INSERT INTO votes");
+		expect(batches[0]![0]!.sql).toContain("ON CONFLICT(comment_id, user_id)");
+		expect(batches[0]![1]!.sql).toContain("UPDATE comments");
+		expect(result).toEqual({ score_up: 1, score_down: 0, my_vote: 1 });
+	});
+
+	it("issues a DELETE + counter recompute for value=0", async () => {
+		const { db, batches } = makeDb({
+			scoresAfter: { score_up: 0, score_down: 0, my_vote: 0 },
+		});
+		await castVote(
+			db as unknown as D1Database,
+			ULID_OK,
+			"01HU000000000000000000",
+			0,
+		);
+		expect(batches).toHaveLength(1);
+		expect(batches[0]![0]!.sql).toContain("DELETE FROM votes");
+		expect(batches[0]![1]!.sql).toContain("UPDATE comments");
+	});
+
+	it("downvote stores value=-1 verbatim", async () => {
+		const { db, batches } = makeDb({
+			scoresAfter: { score_up: 0, score_down: 1, my_vote: -1 },
+		});
+		await castVote(
+			db as unknown as D1Database,
+			ULID_OK,
+			"01HU000000000000000000",
+			-1,
+		);
+		// the UPSERT binds (comment_id, user_id, value, created_at)
+		expect(batches[0]![0]!.binds[2]).toBe(-1);
+	});
+});
+
+// -- route-level input validation -------------------------------------------
+
+const mkRouteApp = (
+	envOver: Partial<{
+		VOTING_ENABLED: string;
+		DOWNVOTES_ENABLED: string;
+	}> = {},
+) => {
+	const app = new Hono<{ Bindings: Record<string, unknown> }>();
+	const { db } = makeDb({
+		comment: {
+			id: ULID_OK,
+			post_slug: "hello",
+			parent_id: null,
+			user_id: "01HU000000000000000000",
+			body_md: "x",
+			body_html: "<p>x</p>",
+			renderer_version: 1,
+			status: "approved",
+			edited_at: null,
+			deleted_at: null,
+			ip_hash: null,
+			user_agent: null,
+			created_at: 1,
+			score_up: 0,
+			score_down: 0,
+		},
+		scoresAfter: { score_up: 1, score_down: 0, my_vote: 1 },
+	});
+	app.route("/v", votes);
+	const env = {
+		DB: db,
+		RATE_LIMITS: {
+			get: async () => null,
+			put: async () => {},
+			delete: async () => {},
+		},
+		ANALYTICS: { writeDataPoint: () => {} },
+		SESSIONS: { get: async () => null },
+		IP_HASH_SECRET: "x".repeat(32),
+		...envOver,
+	};
+	return { app, env };
+};
+
+const post = async (
+	app: Hono,
+	env: Record<string, unknown>,
+	body: unknown,
+) =>
+	app.request(
+		"/v",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		env,
+	);
+
+describe("POST /votes — input validation", () => {
+	it("rejects a missing comment_id with 400", async () => {
+		const { app, env } = mkRouteApp();
+		const res = await post(app, env, { value: 1 });
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects value=2 with 400", async () => {
+		const { app, env } = mkRouteApp();
+		const res = await post(app, env, { comment_id: ULID_OK, value: 2 });
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("invalid_value");
+	});
+
+	it('rejects value="up" with 400', async () => {
+		const { app, env } = mkRouteApp();
+		const res = await post(app, env, { comment_id: ULID_OK, value: "up" });
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects a malformed JSON body with 400", async () => {
+		const { app, env } = mkRouteApp();
+		const res = await app.request(
+			"/v",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: "{not json",
+			},
+			env,
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("accepts value=-1 / 0 / 1 (numbers AND strings)", async () => {
+		const { app, env } = mkRouteApp();
+		for (const value of [1, -1, 0, "1", "-1", "0"]) {
+			const res = await post(app, env, { comment_id: ULID_OK, value });
+			expect(res.status).toBe(200);
+		}
+	});
+});
+
+describe("POST /votes — env flags", () => {
+	it("403s when VOTING_ENABLED=0", async () => {
+		const { app, env } = mkRouteApp({ VOTING_ENABLED: "0" });
+		const res = await post(app, env, { comment_id: ULID_OK, value: 1 });
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("voting_disabled");
+	});
+
+	it("403s a downvote when DOWNVOTES_ENABLED=false but allows upvotes", async () => {
+		const { app, env } = mkRouteApp({ DOWNVOTES_ENABLED: "false" });
+		const down = await post(app, env, { comment_id: ULID_OK, value: -1 });
+		expect(down.status).toBe(403);
+		const up = await post(app, env, { comment_id: ULID_OK, value: 1 });
+		expect(up.status).toBe(200);
+	});
+
+	it("accepts both directions when both flags are unset (default on)", async () => {
+		const { app, env } = mkRouteApp();
+		const up = await post(app, env, { comment_id: ULID_OK, value: 1 });
+		const down = await post(app, env, { comment_id: ULID_OK, value: -1 });
+		expect(up.status).toBe(200);
+		expect(down.status).toBe(200);
+	});
+});

--- a/tests/votes.test.ts
+++ b/tests/votes.test.ts
@@ -143,11 +143,18 @@ describe("castVote", () => {
 
 // -- route-level input validation -------------------------------------------
 
+// The route's ghost-user lookup falls through makeDb's `FROM users` branch,
+// which returns id="01HU000000000000000000". A comment.user_id distinct
+// from that id means the anon voter is NOT the comment author — the
+// default path. The self-vote test below overrides this to match.
+const COMMENT_AUTHOR_ID = "01HU111111111111111111";
+
 const mkRouteApp = (
 	envOver: Partial<{
 		VOTING_ENABLED: string;
 		DOWNVOTES_ENABLED: string;
 	}> = {},
+	commentAuthorId: string = COMMENT_AUTHOR_ID,
 ) => {
 	const app = new Hono<{ Bindings: Record<string, unknown> }>();
 	const { db } = makeDb({
@@ -155,7 +162,7 @@ const mkRouteApp = (
 			id: ULID_OK,
 			post_slug: "hello",
 			parent_id: null,
-			user_id: "01HU000000000000000000",
+			user_id: commentAuthorId,
 			body_md: "x",
 			body_html: "<p>x</p>",
 			renderer_version: 1,
@@ -268,5 +275,33 @@ describe("POST /votes — env flags", () => {
 		const down = await post(app, env, { comment_id: ULID_OK, value: -1 });
 		expect(up.status).toBe(200);
 		expect(down.status).toBe(200);
+	});
+});
+
+describe("POST /votes — self-vote forbidden", () => {
+	// The ghost-user lookup in makeDb returns id="01HU000000000000000000".
+	// Setting the comment's author to the same id puts the voter and the
+	// author at the same identity — the guard must reject all three values
+	// (up, down, clear) rather than letting the author game score-sort.
+	const GHOST_ID = "01HU000000000000000000";
+
+	it("403s an upvote on own comment with vote_self_forbidden", async () => {
+		const { app, env } = mkRouteApp({}, GHOST_ID);
+		const res = await post(app, env, { comment_id: ULID_OK, value: 1 });
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("vote_self_forbidden");
+	});
+
+	it("403s a downvote on own comment", async () => {
+		const { app, env } = mkRouteApp({}, GHOST_ID);
+		const res = await post(app, env, { comment_id: ULID_OK, value: -1 });
+		expect(res.status).toBe(403);
+	});
+
+	it("403s a clear (value=0) on own comment", async () => {
+		const { app, env } = mkRouteApp({}, GHOST_ID);
+		const res = await post(app, env, { comment_id: ULID_OK, value: 0 });
+		expect(res.status).toBe(403);
 	});
 });

--- a/tests/webhook-adapters.test.ts
+++ b/tests/webhook-adapters.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Slack/Discord adapter coverage. The adapters are async and touch the
+ * DB, so we hand them a hand-rolled stub instead of spinning up a
+ * Miniflare worker — what we're testing is the message formatting and
+ * the mention-escape logic, not D1 itself.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	renderDiscordBody,
+	renderSlackBody,
+} from "../src/lib/webhook-adapters";
+import type { WebhookPayload } from "../src/lib/webhook";
+
+// Minimal stub that mimics just enough of D1Database for the three
+// query helpers we call (getComment, getUser, getPost). Each query is a
+// single `prepare(...).bind(...).first()` chain, so the stub returns
+// whatever we configure for the table being queried.
+type Row = Record<string, unknown> | null;
+
+const makeDb = (rows: { comments: Row; users: Row; posts: Row }) => {
+	let lastSql = "";
+	const stub = {
+		prepare(sql: string) {
+			lastSql = sql;
+			return {
+				bind() {
+					return this;
+				},
+				async first() {
+					if (lastSql.includes("FROM comments")) return rows.comments;
+					if (lastSql.includes("FROM users")) return rows.users;
+					if (lastSql.includes("FROM posts")) return rows.posts;
+					return null;
+				},
+				async all() {
+					return { results: [] };
+				},
+				async run() {
+					return {};
+				},
+			};
+		},
+	};
+	return stub as unknown as Parameters<typeof renderSlackBody>[0];
+};
+
+const payload = (
+	over: Partial<WebhookPayload> = {},
+): WebhookPayload => ({
+	event: "comment.posted",
+	comment_id: "01HC000000000000000000",
+	post_slug: "hello-world",
+	user_id: "01HU000000000000000000",
+	ts: 1700000000000,
+	...over,
+});
+
+const baseRows = {
+	comments: {
+		id: "01HC000000000000000000",
+		post_slug: "hello-world",
+		body_md: "Hello *world*",
+		body_html: "<p>hello</p>",
+		renderer_version: 1,
+		status: "approved",
+		edited_at: null,
+		deleted_at: null,
+		ip_hash: null,
+		user_agent: null,
+		created_at: 1_700_000_000_000,
+		parent_id: null,
+		user_id: "01HU000000000000000000",
+	},
+	users: {
+		id: "01HU000000000000000000",
+		name: "Alice",
+		avatar_url: null,
+		provider: "github",
+		email: null,
+		is_admin: 0,
+		is_banned: 0,
+		role: "user",
+		created_at: 0,
+		updated_at: 0,
+	},
+	posts: {
+		slug: "hello-world",
+		title: "Hello, world!",
+		url: null,
+		created_at: 0,
+	},
+};
+
+describe("renderSlackBody", () => {
+	it("returns a JSON string with a text field", async () => {
+		const out = await renderSlackBody(makeDb(baseRows), payload());
+		const parsed = JSON.parse(out);
+		expect(typeof parsed.text).toBe("string");
+		expect(parsed.text).toContain("New comment");
+		expect(parsed.text).toContain("Alice");
+		expect(parsed.text).toContain("Hello, world!");
+	});
+
+	it("uses the right verb per event", async () => {
+		for (const [event, verb] of [
+			["comment.posted", "New comment"],
+			["comment.edited", "Edited comment"],
+			["comment.deleted", "Comment deleted"],
+			["comment.approved", "Comment approved"],
+			["comment.spam", "Comment marked spam"],
+		] as const) {
+			const out = await renderSlackBody(
+				makeDb(baseRows),
+				payload({ event }),
+			);
+			expect(JSON.parse(out).text).toContain(verb);
+		}
+	});
+
+	it("neutralizes @everyone in author name and body", async () => {
+		const rows = {
+			...baseRows,
+			users: { ...baseRows.users, name: "@everyone" },
+			comments: { ...baseRows.comments, body_md: "Hey @everyone look!" },
+		};
+		const out = await renderSlackBody(makeDb(rows), payload());
+		const text = JSON.parse(out).text;
+		// Either contains a zero-width space between @ and everyone,
+		// OR doesn't contain the literal trigger at all.
+		expect(text).not.toMatch(/(?<![​])@everyone(?!​)/);
+	});
+
+	it("neutralizes <!channel> and <@USER> tokens", async () => {
+		const rows = {
+			...baseRows,
+			comments: {
+				...baseRows.comments,
+				body_md: "<!channel> please review <@U123ABC>",
+			},
+		};
+		const out = await renderSlackBody(makeDb(rows), payload());
+		const text = JSON.parse(out).text;
+		expect(text).not.toContain("<!channel>");
+		expect(text).not.toContain("<@U123ABC>");
+		// But the visible content is preserved (with the ZWSP).
+		expect(text).toContain("channel");
+		expect(text).toContain("U123ABC");
+	});
+
+	it("HTML-escapes &, <, > in the snippet", async () => {
+		const rows = {
+			...baseRows,
+			comments: { ...baseRows.comments, body_md: "<script>alert(1)&" },
+		};
+		const out = await renderSlackBody(makeDb(rows), payload());
+		const text = JSON.parse(out).text;
+		expect(text).toContain("&lt;script&gt;");
+		expect(text).toContain("&amp;");
+		expect(text).not.toContain("<script>");
+	});
+
+	it("truncates long bodies with an ellipsis", async () => {
+		const longBody = "x".repeat(5000);
+		const rows = {
+			...baseRows,
+			comments: { ...baseRows.comments, body_md: longBody },
+		};
+		const out = await renderSlackBody(makeDb(rows), payload());
+		const text = JSON.parse(out).text;
+		expect(text).toContain("…");
+		// raw cap is 1500 + some chrome from the formatting.
+		expect(text.length).toBeLessThan(2000);
+	});
+
+	it("degrades to anonymous + no-body-available when rows missing", async () => {
+		const out = await renderSlackBody(
+			makeDb({ comments: null, users: null, posts: null }),
+			payload(),
+		);
+		const text = JSON.parse(out).text;
+		expect(text).toContain("anonymous");
+		expect(text).toContain("no body available");
+	});
+
+	it("produces valid JSON even on weird input", async () => {
+		const rows = {
+			...baseRows,
+			users: { ...baseRows.users, name: 'A"B\\C\nD' },
+		};
+		const out = await renderSlackBody(makeDb(rows), payload());
+		expect(() => JSON.parse(out)).not.toThrow();
+	});
+});
+
+describe("renderDiscordBody", () => {
+	it("returns JSON with a content field", async () => {
+		const out = await renderDiscordBody(makeDb(baseRows), payload());
+		const parsed = JSON.parse(out);
+		expect(typeof parsed.content).toBe("string");
+		expect(parsed.content).toContain("New comment");
+		expect(parsed.content).toContain("Alice");
+	});
+
+	it("neutralizes @everyone and @here", async () => {
+		for (const trigger of ["@everyone", "@here"]) {
+			const rows = {
+				...baseRows,
+				comments: { ...baseRows.comments, body_md: `Hey ${trigger} woo` },
+			};
+			const out = await renderDiscordBody(makeDb(rows), payload());
+			const content = JSON.parse(out).content;
+			expect(content).not.toMatch(
+				new RegExp(`(?<![​])${trigger}(?!​)`),
+			);
+		}
+	});
+
+	it("neutralizes role and user mentions <@…>", async () => {
+		const rows = {
+			...baseRows,
+			comments: {
+				...baseRows.comments,
+				body_md: "ping <@123456789012345678> and <@&987654321>",
+			},
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload());
+		const content = JSON.parse(out).content;
+		expect(content).not.toContain("<@123456789012345678>");
+		expect(content).not.toContain("<@&987654321>");
+	});
+
+	it("stays under Discord's 2000-char content cap", async () => {
+		const rows = {
+			...baseRows,
+			comments: { ...baseRows.comments, body_md: "x".repeat(8000) },
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload());
+		const content = JSON.parse(out).content;
+		expect(content.length).toBeLessThan(2000);
+	});
+
+	it("produces valid JSON for newline + quote-laden bodies", async () => {
+		const rows = {
+			...baseRows,
+			comments: {
+				...baseRows.comments,
+				body_md: 'first line\n"second" line\nthird',
+			},
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload());
+		expect(() => JSON.parse(out)).not.toThrow();
+	});
+});

--- a/tests/webhook-sig.test.ts
+++ b/tests/webhook-sig.test.ts
@@ -18,16 +18,21 @@ import {
 describe("signWebhookBody", () => {
 	it("produces a deterministic hex signature for a fixed (secret, ts, body)", async () => {
 		// Vector computed independently via openssl:
-		//   echo -n '1700000000000.{"hello":"world"}' \
+		//   printf '%s' '1700000000000.{"hello":"world"}' \
 		//     | openssl dgst -sha256 -hmac 'whsec_test'
+		// Pinning the literal digest is the load-bearing assertion: a silent
+		// change to the encoder, key import, HMAC variant, or hex encoder
+		// fails this test even if output stays deterministic and hex-shaped.
+		const EXPECTED_SIG =
+			"195306fc6e208b472595aee6784b376a8e70d774a8dc37119a209093c6923ee5";
 		const out = await signWebhookBody(
 			"whsec_test",
 			'{"hello":"world"}',
 			1_700_000_000_000,
 		);
 		expect(out.ts).toBe(1_700_000_000_000);
-		expect(out.signature).toMatch(/^[0-9a-f]{64}$/);
-		expect(out.header).toBe(`t=1700000000000,v1=${out.signature}`);
+		expect(out.signature).toBe(EXPECTED_SIG);
+		expect(out.header).toBe(`t=1700000000000,v1=${EXPECTED_SIG}`);
 		// Reproducing the signature with the same inputs must produce the
 		// identical hex — guards against any non-determinism creeping into
 		// the encoder/key path.

--- a/tests/webhook-sig.test.ts
+++ b/tests/webhook-sig.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Test vectors for the outbound webhook signature helpers.
+ *
+ * The header format is Stripe-style:
+ *   X-Garrul-Signature: t=<ms>,v1=<hex(hmac_sha256(secret, ts + "." + body))>
+ *
+ * If anything in src/lib/webhook-sig.ts changes, the receiver-side
+ * verification in operator-written code and in docs/webhooks.md must
+ * change too — pin the algorithm with a literal expected hash so a
+ * silent format change is caught immediately.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	signWebhookBody,
+	verifyWebhookSignature,
+} from "../src/lib/webhook-sig";
+
+describe("signWebhookBody", () => {
+	it("produces a deterministic hex signature for a fixed (secret, ts, body)", async () => {
+		// Vector computed independently via openssl:
+		//   echo -n '1700000000000.{"hello":"world"}' \
+		//     | openssl dgst -sha256 -hmac 'whsec_test'
+		const out = await signWebhookBody(
+			"whsec_test",
+			'{"hello":"world"}',
+			1_700_000_000_000,
+		);
+		expect(out.ts).toBe(1_700_000_000_000);
+		expect(out.signature).toMatch(/^[0-9a-f]{64}$/);
+		expect(out.header).toBe(`t=1700000000000,v1=${out.signature}`);
+		// Reproducing the signature with the same inputs must produce the
+		// identical hex — guards against any non-determinism creeping into
+		// the encoder/key path.
+		const out2 = await signWebhookBody(
+			"whsec_test",
+			'{"hello":"world"}',
+			1_700_000_000_000,
+		);
+		expect(out2.signature).toBe(out.signature);
+	});
+
+	it("produces a different signature when only the body differs", async () => {
+		const a = await signWebhookBody("k", "a", 100);
+		const b = await signWebhookBody("k", "b", 100);
+		expect(a.signature).not.toBe(b.signature);
+	});
+
+	it("produces a different signature when only the timestamp differs", async () => {
+		const a = await signWebhookBody("k", "body", 100);
+		const b = await signWebhookBody("k", "body", 200);
+		expect(a.signature).not.toBe(b.signature);
+	});
+
+	it("produces a different signature when only the secret differs", async () => {
+		const a = await signWebhookBody("k1", "body", 100);
+		const b = await signWebhookBody("k2", "body", 100);
+		expect(a.signature).not.toBe(b.signature);
+	});
+});
+
+describe("verifyWebhookSignature", () => {
+	const secret = "whsec_test";
+	const body = '{"hello":"world"}';
+	const ts = 1_700_000_000_000;
+
+	it("accepts a valid signature inside the tolerance window", async () => {
+		const { header } = await signWebhookBody(secret, body, ts);
+		const ok = await verifyWebhookSignature(secret, body, header, {
+			now: ts + 60_000,
+		});
+		expect(ok).toBe(true);
+	});
+
+	it("rejects a signature outside the tolerance window (replay defense)", async () => {
+		const { header } = await signWebhookBody(secret, body, ts);
+		const ok = await verifyWebhookSignature(secret, body, header, {
+			now: ts + 10 * 60 * 1000, // 10min > 5min default
+		});
+		expect(ok).toBe(false);
+	});
+
+	it("rejects a signature when the body has been tampered with", async () => {
+		const { header } = await signWebhookBody(secret, body, ts);
+		const ok = await verifyWebhookSignature(
+			secret,
+			body.replace("world", "evil"),
+			header,
+			{ now: ts },
+		);
+		expect(ok).toBe(false);
+	});
+
+	it("rejects a signature when the secret has been rotated", async () => {
+		const { header } = await signWebhookBody(secret, body, ts);
+		const ok = await verifyWebhookSignature("rotated_secret", body, header, {
+			now: ts,
+		});
+		expect(ok).toBe(false);
+	});
+
+	it("rejects a malformed header", async () => {
+		expect(await verifyWebhookSignature(secret, body, "")).toBe(false);
+		expect(
+			await verifyWebhookSignature(secret, body, "t=abc,v1=nothex"),
+		).toBe(false);
+		expect(await verifyWebhookSignature(secret, body, "garbage")).toBe(false);
+	});
+
+	it("rejects a v1 field of the wrong length without crashing", async () => {
+		// Defense against feeding the constant-time compare arbitrary input.
+		const tooShort = await verifyWebhookSignature(
+			secret,
+			body,
+			"t=1700000000000,v1=deadbeef",
+		);
+		const tooLong = await verifyWebhookSignature(
+			secret,
+			body,
+			`t=1700000000000,v1=${"a".repeat(128)}`,
+		);
+		expect(tooShort).toBe(false);
+		expect(tooLong).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Eight features landed atomically across ~35 commits. Each feature has its own security pass + tests; the suite ends with **415 tests passing** and `tsc --noEmit` clean.

### 1. Moderator role (foundation)
Adds `users.role` (`'user' | 'mod' | 'admin'`) with `requireMod`/`requireAdmin` gate split. Mods get queue + saved replies; admins keep settings, operator, role-grants. `is_admin` stays as a derived column for one release cycle so `/me` doesn't break.

### 2. Webhook HMAC signing + multi-endpoint + retries
Replaces the single `WEBHOOK_URL` env with a `webhook_endpoints` table + `webhook_deliveries` retry queue driven by Cron Triggers (no Cloudflare Queues). Stripe-style `X-Garrul-Signature: t=…,v1=hmac-sha256(secret, ts.body)`. SSRF guard blocks localhost / RFC1918 / link-local. Legacy `WEBHOOK_URL` becomes a synthetic unsigned endpoint (backward-compatible).

### 3. Slack + Discord webhook adapters
`webhook_endpoints.adapter` selects `'generic' | 'slack' | 'discord'`. Adapters format the v1 payload into the target platform's expected shape with mention escaping (`@everyone` is neutralized in comment bodies).

### 4. Cloudflare usage dashboard
`/admin/usage` queries the Cloudflare GraphQL Analytics API server-side, cached 5 min in KV, charts rendered as inline SVG. **Graceful degradation**: with `CF_API_TOKEN`/`CF_ACCOUNT_ID` unset, the nav link hides and direct navigation shows a setup page — no other admin surface breaks.

### 5. Authenticated voting
New `votes` table (PK `(comment_id, user_id)`, value in {-1, +1}). Counters denormalized onto `comments` (`score_up`, `score_down`) with a `(post_slug, status, score, created_at)` index for `sort=top`. Widget gets up/down + sort selector. Site-wide toggle to disable downvotes (brigading mitigation).

### 6. Saved replies (canned moderator responses)
`saved_replies` table with `scope='private'|'shared'`. Mods get a Reply button on the queue; modal picker posts a top-level reply from their account, audit-logged with `meta.from_saved_reply=true`. All bodies routed through the existing `renderMarkdown` allowlist — no raw HTML.

### 7. Disqus importer
`scripts/import-disqus.ts` (CLI) + Operator-page uploader. Idempotent via partial unique index on `(import_source, import_id)`. All imported HTML routed through the markdown allowlist; `javascript:` schemes dropped. Ghost users use HMAC-derived stable provider IDs (keyed off `IP_HASH_SECRET`) so re-imports collapse. 50 MB cap on uploads, format-sniffed before parsing.

### 8. Domain filtering + per-domain breakdowns
The embed already serves multiple hosts under one Worker; the admin UI now lets operators triage by domain. Host is derived read-side from `posts.url` via a single SQL helper (`hostExpr`) — no schema change, no per-domain config (multi-tenant stays a v2 item). Adds:

- `/admin/queue` — host dropdown + host shown on every row; preserves across status tabs and search.
- `/admin/audit` — host dropdown (narrows to comment-action rows on the chosen domain).
- `/admin/subscriptions` — host dropdown narrows to subscriptions whose post lives under the chosen host.
- `/admin` (dashboard) — "Comments by domain" panel with total / pending / spam / spam-rate per host, top 10 + overflow counter; each row links to the filtered queue.
- `/admin/usage` — same breakdown rendered alongside the Cloudflare metrics so quota review and traffic source live on one page.

Host strings from `posts.url` are HTML-escaped and URL-encoded everywhere they render. The host filter parameter is server-trimmed and length-capped (≤253) before binding into a parameter — no string concat into SQL. Sentinel `(no url)` bucket for NULL / empty / schemeless URLs.

## Schema migrations

- `0005_user_roles.sql` — role column
- `0006_webhook_tables.sql` — endpoints + deliveries
- `0007_votes.sql` — votes + denormalized counters
- `0008_saved_replies.sql` — saved replies
- `0009_import_tracking.sql` — import source/id + partial unique index

All forward-only, additive, idempotent. **Domain filtering ships no migration** — it's pure read-side derivation.

## New env vars (all optional with graceful fallback)

- `CF_API_TOKEN`, `CF_ACCOUNT_ID` — usage dashboard
- `VOTING_ENABLED`, `DOWNVOTES_ENABLED` — voting toggles (both default on; set to `0`/`false` to disable)
- Existing `IP_HASH_SECRET` is reused for the importer's ghost-author HMAC

## Test plan

- [x] `npm test` — 415 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run migrate` against dogfood D1 (0005–0009)
- [ ] Manual: promote a user to mod, confirm queue access but `/admin/settings` 403s
- [x] Manual: register a signed webhook endpoint, post a comment, verify `X-Garrul-Signature` arrives and HMAC matches
- [x] Manual: point an endpoint at Slack + Discord incoming webhooks, post a comment
- [ ] Manual: load `/admin/usage` with `CF_API_TOKEN` set; then unset it and confirm graceful fallback
- [x] Manual: upvote/downvote from two browsers, sort by `top`, confirm rankings
- [x] Manual: post a saved reply from the queue, confirm audit entry + rendered markdown
- [ ] Manual: import a small Disqus XML in dry-run, then real; re-run and confirm 0 new rows
- [x] Manual (domain filtering): `/admin/queue` dropdown narrows rows; status-tab switch keeps `?host=…`; `/admin/audit?host=…` shows only comment-action rows; dashboard + usage panels list the right hosts; `?host=' OR '1'='1` returns zero rows.

## Out of scope (intentionally deferred)

- WordPress WXR importer (nearly free after the Disqus scaffold; pick up next)
- Per-post moderation delegation
- Admin-editable auto-rules
- Generic OIDC provider
- Multi-tenant / per-domain configuration (stored host column, `sites` table, per-domain settings) — v2 anchor; this PR's read-side filtering is the v1-safe slice