### PR TITLE
docs(agents): correct three claims flagged by Copilot review on #24

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -111,7 +111,7 @@ Three configuration surfaces:
 | `WEBHOOK_URL` | secret | Legacy single-URL webhook (fire-and-forget, no retries). Only honored when no endpoints are configured on `/admin/webhooks` — prefer endpoint rows (signed, retried, per-event filters). | `https://example.com/hook` | `wrangler secret put` / `.dev.vars` |
 | `VOTING_ENABLED` | var | Comment voting (up/down buttons in the widget). Defaults **on** when unset; set `0`/`false`/`no`/`off` to disable instance-wide. | `true` | `wrangler.toml` |
 | `DOWNVOTES_ENABLED` | var | Downvote button. Same defaults-on semantics; implicitly off when voting is off. | `true` | `wrangler.toml` |
-| `CF_ACCOUNT_ID` | var | Optional. Cloudflare account ID; paired with `CF_API_TOKEN` to enable the `/admin/usage` analytics page. | `0123abcd...` | `wrangler.toml` |
+| `CF_ACCOUNT_ID` | var | Optional. Cloudflare account ID; paired with `CF_API_TOKEN` to enable the `/admin/usage` analytics page. | `0123abcd...` | `wrangler.toml` (or `wrangler secret put` — the in-app setup guide uses the secret form; both work) |
 | `CF_API_TOKEN` | secret | Optional. Cloudflare API token (Analytics read scope) for `/admin/usage`. The page renders setup instructions when either value is unset. | `...` | `wrangler secret put` / `.dev.vars` |
 
 Bindings (D1, KV, Analytics) live in `wrangler.toml` outside `[vars]`
@@ -311,9 +311,11 @@ numbered file. When upgrading an existing install, re-running
   user detail page. OAuth signups matching `ADMIN_EMAILS` are
   auto-admin.
 
-**Admin UI.** `/admin` requires an OAuth sign-in with the `admin` role
-(or `mod` for the moderation surfaces listed above). Server-rendered
-HTML + Alpine.js, no SPA.
+**Admin UI.** `/admin` requires an OAuth sign-in with the `mod` or
+`admin` role. Mods see the moderation surfaces — dashboard, queue,
+single-comment view, saved replies, about; everything else (users,
+audit, subscriptions, operator, settings, webhooks, usage) is
+admin-only. Server-rendered HTML + Alpine.js, no SPA.
 
 Pages (top nav):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,12 +212,13 @@ host-page wiring:
   (both default **on**; downvotes are implicitly off when voting is
   off). Integrators see the buttons only when the instance has them
   enabled.
-- **API shape.** Each comment carries `score_up` and `score_down`
-  counters. Authenticated viewers also get `my_vote` (`-1 | 0 | 1`) in
-  the list response; anonymous list responses omit it (the cached tree
-  is shared). Votes are cast via `POST /api/v1/votes` with
-  `{comment_id, value}` where `value` is `-1 | 0 | 1` (`0` clears the
-  vote); the response returns the fresh counters plus `my_vote`.
+- **API shape.** Each comment carries `score_up`, `score_down`, and
+  `my_vote` (`-1 | 0 | 1`). `my_vote` is only meaningful for
+  authenticated viewers — anonymous list responses always carry `0`
+  (the first page is KV-cached and shared across anonymous viewers).
+  Votes are cast via `POST /api/v1/votes` with `{comment_id, value}`
+  where `value` is `-1 | 0 | 1` (`0` clears the vote); the response
+  returns the fresh counters plus `my_vote`.
 - **Anonymous viewers can vote.** They use the same IP-hashed ghost
   identity as anonymous comments — one vote per identity per comment.
   Authors cannot vote on their own comments.


### PR DESCRIPTION
Post-merge Copilot review on #24 flagged three factual issues — all three verified correct against source and fixed:

1. **`my_vote` is never omitted** — `buildTree` always emits it (`src/lib/tree.ts:156`); anonymous viewers get `0` because their first page is KV-cached and shared. AGENTS.md previously said the field was omitted.
2. **`/admin` dashboard is mod-accessible** — `GET /admin` is `requireMod`. Docs now spell out the exact split: mods get dashboard, queue, comment detail, saved replies, about; users/audit/subscriptions/operator/settings/webhooks/usage are admin-only (verified per-route).
3. **`CF_ACCOUNT_ID` var-or-secret** — the in-app `/admin/usage` setup guide instructs `wrangler secret put CF_ACCOUNT_ID`; the runtime reads either. The env table now documents both forms.

Tests: 430 passed.