### PR TITLE
fix(import): single source of truth for Disqus upload size limit

### DIFF
--- a/src/admin-ui/pages/operator.ts
+++ b/src/admin-ui/pages/operator.ts
@@ -1,9 +1,14 @@
 import type { RerenderStats } from "../../db/rerender";
+import { MAX_XML_BYTES } from "../../lib/disqus-import";
 
 export type OperatorData = {
 	rerender: RerenderStats;
 	seed_demo_allowed: boolean;
 };
+
+// Human-readable form of the shared import cap for the UI hint + client
+// error message. Whole MB by construction (MAX_XML_BYTES is N * 1024²).
+const MAX_XML_MB = Math.floor(MAX_XML_BYTES / (1024 * 1024));
 
 export const renderOperator = (data: OperatorData): string => {
 	const { rerender, seed_demo_allowed } = data;
@@ -108,8 +113,8 @@ ${seedCard}
   includeSpam: false,
   async run(file) {
     if (!file) return;
-    if (file.size > 50 * 1024 * 1024) {
-      this.error = 'file too large (max 50 MB)';
+    if (file.size > ${MAX_XML_BYTES}) {
+      this.error = 'file too large (max ${MAX_XML_MB} MB)';
       return;
     }
     this.busy = true; this.error = null; this.result = null;
@@ -158,7 +163,7 @@ ${seedCard}
   <pre x-show="result" x-text="result &amp;&amp; JSON.stringify(result, null, 2)"
        style="background:var(--bg);padding:0.6rem;border-radius:4px;font-size:0.85rem"></pre>
   <p style="color:var(--bad)" x-show="error" x-text="error"></p>
-  <p class="muted">For large exports prefer the CLI: <code>npm run import-disqus -- ./export.xml --dry-run</code>.</p>
+  <p class="muted">Max upload: ${MAX_XML_MB} MB. For larger exports use the CLI: <code>npm run import-disqus -- ./export.xml --dry-run</code>.</p>
 </div>
 `;
 };

--- a/src/lib/disqus-import.ts
+++ b/src/lib/disqus-import.ts
@@ -65,7 +65,10 @@ export type DisqusExport = {
 	posts: DisqusPost[];
 };
 
-const MAX_XML_BYTES = 50 * 1024 * 1024;
+// Single source of truth for the import size cap (issue #15). The admin
+// upload route rejects content-length above this before reading the body,
+// and the operator page's client-side check + UI hint derive from it too.
+export const MAX_XML_BYTES = 50 * 1024 * 1024;
 
 const stripCdata = (s: string): string => {
 	const m = s.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -116,7 +116,7 @@ import {
 	type SubscriptionsFilters,
 } from "../admin-ui/pages/subscriptions";
 import { CURRENT_RENDERER_VERSION, renderMarkdown } from "../lib/markdown";
-import { runDisqusImport } from "../lib/disqus-import";
+import { MAX_XML_BYTES, runDisqusImport } from "../lib/disqus-import";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
 import { runSeedDemo } from "../db/seed-demo";
 import { renderConfirmEmailHtml } from "../lib/digest";
@@ -1525,23 +1525,22 @@ admin.post("/api/ops/rerender", async (c) => {
 //
 // Admin-only. Accepts a Disqus comment-export XML in the request body
 // (raw text/xml or application/xml). Idempotent — re-uploading the same
-// file inserts zero new rows. Capped at 50 MB to keep a hostile / huge
-// payload from running away inside the Worker; larger imports should go
-// through the CLI (`npm run import-disqus`).
-
-const MAX_IMPORT_BYTES = 50 * 1024 * 1024;
+// file inserts zero new rows. Capped at MAX_XML_BYTES (shared with the
+// parser and the operator page, so the three limits can't drift) to keep
+// a hostile / huge payload from running away inside the Worker; larger
+// imports should go through the CLI (`npm run import-disqus`).
 
 admin.post("/api/ops/import-disqus", async (c) => {
 	const user = await requireAdmin(c);
 	if (user instanceof Response) return user;
 
 	const contentLength = Number(c.req.header("content-length") ?? "0");
-	if (contentLength > MAX_IMPORT_BYTES) {
+	if (contentLength > MAX_XML_BYTES) {
 		return c.json({ error: "too_large" }, 413);
 	}
 	const xml = await c.req.text();
 	if (xml.length === 0) return c.json({ error: "empty_body" }, 400);
-	if (xml.length > MAX_IMPORT_BYTES) {
+	if (xml.length > MAX_XML_BYTES) {
 		return c.json({ error: "too_large" }, 413);
 	}
 	// Lightweight format sanity check before we hit the parser. Reject

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -15,6 +15,7 @@ import {
 	type SubscriptionsFilters,
 } from "../src/admin-ui/pages/subscriptions";
 import { renderOperator } from "../src/admin-ui/pages/operator";
+import { MAX_XML_BYTES } from "../src/lib/disqus-import";
 import { renderDashboard } from "../src/admin-ui/pages/dashboard";
 import { renderUpdateBanner } from "../src/admin-ui/layout";
 import type {
@@ -418,6 +419,19 @@ describe("renderOperator", () => {
 		});
 		expect(work).toContain(">Run rerender<");
 		expect(work).toContain("oldest stale at v1");
+	});
+
+	it("derives the import size check and UI hint from MAX_XML_BYTES (issue #15)", () => {
+		const html = renderOperator({
+			rerender: { current_version: 1, up_to_date: 10, stale: 0, oldest_version: null },
+			seed_demo_allowed: false,
+		});
+		const mb = Math.floor(MAX_XML_BYTES / (1024 * 1024));
+		// Client-side size check uses the shared constant, not a literal.
+		expect(html).toContain(`file.size > ${MAX_XML_BYTES}`);
+		// Visible hint + error message agree with it.
+		expect(html).toContain(`Max upload: ${mb} MB`);
+		expect(html).toContain(`file too large (max ${mb} MB)`);
 	});
 });
 


### PR DESCRIPTION
## Summary
Resolves #15. Findings against the issue's three action items:

1. **Confirm the limits match** — they did (all 50 MB), but as **four independent literals**: `MAX_XML_BYTES` (parser), `MAX_IMPORT_BYTES` (route), and a hardcoded `file.size` check + error string in the operator page. This PR exports `MAX_XML_BYTES` from `src/lib/disqus-import.ts` and derives everything else from it, so they can't drift.
2. **Route-layer content-length rejection** — **already implemented** (`src/routes/admin.ts` rejects `content-length > cap` with 413 before reading the body, plus a post-read recheck). Now it uses the shared constant.
3. **Document the limit on the operator page** — done: visible "Max upload: 50 MB" hint next to the CLI suggestion, and the client error message derives from the same constant.

No behavior change — same 50 MB everywhere; the server check remains authoritative, the client check is UX only.

## Tests
New render test pins the alignment: the Alpine `file.size` check, error message, and UI hint in the rendered operator page all match `MAX_XML_BYTES`.

- `npx vitest run` — 427 passed, 0 failed
- `npx tsc --noEmit` — clean

Closes #15