### PR TITLE
fix: address Copilot review follow-ups from #21 and #22

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1538,11 +1538,16 @@ admin.post("/api/ops/import-disqus", async (c) => {
 	if (contentLength > MAX_XML_BYTES) {
 		return c.json({ error: "too_large" }, 413);
 	}
-	const xml = await c.req.text();
-	if (xml.length === 0) return c.json({ error: "empty_body" }, 400);
-	if (xml.length > MAX_XML_BYTES) {
+	// Byte-accurate recheck for bodies that dodge the header check (e.g.
+	// chunked encoding with no content-length). String .length counts
+	// UTF-16 code units, which undercounts UTF-8 bytes for multibyte
+	// content — so measure the raw bytes before decoding.
+	const buf = await c.req.arrayBuffer();
+	if (buf.byteLength === 0) return c.json({ error: "empty_body" }, 400);
+	if (buf.byteLength > MAX_XML_BYTES) {
 		return c.json({ error: "too_large" }, 413);
 	}
+	const xml = new TextDecoder().decode(buf);
 	// Lightweight format sanity check before we hit the parser. Reject
 	// non-XML uploads up front so an operator who picks the wrong file
 	// gets a clear error rather than a parser stack trace.

--- a/tests/scheduled.test.ts
+++ b/tests/scheduled.test.ts
@@ -8,7 +8,7 @@
  * The two run* functions are mocked at the module boundary; everything
  * else in src/index.ts loads for real.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/lib/digest", async (importOriginal) => ({
 	...(await importOriginal<typeof import("../src/lib/digest")>()),
@@ -51,7 +51,10 @@ describe("scheduled handler pass isolation", () => {
 		vi.mocked(runDigest).mockReset().mockResolvedValue(undefined);
 		vi.mocked(runWebhookRetries).mockReset().mockResolvedValue(undefined);
 		errSpy = vi.spyOn(log, "error").mockImplementation(() => {});
-		return () => errSpy.mockRestore();
+	});
+
+	afterEach(() => {
+		errSpy.mockRestore();
 	});
 
 	it("runs both passes under separate waitUntil calls", async () => {


### PR DESCRIPTION
## Summary
Both merged PRs got post-merge Copilot review comments; this addresses them.

### 1. Byte-accurate Disqus upload recheck (from #21 — real finding)
The post-read recheck used `xml.length` (UTF-16 code units), which **undercounts** UTF-8 bytes for multibyte content. With a chunked upload and no `content-length` header, a multibyte payload could exceed the 50 MB byte cap by ~3-4×. Now the route reads the body as an `ArrayBuffer`, checks `byteLength` against `MAX_XML_BYTES`, then decodes. The fast `content-length` pre-check stays.

### 2. Explicit `afterEach` in scheduled tests (from #22 — false positive, fixed for clarity)
Copilot claimed Vitest ignores a cleanup function returned from `beforeEach` — it doesn't ([documented Vitest behavior](https://vitest.dev/api/#beforeeach), unlike Jest). Switched to an explicit `afterEach` anyway so intent is unambiguous.

## Testing
- `npx vitest run` — 430 passed, 0 failed
- `npx tsc --noEmit` — clean