### PR TITLE
fix(webhook): bound webhook_deliveries body size at enqueue time

### DIFF
--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -79,6 +79,15 @@ type WebhookEnv = {
 
 const TIMEOUT_MS = 5000;
 
+// Cap on the rendered body we'll persist to webhook_deliveries for retry
+// (issue #13). The table stores bodies verbatim so retries can re-send
+// them; a chatty event filter pointed at a flapping receiver could grow
+// the table inside the 30-day prune window. 64 KB is well above anything
+// the adapters emit (Slack/Discord bodies truncate under 2 KB; generic is
+// a small fixed-shape payload), so tripping this means something upstream
+// is misbehaving — the inline POST still fires, we just skip the queue.
+export const MAX_DELIVERY_BODY_BYTES = 64 * 1024;
+
 // Exponential backoff schedule (ms). Index 0 is "first retry after the
 // initial inline failure". After we've exhausted this list we mark the
 // delivery 'giveup' and bump the endpoint's fail_count.
@@ -196,16 +205,28 @@ const dispatchToEndpoint = async (
 		return;
 	}
 	const errorTag = result.error ?? `http_${result.status}`;
+	const bodyBytes = new TextEncoder().encode(body).byteLength;
 	log.warn("webhook.failed", {
 		endpoint_id: endpoint.id,
 		event: payload.event,
 		comment_id: payload.comment_id,
 		status: result.status,
 		error: errorTag,
+		body_bytes: bodyBytes,
 	});
 	// Synthetic env endpoint has no row to queue against — legacy fire-
 	// and-forget semantics. Real endpoints get a delivery row for retry.
 	if (endpoint.id === "_env") return;
+	if (bodyBytes > MAX_DELIVERY_BODY_BYTES) {
+		log.warn("webhook.delivery_body_too_large", {
+			endpoint_id: endpoint.id,
+			event: payload.event,
+			comment_id: payload.comment_id,
+			body_bytes: bodyBytes,
+			max_bytes: MAX_DELIVERY_BODY_BYTES,
+		});
+		return;
+	}
 	await enqueueWebhookDelivery(
 		env.DB,
 		endpoint.id,

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -10,7 +10,11 @@
  * condition that triggers the env-shim synthesis in loadEndpoints.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { dispatchWebhook, type WebhookPayload } from "../src/lib/webhook";
+import {
+	dispatchWebhook,
+	MAX_DELIVERY_BODY_BYTES,
+	type WebhookPayload,
+} from "../src/lib/webhook";
 import { log } from "../src/lib/log";
 
 // Minimal D1 stub: every .all() returns no rows (no webhook_endpoints
@@ -115,5 +119,105 @@ describe("WEBHOOK_URL env shim SSRF guard", () => {
 	it("allows public http:// for the legacy env shim (allowHttp carve-out)", async () => {
 		await dispatchWebhook(makeEnv("http://example.com/hook"), payload);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+// D1 stub with one enabled generic endpoint row; records every
+// webhook_deliveries INSERT so tests can assert whether a retry row was
+// queued. Row shape mirrors WebhookEndpointRow (enabled as 0/1, events
+// as a comma string or null) so toWebhookEndpoint maps it for real.
+const makeDbWithEndpoint = () => {
+	const inserts: unknown[][] = [];
+	const endpointRow = {
+		id: "01HE000000000000000000",
+		url: "https://example.com/hook",
+		secret: null,
+		events: null,
+		adapter: "generic",
+		enabled: 1,
+		fail_count: 0,
+		disabled_at: null,
+		created_at: 0,
+		updated_at: 0,
+	};
+	const db = {
+		prepare(sql: string) {
+			let bound: unknown[] = [];
+			return {
+				bind(...args: unknown[]) {
+					bound = args;
+					return this;
+				},
+				async first() {
+					return null;
+				},
+				async all() {
+					if (sql.includes("FROM webhook_endpoints")) {
+						return { results: [endpointRow] };
+					}
+					return { results: [] };
+				},
+				async run() {
+					if (sql.includes("INSERT INTO webhook_deliveries")) {
+						inserts.push(bound);
+					}
+					return {};
+				},
+			};
+		},
+	} as unknown as D1Database;
+	return { db, inserts };
+};
+
+describe("webhook_deliveries body cap (issue #13)", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// Receiver always fails → dispatch wants to queue a retry row.
+		fetchMock = vi.fn(async () => new Response("nope", { status: 500 }));
+		vi.stubGlobal("fetch", fetchMock);
+		warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		warnSpy.mockRestore();
+	});
+
+	it("queues a retry row for a normal-sized body", async () => {
+		const { db, inserts } = makeDbWithEndpoint();
+		await dispatchWebhook({ DB: db, ENV: "production" }, payload);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(inserts).toHaveLength(1);
+	});
+
+	it("skips the retry queue for an oversized body but still POSTs inline", async () => {
+		const { db, inserts } = makeDbWithEndpoint();
+		// Generic adapter stringifies the payload verbatim, so a huge slug
+		// pushes the rendered body past the cap.
+		const fat: WebhookPayload = {
+			...payload,
+			post_slug: "x".repeat(MAX_DELIVERY_BODY_BYTES + 1024),
+		};
+		await dispatchWebhook({ DB: db, ENV: "production" }, fat);
+		expect(fetchMock).toHaveBeenCalledTimes(1); // inline attempt still fires
+		expect(inserts).toHaveLength(0); // but nothing persisted
+		expect(warnSpy).toHaveBeenCalledWith(
+			"webhook.delivery_body_too_large",
+			expect.objectContaining({
+				max_bytes: MAX_DELIVERY_BODY_BYTES,
+				body_bytes: expect.any(Number),
+			}),
+		);
+	});
+
+	it("reports body_bytes on every failure log line", async () => {
+		const { db } = makeDbWithEndpoint();
+		await dispatchWebhook({ DB: db, ENV: "production" }, payload);
+		expect(warnSpy).toHaveBeenCalledWith(
+			"webhook.failed",
+			expect.objectContaining({ body_bytes: expect.any(Number) }),
+		);
 	});
 });


### PR DESCRIPTION
## Summary
Resolves #13 with mitigations **1 + 2** (option 3, the admin-page surface, deliberately left out per scope decision).

1. **Cap at insert** — new `MAX_DELIVERY_BODY_BYTES = 64 KB` (exported from `src/lib/webhook.ts`). If a failed dispatch's rendered body exceeds it, the retry row is skipped and `webhook.delivery_body_too_large` is logged with `body_bytes`/`max_bytes`. The inline POST still fires — only persistence is refused. 64 KB is far above adapter output (Slack/Discord truncate < 2 KB, generic is a fixed-shape payload), so tripping it signals upstream misbehavior.
2. **Size on every failure log** — `webhook.failed` now includes `body_bytes` so operators see growth trends in `wrangler tail` before it's a problem.

Log hygiene: only byte counts are logged, never body content.

## Tests (`tests/webhook.test.ts`, +3)
- normal-sized body on a failing receiver → retry row queued (captured via D1 stub recording `webhook_deliveries` INSERTs)
- oversized body → inline POST still fires, **no** retry row, `webhook.delivery_body_too_large` logged
- `body_bytes` present on every `webhook.failed` line

## Testing
- `npx vitest run` — 426 passed, 0 failed
- `npx tsc --noEmit` — clean

Closes #13