### PR TITLE
docs(votes): document castVote counter-recompute cost and threshold

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2320,6 +2320,18 @@ const reselectScores = async (
  *
  * Returns the post-write counters and the requester's now-vote so the
  * widget can patch the DOM without busting the per-post tree cache.
+ *
+ * Perf note (issue #12): the two `(SELECT COUNT(*) …)` subqueries scan
+ * the comment's full vote set on every cast — a PK-index range scan on
+ * comment_id plus a row fetch per vote to read `value`, so O(N) per
+ * write. That's deliberate:
+ * recomputing from the source of truth means the denormalized counters
+ * can never drift, and there's no read-modify-write race surface like
+ * delta updates (`score_up = score_up + ?`) would introduce. For the
+ * target audience (small self-hosted instances) N stays in the hundreds
+ * and this is noise. It would only matter under brigade load — thousands
+ * of votes/min serializing on ONE hot comment — at which point switch to
+ * deltas computed from the prior vote value read inside the batch.
  */
 export const castVote = async (
 	db: D1Database,


### PR DESCRIPTION
## Summary
Resolves #12 with its recommended **Option 1: document and move on** — no code change.

Adds a perf note to the `castVote` docstring covering:
- the O(N)-per-cast cost of the two `(SELECT COUNT(*) …)` recompute subqueries
- why it's deliberate: recomputing from the source of truth is drift-proof and has no read-modify-write race surface, unlike `score_up = score_up + ?` deltas
- the threshold where it'd matter (brigade load — thousands of votes/min on ONE hot comment) and what to switch to if that ever happens

One correction to the issue text: `votes` is a regular rowid table (migration `0007_votes.sql`), so the `value` filter costs a row fetch per PK-index hit — a range scan + fetch, not truly index-only. Same O(N) conclusion.

## Testing
- `npx vitest run tests/votes.test.ts` — 14 passed
- `npx tsc --noEmit` — clean (comment-only change)

Closes #12