### PR TITLE
feat: configurable comment pagination + collapsible nested replies

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -115,6 +115,9 @@ Three configuration surfaces:
 | `DOWNVOTES_ENABLED` | var | Downvote button. Same defaults-on semantics. Applies to **both** comment votes and page votes (a brigading-mitigation switch); independent of `VOTING_ENABLED`. | `true` | `wrangler.toml` |
 | `PAGE_REACTIONS_ENABLED` | var | Article-level emoji reaction bar (react to the page itself, no comment). Defaults **off** so an upgrade never surfaces new UI unasked. Enables `POST /api/v1/page-engagement/reactions` and the widget bar. | `false` | `wrangler.toml` |
 | `PAGE_VOTES_ENABLED` | var | Article-level "was this helpful?" up/down vote tally. Defaults **off**. Enables `POST /api/v1/page-engagement/votes`; downvotes here still honor `DOWNVOTES_ENABLED`. | `false` | `wrangler.toml` |
+| `COMMENTS_PER_PAGE` | var | Top-level comments shown per initial load and per "Load older comments" click (server-side slice in `api.comments.ts`). Defaults **25**; clamped to `[1, 200]`. **Behavior change in v1.10.0:** older installs rendered up to 100 at once — set this to `100` to restore that. | `25` | `wrangler.toml` |
+| `REPLIES_PER_THREAD` | var | Replies shown under each comment before a "Show N more replies" button (widget). `0` = show all. Defaults **3**; clamped to `[0, 100]`. | `3` | `wrangler.toml` |
+| `AUTO_COLLAPSE_DEPTH` | var | Replies nested at this depth or deeper start collapsed in the widget. `0` = never auto-collapse. Defaults **3**; clamped to `[0, 4]` (the tree depth cap). | `3` | `wrangler.toml` |
 | `CF_ACCOUNT_ID` | var | Optional. Cloudflare account ID; paired with `CF_API_TOKEN` to enable the `/admin/usage` analytics page. | `0123abcd...` | `wrangler.toml` (or `wrangler secret put` — the in-app setup guide uses the secret form; both work) |
 | `CF_API_TOKEN` | secret | Optional. Cloudflare API token (Analytics read scope) for `/admin/usage`. The page renders setup instructions when either value is unset. | `...` | `wrangler secret put` / `.dev.vars` |
 
@@ -141,6 +144,29 @@ busted on save, so a toggle takes effect within seconds across the widget
 (`/api/v1/config`) and the server-side gates. Leaving a flag untouched in
 the admin UI writes no row, so existing installs that only set env vars are
 unaffected. Implementation: `src/lib/settings.ts`.
+
+### Display & pagination: numeric settings (since v1.10.0)
+
+`COMMENTS_PER_PAGE`, `REPLIES_PER_THREAD`, and `AUTO_COLLAPSE_DEPTH` follow the
+**same hybrid precedence** as the feature flags (DB settings row > env var >
+default) and are edited from the same **Settings → Display & pagination**
+section. They're integers, each clamped to a `[min, max]` range server-side, so
+a junk or hostile value (negative, or a `COMMENTS_PER_PAGE` large enough to
+slice an enormous in-memory page) can never reach the slice/render paths —
+out-of-range values clamp, non-numeric values fall back to the default.
+
+- `COMMENTS_PER_PAGE` is consumed **server-side**: it drives the top-level
+  slice in `GET /api/v1/comments` and is baked into the first-page KV cache key
+  (`tree:<slug>:first:<sort>:n<size>`), so changing it never serves a
+  stale-sized page. Both `sort=new` and `sort=top` paginate, so shrinking the
+  page size never hides top-voted threads past the first page.
+- `REPLIES_PER_THREAD` and `AUTO_COLLAPSE_DEPTH` are consumed **client-side**:
+  the widget reads them from `/api/v1/config` and uses them purely for reply
+  folding (no API/payload change — all replies still arrive in one response).
+
+**Upgrade note:** installs upgrading to v1.10.0 that never set `COMMENTS_PER_PAGE`
+will see **25** initial comments instead of the previous ~100. Set it to `100`
+(env var or Settings page) to restore the old behavior.
 
 ## 6. `ALLOWED_ORIGINS` deep-dive
 

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -115,7 +115,7 @@ Three configuration surfaces:
 | `DOWNVOTES_ENABLED` | var | Downvote button. Same defaults-on semantics. Applies to **both** comment votes and page votes (a brigading-mitigation switch); independent of `VOTING_ENABLED`. | `true` | `wrangler.toml` |
 | `PAGE_REACTIONS_ENABLED` | var | Article-level emoji reaction bar (react to the page itself, no comment). Defaults **off** so an upgrade never surfaces new UI unasked. Enables `POST /api/v1/page-engagement/reactions` and the widget bar. | `false` | `wrangler.toml` |
 | `PAGE_VOTES_ENABLED` | var | Article-level "was this helpful?" up/down vote tally. Defaults **off**. Enables `POST /api/v1/page-engagement/votes`; downvotes here still honor `DOWNVOTES_ENABLED`. | `false` | `wrangler.toml` |
-| `COMMENTS_PER_PAGE` | var | Top-level comments shown per initial load and per "Load older comments" click (server-side slice in `api.comments.ts`). Defaults **25**; clamped to `[1, 200]`. **Behavior change in v1.10.0:** older installs rendered up to 100 at once — set this to `100` to restore that. | `25` | `wrangler.toml` |
+| `COMMENTS_PER_PAGE` | var | Top-level comments shown per initial load and per "Load older comments" click (server-side slice in `api.comments.ts`). Defaults **25**; clamped to `[1, 200]`. **Behavior change in v1.11.0:** older installs rendered up to 100 at once — set this to `100` to restore that. | `25` | `wrangler.toml` |
 | `REPLIES_PER_THREAD` | var | Replies shown under each comment before a "Show N more replies" button (widget). `0` = show all. Defaults **3**; clamped to `[0, 100]`. | `3` | `wrangler.toml` |
 | `AUTO_COLLAPSE_DEPTH` | var | Replies nested at this depth or deeper start collapsed in the widget. `0` = never auto-collapse. Defaults **3**; clamped to `[0, 4]` (the tree depth cap). | `3` | `wrangler.toml` |
 | `CF_ACCOUNT_ID` | var | Optional. Cloudflare account ID; paired with `CF_API_TOKEN` to enable the `/admin/usage` analytics page. | `0123abcd...` | `wrangler.toml` (or `wrangler secret put` — the in-app setup guide uses the secret form; both work) |
@@ -145,7 +145,7 @@ busted on save, so a toggle takes effect within seconds across the widget
 the admin UI writes no row, so existing installs that only set env vars are
 unaffected. Implementation: `src/lib/settings.ts`.
 
-### Display & pagination: numeric settings (since v1.10.0)
+### Display & pagination: numeric settings (since v1.11.0)
 
 `COMMENTS_PER_PAGE`, `REPLIES_PER_THREAD`, and `AUTO_COLLAPSE_DEPTH` follow the
 **same hybrid precedence** as the feature flags (DB settings row > env var >
@@ -164,7 +164,7 @@ out-of-range values clamp, non-numeric values fall back to the default.
   the widget reads them from `/api/v1/config` and uses them purely for reply
   folding (no API/payload change — all replies still arrive in one response).
 
-**Upgrade note:** installs upgrading to v1.10.0 that never set `COMMENTS_PER_PAGE`
+**Upgrade note:** installs upgrading to v1.11.0 that never set `COMMENTS_PER_PAGE`
 will see **25** initial comments instead of the previous ~100. Set it to `100`
 (env var or Settings page) to restore the old behavior.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,34 @@ what you preview is byte-identical to what gets posted, with no
 client-side markdown library and no XSS divergence. The endpoint is
 public but rate-limited; no auth required.
 
+### Pagination and reply collapsing (since v1.10.0)
+
+The thread no longer dumps every comment into the page at once. Three
+operator-tunable settings (Settings → Display & pagination, or the
+`COMMENTS_PER_PAGE` / `REPLIES_PER_THREAD` / `AUTO_COLLAPSE_DEPTH` env vars —
+see AGENTS-OPERATE.md §5) control the volume:
+
+- **Top-level paging.** The list loads `COMMENTS_PER_PAGE` threads (default
+  **25**) with a **"Load older comments"** button that appends the next batch.
+  Paging is server-side and cursor-based; both `new` and `top` sorts paginate,
+  so a small page size never hides high-scoring threads. **Behavior change:**
+  pre-v1.10.0 installs rendered up to ~100 at once — set `COMMENTS_PER_PAGE=100`
+  to restore that.
+- **Per-comment collapse.** Any comment with replies gets a `▸`/`▾` toggle that
+  folds its reply subtree — always present, no setting needed.
+- **"Show N more replies."** Each parent renders the first `REPLIES_PER_THREAD`
+  replies (default **3**) then a button to reveal the rest. `0` = show all.
+- **Auto-collapse depth.** Replies at `AUTO_COLLAPSE_DEPTH` or deeper (default
+  **3**) start folded so a hot deep thread doesn't shove the page down. `0` =
+  never auto-collapse.
+
+Reply collapsing is **purely client-side** — all replies still arrive in the
+single list response; the widget folds them. There is no `data-*` per-page
+override; these are instance-wide. The new affordances inherit the existing
+theming variables — the collapse toggle from `--garrul-muted`, the
+"Show N more replies" / "Load older comments" buttons from `--garrul-link`
+(see `docs/THEMING.md`).
+
 ## 5. Styling
 
 The widget mounts in a Shadow DOM, so host CSS does NOT leak in. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,7 @@ what you preview is byte-identical to what gets posted, with no
 client-side markdown library and no XSS divergence. The endpoint is
 public but rate-limited; no auth required.
 
-### Pagination and reply collapsing (since v1.10.0)
+### Pagination and reply collapsing (since v1.11.0)
 
 The thread no longer dumps every comment into the page at once. Three
 operator-tunable settings (Settings → Display & pagination, or the
@@ -273,7 +273,7 @@ see AGENTS-OPERATE.md §5) control the volume:
   **25**) with a **"Load older comments"** button that appends the next batch.
   Paging is server-side and cursor-based; both `new` and `top` sorts paginate,
   so a small page size never hides high-scoring threads. **Behavior change:**
-  pre-v1.10.0 installs rendered up to ~100 at once — set `COMMENTS_PER_PAGE=100`
+  pre-v1.11.0 installs rendered up to ~100 at once — set `COMMENTS_PER_PAGE=100`
   to restore that.
 - **Per-comment collapse.** Any comment with replies gets a `▸`/`▾` toggle that
   folds its reply subtree — always present, no setting needed.

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -40,13 +40,13 @@ Or in a stylesheet:
 | `--garrul-font-size`      | `15px`                                   | Base font size                        |
 | `--garrul-fg`             | `#1a1a1a`                                | Primary text color                    |
 | `--garrul-bg`             | `transparent`                            | Widget background                     |
-| `--garrul-muted`          | `#6b7280`                                | Timestamps, "be the first…" message   |
+| `--garrul-muted`          | `#6b7280`                                | Timestamps, "be the first…" message, the reply collapse toggle (`▸`/`▾`) |
 | `--garrul-border`         | `#d0d3d8`                                | Input borders                         |
 | `--garrul-radius`         | `6px`                                    | Border-radius on inputs and buttons   |
 | `--garrul-input-bg`       | `#fff`                                   | Input + textarea background           |
 | `--garrul-accent`         | `#2563eb`                                | Submit button background              |
 | `--garrul-accent-fg`      | `#fff`                                   | Submit button text                    |
-| `--garrul-link`           | `#2563eb`                                | Link color in comment bodies          |
+| `--garrul-link`           | `#2563eb`                                | Link color in comment bodies, the "Show N more replies" / "Load older comments" buttons |
 | `--garrul-error`          | `#b91c1c`                                | Error message color                   |
 | `--garrul-badge-bg`       | `#e0e7ff`                                | "Verified" badge background           |
 | `--garrul-badge-fg`       | `#1e3a8a`                                | "Verified" badge text                 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 1,

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -130,6 +130,21 @@
       "name": "PAGE_VOTES_ENABLED",
       "required": false,
       "addedIn": "1.10.0"
+    },
+    {
+      "name": "COMMENTS_PER_PAGE",
+      "required": false,
+      "addedIn": "1.10.0"
+    },
+    {
+      "name": "REPLIES_PER_THREAD",
+      "required": false,
+      "addedIn": "1.10.0"
+    },
+    {
+      "name": "AUTO_COLLAPSE_DEPTH",
+      "required": false,
+      "addedIn": "1.10.0"
     }
   ],
   "kvNamespaces": [

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -1,5 +1,11 @@
 import type { Bindings } from "../../index";
-import type { FlagKey, ResolvedFlags } from "../../lib/settings";
+import {
+	type FlagKey,
+	type NumberKey,
+	type ResolvedFlags,
+	type ResolvedNumbers,
+	numberBounds,
+} from "../../lib/settings";
 import { escapeHtml } from "../escape";
 
 // Operator-facing labels + help for each runtime feature flag. Order here is
@@ -37,7 +43,32 @@ const FLAG_META: { key: FlagKey; label: string; help: string }[] = [
 	},
 ];
 
-export const renderSettings = (env: Bindings, flags: ResolvedFlags): string => {
+// Operator-facing labels + help for each numeric display setting. Bounds are
+// pulled from the settings registry so the input min/max can't drift from the
+// server-side clamp.
+const NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
+	{
+		key: "comments_per_page",
+		label: "Comments per page",
+		help: "Top-level comments shown per initial load. \"Load older comments\" reveals the next batch.",
+	},
+	{
+		key: "replies_per_thread",
+		label: "Replies before “show more”",
+		help: "Replies shown under each comment before a “Show N more replies” button. 0 = show all.",
+	},
+	{
+		key: "auto_collapse_depth",
+		label: "Auto-collapse depth",
+		help: "Replies nested at this depth or deeper start collapsed. 0 = never auto-collapse.",
+	},
+];
+
+export const renderSettings = (
+	env: Bindings,
+	flags: ResolvedFlags,
+	numbers: ResolvedNumbers,
+): string => {
 	const rows: [string, string][] = [
 		["ENV", env.ENV ?? "(unset)"],
 		["ALLOWED_ORIGINS", env.ALLOWED_ORIGINS ?? "(unset)"],
@@ -82,21 +113,40 @@ export const renderSettings = (env: Bindings, flags: ResolvedFlags): string => {
     </div>`;
 	}).join("");
 
+	// Numeric display settings. Each input reflects the resolved effective
+	// value; min/max mirror the server-side clamp (numberBounds).
+	const numberInputs = NUMBER_META.map((f) => {
+		const b = numberBounds(f.key);
+		return `
+    <div class="flag-row">
+      <label>
+        <input type="number" name="${f.key}" min="${b.min}" max="${b.max}" step="1"
+               x-model.number="nums.${f.key}" style="width:5rem">
+        <strong>${escapeHtml(f.label)}</strong>
+      </label>
+      <span class="muted">${escapeHtml(f.help)}</span>
+    </div>`;
+	}).join("");
+
 	const initial = JSON.stringify(
 		Object.fromEntries(FLAG_META.map((f) => [f.key, flags[f.key]])),
+	);
+	const numInitial = JSON.stringify(
+		Object.fromEntries(NUMBER_META.map((f) => [f.key, numbers[f.key]])),
 	);
 
 	return `
 <div class="card" x-data="{
   busy: false,
   flags: ${escapeHtml(initial)},
+  nums: ${escapeHtml(numInitial)},
   async save() {
     this.busy = true;
     try {
       const r = await fetch('/admin/settings', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ flags: this.flags }),
+        body: JSON.stringify({ flags: this.flags, numbers: this.nums }),
       });
       if (!r.ok) {
         const j = await r.json().catch(() => ({}));
@@ -137,8 +187,13 @@ export const renderSettings = (env: Bindings, flags: ResolvedFlags): string => {
   defaults apply again.</p>
   <form @submit.prevent="save()">
     ${toggles}
+    <h3 style="margin-top:1.25rem">Display &amp; pagination</h3>
+    <p class="muted">Control how many comments load at once and how nested
+    replies collapse. Smaller values keep a busy thread from pushing the rest
+    of the page down.</p>
+    ${numberInputs}
     <p style="margin-top:1rem">
-      <button type="submit" :disabled="busy">Save features</button>
+      <button type="submit" :disabled="busy">Save settings</button>
       <button type="button" class="secondary" @click="reset()" :disabled="busy">Reset to defaults</button>
     </p>
   </form>

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,14 @@ export type Bindings = {
 	REACTIONS_ENABLED?: string;
 	PAGE_REACTIONS_ENABLED?: string;
 	PAGE_VOTES_ENABLED?: string;
+	// Numeric display settings. Env-var *defaults*; a row in the `settings`
+	// table overrides the matching one at runtime (see src/lib/settings.ts).
+	//   COMMENTS_PER_PAGE   — top-level threads per initial load + Load-more.
+	//   REPLIES_PER_THREAD  — replies shown per parent before "Show N more"; 0 = all.
+	//   AUTO_COLLAPSE_DEPTH — replies at depth >= this start collapsed; 0 = never.
+	COMMENTS_PER_PAGE?: string;
+	REPLIES_PER_THREAD?: string;
+	AUTO_COLLAPSE_DEPTH?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -22,6 +22,7 @@
  */
 import type { Bindings } from "../index";
 import { getAllSettings } from "../db/queries";
+import { MAX_DEPTH } from "./tree";
 
 export type FlagKey =
 	| "comments_enabled"
@@ -69,8 +70,14 @@ const NUMBERS: Record<
 	// 0 = show all replies.
 	replies_per_thread: { env: "REPLIES_PER_THREAD", default: 3, min: 0, max: 100 },
 	// A comment at depth >= this starts with its replies collapsed (widget).
-	// 0 = never auto-collapse. Capped at the tree's MAX_DEPTH (4).
-	auto_collapse_depth: { env: "AUTO_COLLAPSE_DEPTH", default: 3, min: 0, max: 4 },
+	// 0 = never auto-collapse. Capped at the tree's MAX_DEPTH so the clamp
+	// tracks the depth cap if it ever changes.
+	auto_collapse_depth: {
+		env: "AUTO_COLLAPSE_DEPTH",
+		default: 3,
+		min: 0,
+		max: MAX_DEPTH,
+	},
 };
 
 export const NUMBER_KEYS = Object.keys(NUMBERS) as NumberKey[];

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -33,6 +33,13 @@ export type FlagKey =
 
 export type ResolvedFlags = Record<FlagKey, boolean>;
 
+export type NumberKey =
+	| "comments_per_page"
+	| "replies_per_thread"
+	| "auto_collapse_depth";
+
+export type ResolvedNumbers = Record<NumberKey, number>;
+
 // Each flag's env-var source and hardcoded default. `votes_enabled` /
 // `downvotes_enabled` keep their legacy env names so existing wrangler.toml
 // vars keep working.
@@ -47,7 +54,37 @@ const FLAGS: Record<FlagKey, { env: keyof Bindings; default: boolean }> = {
 
 export const FLAG_KEYS = Object.keys(FLAGS) as FlagKey[];
 
+// Numeric display settings. Same precedence chain as FLAGS (DB > env >
+// default), but each carries a [min, max] clamp so a junk or hostile value
+// (negative, or a huge `comments_per_page` that would slice an enormous
+// in-memory page) can't reach the slice/render paths.
+const NUMBERS: Record<
+	NumberKey,
+	{ env: keyof Bindings; default: number; min: number; max: number }
+> = {
+	// Top-level threads per initial load and per Load-more click (server-side
+	// slice in api.comments.ts).
+	comments_per_page: { env: "COMMENTS_PER_PAGE", default: 25, min: 1, max: 200 },
+	// Replies shown per parent before a "Show N more replies" button (widget).
+	// 0 = show all replies.
+	replies_per_thread: { env: "REPLIES_PER_THREAD", default: 3, min: 0, max: 100 },
+	// A comment at depth >= this starts with its replies collapsed (widget).
+	// 0 = never auto-collapse. Capped at the tree's MAX_DEPTH (4).
+	auto_collapse_depth: { env: "AUTO_COLLAPSE_DEPTH", default: 3, min: 0, max: 4 },
+};
+
+export const NUMBER_KEYS = Object.keys(NUMBERS) as NumberKey[];
+
+/** Min/max clamp bounds for a numeric setting (used by the admin UI inputs). */
+export const numberBounds = (
+	key: NumberKey,
+): { default: number; min: number; max: number } => {
+	const { default: def, min, max } = NUMBERS[key];
+	return { default: def, min, max };
+};
+
 const CACHE_KEY = "settings:flags";
+const CACHE_KEY_NUMBERS = "settings:numbers";
 const CACHE_TTL_SEC = 60;
 
 // Defaults-on/off boolish parse: present + falsy → false; anything else
@@ -59,6 +96,38 @@ const parseBool = (raw: string | undefined, fallback: boolean): boolean => {
 	if (v === "") return fallback;
 	if (v === "0" || v === "false" || v === "no" || v === "off") return false;
 	return true;
+};
+
+// Parse an integer setting and clamp it into [min, max]. Junk / empty / NaN
+// falls back to `fallback` (which callers pass already inside the bounds).
+export const parseIntSetting = (
+	raw: string | undefined,
+	fallback: number,
+	min: number,
+	max: number,
+): number => {
+	if (raw == null) return fallback;
+	const v = raw.trim();
+	if (v === "") return fallback;
+	const n = Number.parseInt(v, 10);
+	if (!Number.isFinite(n)) return fallback;
+	return Math.min(max, Math.max(min, n));
+};
+
+const resolveNumbers = (
+	env: Bindings,
+	dbSettings: Record<string, string>,
+): ResolvedNumbers => {
+	const out = {} as ResolvedNumbers;
+	for (const key of NUMBER_KEYS) {
+		const spec = NUMBERS[key];
+		const raw =
+			key in dbSettings
+				? dbSettings[key]
+				: (env[spec.env] as string | undefined);
+		out[key] = parseIntSetting(raw, spec.default, spec.min, spec.max);
+	}
+	return out;
 };
 
 const resolve = (
@@ -95,3 +164,24 @@ export const loadFlags = async (env: Bindings): Promise<ResolvedFlags> => {
 /** Drop the cached resolved flags so the next read reflects a fresh save. */
 export const bustFlagsCache = (env: Bindings): Promise<void> =>
 	env.TREE_CACHE.delete(CACHE_KEY).catch(() => {});
+
+/**
+ * Resolve all numeric display settings (DB override > env > default), KV-cached
+ * under its own key so it doesn't disturb the boolean-flag cache entry/tests.
+ */
+export const loadNumbers = async (env: Bindings): Promise<ResolvedNumbers> => {
+	const cached = await env.TREE_CACHE.get(CACHE_KEY_NUMBERS, "json").catch(
+		() => null,
+	);
+	if (cached) return cached as ResolvedNumbers;
+	const dbSettings = await getAllSettings(env.DB);
+	const numbers = resolveNumbers(env, dbSettings);
+	await env.TREE_CACHE.put(CACHE_KEY_NUMBERS, JSON.stringify(numbers), {
+		expirationTtl: CACHE_TTL_SEC,
+	}).catch(() => {});
+	return numbers;
+};
+
+/** Drop the cached resolved numbers so the next read reflects a fresh save. */
+export const bustNumbersCache = (env: Bindings): Promise<void> =>
+	env.TREE_CACHE.delete(CACHE_KEY_NUMBERS).catch(() => {});

--- a/src/lib/tree-cache.ts
+++ b/src/lib/tree-cache.ts
@@ -20,5 +20,10 @@ export const bustTreeCache = async (
 		prefix: `tree:${slug}:first`,
 	}).catch(() => null);
 	if (!listed) return;
-	await Promise.all(listed.keys.map((k) => env.TREE_CACHE.delete(k.name)));
+	// Swallow per-key delete failures: cache busting is best-effort and must
+	// never turn a transient KV hiccup into a failed user-visible write
+	// (comment post / edit / delete / reaction all call this).
+	await Promise.all(
+		listed.keys.map((k) => env.TREE_CACHE.delete(k.name).catch(() => {})),
+	);
 };

--- a/src/lib/tree-cache.ts
+++ b/src/lib/tree-cache.ts
@@ -1,0 +1,24 @@
+/**
+ * First-page comment-tree cache invalidation.
+ *
+ * GET /api/v1/comments caches the first page per slug in KV under
+ * `tree:<slug>:first:<sort>:n<size>` — keyed by sort AND the operator-tunable
+ * page size. Because the size is variable, a write path can't enumerate the
+ * exact keys to delete; it prefix-lists instead. The `:first` suffix bounds the
+ * prefix to first-page keys (and catches the legacy `tree:<slug>:first` key
+ * from before the sort/size split).
+ *
+ * Best-effort: older pages bypass the cache entirely, so a brief stale first
+ * page is the worst case. Every comment mutation (create / edit / delete /
+ * moderate / react) calls this so the public reader path stays fresh.
+ */
+export const bustTreeCache = async (
+	env: { TREE_CACHE: KVNamespace },
+	slug: string,
+): Promise<void> => {
+	const listed = await env.TREE_CACHE.list({
+		prefix: `tree:${slug}:first`,
+	}).catch(() => null);
+	if (!listed) return;
+	await Promise.all(listed.keys.map((k) => env.TREE_CACHE.delete(k.name)));
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -662,7 +662,7 @@ admin.post("/settings", async (c) => {
 	const numbersObj =
 		body.numbers && typeof body.numbers === "object" ? body.numbers : null;
 	if (!flagsObj && !numbersObj) {
-		return c.json({ error: "flags_required" }, 400);
+		return c.json({ error: "settings_required" }, 400);
 	}
 
 	// Only persist known keys; ignore anything else the client sends.
@@ -698,7 +698,7 @@ admin.post("/settings", async (c) => {
 		Object.keys(writtenFlags).length === 0 &&
 		Object.keys(writtenNumbers).length === 0
 	) {
-		return c.json({ error: "flags_required" }, 400);
+		return c.json({ error: "settings_required" }, 400);
 	}
 
 	for (const [key, value] of Object.entries(writtenFlags)) {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -98,7 +98,15 @@ import { renderUserDetail } from "../admin-ui/pages/user-detail";
 import { renderUsers } from "../admin-ui/pages/users";
 import { renderOperator } from "../admin-ui/pages/operator";
 import { renderSettings } from "../admin-ui/pages/settings";
-import { bustFlagsCache, FLAG_KEYS, loadFlags } from "../lib/settings";
+import {
+	bustFlagsCache,
+	bustNumbersCache,
+	FLAG_KEYS,
+	loadFlags,
+	loadNumbers,
+	NUMBER_KEYS,
+	numberBounds,
+} from "../lib/settings";
 import { bustTreeCache } from "../lib/tree-cache";
 import {
 	renderWebhookForm,
@@ -602,21 +610,31 @@ admin.get("/operator", async (c) => {
 admin.get("/settings", async (c) => {
 	const user = await requireAdmin(c);
 	if (user instanceof Response) return user;
-	const [updateInfo, flags] = await Promise.all([
+	const [updateInfo, flags, numbers] = await Promise.all([
 		peekCachedLatestVersion(c.env),
 		loadFlags(c.env),
+		loadNumbers(c.env),
 	]);
 	return c.html(
-		renderPage(c, "Settings", renderSettings(c.env, flags), user, updateInfo),
+		renderPage(
+			c,
+			"Settings",
+			renderSettings(c.env, flags, numbers),
+			user,
+			updateInfo,
+		),
 	);
 });
 
-// Persist runtime feature-flag overrides. Body is either
-//   { flags: { comments_enabled: bool, … } }  — write an override per flag
-//   { reset: true }                            — clear all overrides
+// Persist runtime settings overrides. Body is either
+//   { flags: { comments_enabled: bool, … },     — boolean feature toggles
+//     numbers: { comments_per_page: 25, … } }    — numeric display settings
+//   { reset: true }                              — clear all overrides
+// flags and numbers are independent; either or both may be present.
 // Admin-only; same-origin CSRF check is enforced by the admin middleware.
 type SettingsBody = {
 	flags?: Record<string, unknown>;
+	numbers?: Record<string, unknown>;
 	reset?: unknown;
 };
 
@@ -627,48 +645,81 @@ admin.post("/settings", async (c) => {
 	if (!body) return c.json({ error: "invalid_body" }, 400);
 
 	if (body.reset === true) {
-		await deleteSettings(c.env.DB, FLAG_KEYS);
-		await bustFlagsCache(c.env);
+		await deleteSettings(c.env.DB, [...FLAG_KEYS, ...NUMBER_KEYS]);
+		await Promise.all([bustFlagsCache(c.env), bustNumbersCache(c.env)]);
 		await adminInsertAudit(c.env.DB, {
 			admin_id: user.id,
 			action: "settings.update",
 			target_kind: "system",
-			target_id: "flags",
+			target_id: "settings",
 			meta: { reset: true },
 		});
 		return c.json({ ok: true, reset: true });
 	}
 
-	if (!body.flags || typeof body.flags !== "object") {
+	const flagsObj =
+		body.flags && typeof body.flags === "object" ? body.flags : null;
+	const numbersObj =
+		body.numbers && typeof body.numbers === "object" ? body.numbers : null;
+	if (!flagsObj && !numbersObj) {
 		return c.json({ error: "flags_required" }, 400);
 	}
 
-	// Only persist known flags; ignore anything else the client sends.
-	const written: Record<string, boolean> = {};
-	for (const key of FLAG_KEYS) {
-		const raw = body.flags[key];
-		if (raw === undefined) continue;
-		if (typeof raw !== "boolean") {
-			return c.json({ error: `invalid_flag:${key}` }, 400);
+	// Only persist known keys; ignore anything else the client sends.
+	const writtenFlags: Record<string, boolean> = {};
+	if (flagsObj) {
+		for (const key of FLAG_KEYS) {
+			const raw = flagsObj[key];
+			if (raw === undefined) continue;
+			if (typeof raw !== "boolean") {
+				return c.json({ error: `invalid_flag:${key}` }, 400);
+			}
+			writtenFlags[key] = raw;
 		}
-		written[key] = raw;
 	}
-	if (Object.keys(written).length === 0) {
+
+	// Numbers are validated and clamped into their declared [min,max] so a
+	// hostile or fat-fingered value can't reach the slice/render paths.
+	const writtenNumbers: Record<string, number> = {};
+	if (numbersObj) {
+		for (const key of NUMBER_KEYS) {
+			const raw = numbersObj[key];
+			if (raw === undefined) continue;
+			const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+			if (!Number.isFinite(n)) {
+				return c.json({ error: `invalid_number:${key}` }, 400);
+			}
+			const { min, max } = numberBounds(key);
+			writtenNumbers[key] = Math.min(max, Math.max(min, Math.trunc(n)));
+		}
+	}
+
+	if (
+		Object.keys(writtenFlags).length === 0 &&
+		Object.keys(writtenNumbers).length === 0
+	) {
 		return c.json({ error: "flags_required" }, 400);
 	}
 
-	for (const [key, value] of Object.entries(written)) {
+	for (const [key, value] of Object.entries(writtenFlags)) {
 		await setSetting(c.env.DB, key, value ? "true" : "false");
 	}
-	await bustFlagsCache(c.env);
+	for (const [key, value] of Object.entries(writtenNumbers)) {
+		await setSetting(c.env.DB, key, String(value));
+	}
+	const busts: Promise<void>[] = [];
+	if (Object.keys(writtenFlags).length > 0) busts.push(bustFlagsCache(c.env));
+	if (Object.keys(writtenNumbers).length > 0)
+		busts.push(bustNumbersCache(c.env));
+	await Promise.all(busts);
 	await adminInsertAudit(c.env.DB, {
 		admin_id: user.id,
 		action: "settings.update",
 		target_kind: "system",
-		target_id: "flags",
-		meta: written,
+		target_id: "settings",
+		meta: { ...writtenFlags, ...writtenNumbers },
 	});
-	return c.json({ ok: true, flags: written });
+	return c.json({ ok: true, flags: writtenFlags, numbers: writtenNumbers });
 });
 
 admin.get("/about", async (c) => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -99,6 +99,7 @@ import { renderUsers } from "../admin-ui/pages/users";
 import { renderOperator } from "../admin-ui/pages/operator";
 import { renderSettings } from "../admin-ui/pages/settings";
 import { bustFlagsCache, FLAG_KEYS, loadFlags } from "../lib/settings";
+import { bustTreeCache } from "../lib/tree-cache";
 import {
 	renderWebhookForm,
 	renderWebhooksList,
@@ -1219,11 +1220,7 @@ admin.post("/api/saved-replies/:id/post", async (c) => {
 		},
 	});
 	// Bust the post's tree caches so the new reply is visible immediately.
-	await Promise.all([
-		c.env.TREE_CACHE.delete(`tree:${target.post_slug}:first:new`),
-		c.env.TREE_CACHE.delete(`tree:${target.post_slug}:first:top`),
-		c.env.TREE_CACHE.delete(`tree:${target.post_slug}:first`),
-	]);
+	await bustTreeCache(c.env, target.post_slug);
 	fireWebhook(c.env, c.executionCtx, {
 		event: "comment.posted",
 		comment_id: inserted.id,
@@ -1273,7 +1270,7 @@ admin.post("/api/comments/:id", async (c) => {
 		meta: { prev_status: existing.status, new_status: newStatus },
 	});
 	// Bust the cached first page so the moderation result is visible.
-	await c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`);
+	await bustTreeCache(c.env, existing.post_slug);
 	const webhookEvent: WebhookEvent | null =
 		newStatus === "approved"
 			? "comment.approved"
@@ -1358,7 +1355,7 @@ admin.post("/api/comments/bulk", async (c) => {
 			target_id: id,
 			meta: { batch_size: touched.length, new_status: newStatus },
 		});
-		await c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`);
+		await bustTreeCache(c.env, existing.post_slug);
 		if (webhookEvent) {
 			fireWebhook(c.env, c.executionCtx, {
 				event: webhookEvent,

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -49,7 +49,8 @@ import { readSession } from "../lib/session";
 import { verifyTurnstile } from "../lib/turnstile";
 import { writeEvent } from "../lib/analytics";
 import { fireWebhook } from "../lib/webhook";
-import { loadFlags } from "../lib/settings";
+import { loadFlags, loadNumbers } from "../lib/settings";
+import { bustTreeCache } from "../lib/tree-cache";
 import { log } from "../lib/log";
 import {
 	countLinks,
@@ -67,7 +68,6 @@ import {
 } from "../lib/tree";
 import { t } from "../i18n";
 
-const TOP_LEVEL_PAGE = 100;
 const TREE_CACHE_TTL = 300; // seconds; busted on every write, so a long TTL is fine
 
 type SessionVars = {
@@ -450,13 +450,7 @@ comments.post("/", async (c) => {
 	// Bust the cached first page. Older pages bypass cache, so there's
 	// nothing else to invalidate. Pending comments don't appear in the
 	// public tree but the cache key is the same; busting is still correct.
-	await Promise.all([
-		c.env.TREE_CACHE.delete(`tree:${slug}:first:new`),
-		c.env.TREE_CACHE.delete(`tree:${slug}:first:top`),
-		// Legacy key from before the sort-keyed cache split. Drop after
-		// one release cycle when prod caches have rotated.
-		c.env.TREE_CACHE.delete(`tree:${slug}:first`),
-	]);
+	await bustTreeCache(c.env, slug);
 
 	// Persist whichever spam signals ran. Fire-and-forget so a slow D1
 	// write never adds latency to the user-visible POST. Mirror the
@@ -547,17 +541,40 @@ type ListPayload = {
 	next_cursor: string | null;
 };
 
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
 /**
- * Cursor format: just the ULID of the oldest top-level thread on the
- * current page. Top-level threads are sorted DESC by created_at, so the
- * next page is `WHERE id < cursor_id`. Using the ULID (which is a
- * lexicographically-comparable time-prefixed ID) sidesteps the
- * timestamp-collision edge case.
+ * `new`-sort cursor: just the ULID of the oldest top-level thread on the
+ * current page. Threads are sorted DESC by created_at, so the next page is
+ * `id < cursor`. The ULID (lexicographically-comparable, time-prefixed)
+ * sidesteps the timestamp-collision edge case.
  */
 const decodeCursor = (raw: string | null): string | null => {
 	if (!raw) return null;
-	return /^[0-9A-HJKMNP-TV-Z]{26}$/.test(raw) ? raw : null;
+	return ULID_RE.test(raw) ? raw : null;
 };
+
+/** Net score (up − down) of a thread, the `top`-sort key. */
+const threadScore = (t: TreeNode): number => t.score_up - t.score_down;
+
+/**
+ * `top`-sort cursor: `<score>:<ulid>` of the last thread on the current page.
+ * `top` is ordered by (score DESC, id DESC) — a total order, since ULIDs are
+ * unique — so the next page is everything ranked strictly after the cursor:
+ * `score < cur.score || (score === cur.score && id < cur.id)`. Tie-breaking on
+ * id (rather than created_at) keeps the cursor stable against ms collisions.
+ */
+type TopCursor = { score: number; id: string };
+const decodeTopCursor = (raw: string | null): TopCursor | null => {
+	if (!raw) return null;
+	const sep = raw.indexOf(":");
+	if (sep <= 0) return null;
+	const score = Number.parseInt(raw.slice(0, sep), 10);
+	const id = raw.slice(sep + 1);
+	if (!Number.isFinite(score) || !ULID_RE.test(id)) return null;
+	return { score, id };
+};
+const encodeTopCursor = (t: TreeNode): string => `${threadScore(t)}:${t.id}`;
 
 comments.get("/", async (c) => {
 	const slug = (c.req.query("slug") ?? "").trim();
@@ -567,22 +584,26 @@ comments.get("/", async (c) => {
 	const sortParam = (c.req.query("sort") ?? "new").trim();
 	const sort: "new" | "top" = sortParam === "top" ? "top" : "new";
 
-	// The cursor format (`id < cursor`) only makes sense for the time-DESC
-	// `new` ordering — applying it to score-sorted results would skip or
-	// duplicate threads as scores shift. `top` returns a single page; any
-	// supplied ?before is ignored.
-	const cursor = sort === "top"
-		? null
-		: decodeCursor(c.req.query("before") ?? null);
+	// Each sort has its own cursor encoding: `new` pages by ULID (id < cursor),
+	// `top` pages by a composite score:id (see decodeTopCursor). A cursor from
+	// the wrong sort decodes to null → treated as the first page.
+	const beforeRaw = c.req.query("before") ?? null;
+	const cursor = sort === "new" ? decodeCursor(beforeRaw) : null;
+	const topCursor = sort === "top" ? decodeTopCursor(beforeRaw) : null;
 	const session = await readSession(c);
 
+	// Top-level threads per page, operator-tunable (DB > env > default 25),
+	// clamped to [1,200] in the settings layer.
+	const pageSize = (await loadNumbers(c.env)).comments_per_page;
+
 	// Fast path: first page is cached in KV for anonymous viewers only,
-	// keyed by sort so `top` and `new` don't poison each other.
-	// Signed-in viewers see per-user my_vote / mine flags so they bypass
-	// the cache. KV cache hit-rate stays high on the public reader path,
-	// which dominates traffic.
-	const cacheKey = `tree:${slug}:first:${sort}`;
-	if (!cursor && !session) {
+	// keyed by sort AND page size so `top`/`new` and a changed page size
+	// don't serve each other's slices. Signed-in viewers see per-user
+	// my_vote / mine flags so they bypass the cache. KV cache hit-rate stays
+	// high on the public reader path, which dominates traffic.
+	const cacheKey = `tree:${slug}:first:${sort}:n${pageSize}`;
+	const hasCursor = cursor !== null || topCursor !== null;
+	if (!hasCursor && !session) {
 		const cached = await c.env.TREE_CACHE.get(cacheKey, "json");
 		if (cached) return c.json(cached);
 	}
@@ -614,13 +635,14 @@ comments.get("/", async (c) => {
 
 	if (sort === "top") {
 		// Top-level only — replies stay in created_at ASC so threaded
-		// conversation reads top-down. Tie-break on newer-first so a
-		// fresh comment with the same score floats above an old one.
+		// conversation reads top-down. Order by (score DESC, id DESC): a total
+		// order over unique ULIDs, which the composite score:id cursor pages
+		// through. id-desc also floats a fresher same-score comment above an
+		// older one (ULIDs are time-monotonic).
 		allThreads.sort((a, b) => {
-			const sa = a.score_up - a.score_down;
-			const sb = b.score_up - b.score_down;
-			if (sb !== sa) return sb - sa;
-			return b.created_at - a.created_at;
+			const d = threadScore(b) - threadScore(a);
+			if (d !== 0) return d;
+			return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
 		});
 	} else {
 		// Newest-first top-level ordering. The tree builder returns ASC so
@@ -628,20 +650,32 @@ comments.get("/", async (c) => {
 		allThreads.reverse();
 	}
 
-	// Apply cursor: slice threads with id < cursor.
-	const startIdx = cursor
-		? allThreads.findIndex((t) => t.id < cursor)
-		: 0;
-	const sliceFrom = startIdx < 0 ? allThreads.length : startIdx;
-	const page = allThreads.slice(sliceFrom, sliceFrom + TOP_LEVEL_PAGE);
-	// `top` is a single page (see cursor-decoding note above) so callers
-	// shouldn't get a next_cursor that would lead to ill-defined paging.
-	const more = sort === "new" && allThreads.length > sliceFrom + TOP_LEVEL_PAGE;
-	const next_cursor = more ? (page[page.length - 1]?.id ?? null) : null;
+	// Apply the cursor: drop everything up to and including it, in the sort's
+	// own order. `new` → id < cursor; `top` → ranked strictly after (score,id).
+	let startIdx = 0;
+	if (cursor) {
+		const i = allThreads.findIndex((t) => t.id < cursor);
+		startIdx = i < 0 ? allThreads.length : i;
+	} else if (topCursor) {
+		const i = allThreads.findIndex(
+			(t) =>
+				threadScore(t) < topCursor.score ||
+				(threadScore(t) === topCursor.score && t.id < topCursor.id),
+		);
+		startIdx = i < 0 ? allThreads.length : i;
+	}
+	const page = allThreads.slice(startIdx, startIdx + pageSize);
+	const more = allThreads.length > startIdx + pageSize;
+	const last = page[page.length - 1];
+	const next_cursor = more && last
+		? sort === "top"
+			? encodeTopCursor(last)
+			: last.id
+		: null;
 
 	const payload: ListPayload = { post, threads: page, next_cursor };
 
-	if (!cursor && !session) {
+	if (!hasCursor && !session) {
 		// Write-through cache. expirationTtl is in seconds.
 		await c.env.TREE_CACHE.put(cacheKey, JSON.stringify(payload), {
 			expirationTtl: TREE_CACHE_TTL,
@@ -682,11 +716,7 @@ comments.patch("/:id", async (c) => {
 		body_html,
 		CURRENT_RENDERER_VERSION,
 	);
-	await Promise.all([
-		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:new`),
-		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:top`),
-		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`),
-	]);
+	await bustTreeCache(c.env, existing.post_slug);
 	writeEvent(c.env.ANALYTICS, "comment.edited", { post_slug: existing.post_slug });
 	fireWebhook(c.env, c.executionCtx, {
 		event: "comment.edited",
@@ -733,11 +763,7 @@ comments.delete("/:id", async (c) => {
 	}
 
 	await softDeleteComment(c.env.DB, id);
-	await Promise.all([
-		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:new`),
-		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first:top`),
-		c.env.TREE_CACHE.delete(`tree:${existing.post_slug}:first`),
-	]);
+	await bustTreeCache(c.env, existing.post_slug);
 	writeEvent(c.env.ANALYTICS, "comment.deleted", { post_slug: existing.post_slug });
 	fireWebhook(c.env, c.executionCtx, {
 		event: "comment.deleted",

--- a/src/routes/api.config.ts
+++ b/src/routes/api.config.ts
@@ -15,6 +15,9 @@
  *     surfaces the widget should render. Resolved with DB-override > env >
  *     default precedence (see src/lib/settings.ts); operators toggle them at
  *     runtime from the admin Settings page.
+ *   - numeric display settings (comments_per_page, replies_per_thread,
+ *     auto_collapse_depth): page size and reply-collapse tuning, same
+ *     DB-override > env > default precedence (see src/lib/settings.ts).
  *
  * The widget calls this once on mount. Missing or empty → widget renders
  * without a Turnstile challenge (and anonymous POSTs will be rejected
@@ -23,7 +26,7 @@
 import { Hono } from "hono";
 import type { Bindings } from "../index";
 import { PROVIDERS, type ProviderId } from "../lib/oauth";
-import { loadFlags } from "../lib/settings";
+import { loadFlags, loadNumbers } from "../lib/settings";
 
 const config = new Hono<{ Bindings: Bindings }>();
 
@@ -38,8 +41,12 @@ config.get("/", async (c) => {
 		const cfg = PROVIDERS[p];
 		return !!c.env[cfg.client_id_env] && !!c.env[cfg.client_secret_env];
 	});
-	// Feature flags resolved with DB-override > env > default precedence.
-	const flags = await loadFlags(c.env);
+	// Feature flags + numeric display settings, both resolved with
+	// DB-override > env > default precedence.
+	const [flags, numbers] = await Promise.all([
+		loadFlags(c.env),
+		loadNumbers(c.env),
+	]);
 	return c.json({
 		turnstile_site_key: c.env.TURNSTILE_SITE_KEY || null,
 		edit_window_minutes,
@@ -56,6 +63,13 @@ config.get("/", async (c) => {
 		downvotes_enabled: flags.downvotes_enabled,
 		page_reactions_enabled: flags.page_reactions_enabled,
 		page_votes_enabled: flags.page_votes_enabled,
+		// Display/pagination. comments_per_page drives the server-side page
+		// slice (included here for parity/debuggability); the widget consumes
+		// replies_per_thread and auto_collapse_depth for client-side reply
+		// collapsing.
+		comments_per_page: numbers.comments_per_page,
+		replies_per_thread: numbers.replies_per_thread,
+		auto_collapse_depth: numbers.auto_collapse_depth,
 	});
 });
 

--- a/src/routes/api.reactions.ts
+++ b/src/routes/api.reactions.ts
@@ -15,6 +15,7 @@ import { checkRateLimit } from "../lib/ratelimit";
 import { readSession } from "../lib/session";
 import { writeEvent } from "../lib/analytics";
 import { loadFlags } from "../lib/settings";
+import { bustTreeCache } from "../lib/tree-cache";
 import { t } from "../i18n";
 
 const reactions = new Hono<{ Bindings: Bindings }>();
@@ -72,11 +73,7 @@ reactions.post("/", async (c) => {
 	const result = await toggleReaction(c.env.DB, comment_id, userId, kind);
 
 	// Bust the cached first page so reaction counts reflect immediately.
-	await Promise.all([
-		c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first:new`),
-		c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first:top`),
-		c.env.TREE_CACHE.delete(`tree:${comment.post_slug}:first`),
-	]);
+	await bustTreeCache(c.env, comment.post_slug);
 
 	writeEvent(c.env.ANALYTICS, "reaction.toggled", {
 		post_slug: comment.post_slug,

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -299,6 +299,17 @@ const STYLE_CSS = `
 	align-self: center;
 }
 .gr-loadmore[disabled] { opacity: 0.6; cursor: progress; }
+.gr-collapse, .gr-showmore {
+	font: inherit;
+	font-size: 0.85em;
+	background: transparent;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	align-self: flex-start;
+}
+.gr-collapse { color: var(--garrul-muted, #6b7280); }
+.gr-showmore { color: var(--garrul-link, #2563eb); margin-top: 0.25rem; }
 .gr-signin { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
 .gr-signin button {
 	font: inherit;
@@ -560,6 +571,11 @@ type WidgetCtx = {
 	downvotesEnabled: boolean;
 	pageReactionsEnabled: boolean;
 	pageVotesEnabled: boolean;
+	// Reply-collapse tuning (server config). repliesPerThread: replies shown
+	// under a parent before a "Show N more" button (0 = all). autoCollapseDepth:
+	// a comment at depth >= this starts with its replies collapsed (0 = never).
+	repliesPerThread: number;
+	autoCollapseDepth: number;
 	reload: () => void;
 };
 
@@ -1282,6 +1298,72 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	return row;
 };
 
+/** Total nested replies under a node (whole subtree), for the toggle label. */
+const countDescendants = (n: TreeNode): number => {
+	let total = n.replies.length;
+	for (const r of n.replies) total += countDescendants(r);
+	return total;
+};
+
+const plural = (n: number, one: string, many: string): string =>
+	`${n} ${n === 1 ? one : many}`;
+
+/**
+ * Collapse/expand control for a node's replies. Hides/shows the replies
+ * container in place (all replies are already in the DOM). `startCollapsed`
+ * comes from the auto-collapse-depth setting.
+ */
+const buildCollapseToggle = (
+	repliesEl: HTMLElement,
+	count: number,
+	startCollapsed: boolean,
+): HTMLButtonElement => {
+	const btn = el("button", "gr-collapse") as HTMLButtonElement;
+	btn.type = "button";
+	let collapsed = startCollapsed;
+	const apply = () => {
+		repliesEl.style.display = collapsed ? "none" : "";
+		btn.textContent = `${collapsed ? "▸" : "▾"} ${plural(count, "reply", "replies")}`;
+		btn.setAttribute("aria-expanded", String(!collapsed));
+	};
+	btn.addEventListener("click", () => {
+		collapsed = !collapsed;
+		apply();
+	});
+	apply();
+	return btn;
+};
+
+/**
+ * Render a parent's direct replies into `container`, capping at
+ * repliesPerThread and appending a "Show N more replies" button for the rest
+ * (0 = show all). The cap applies recursively as each reply is itself a thread.
+ */
+const renderReplyList = (
+	container: HTMLElement,
+	replies: TreeNode[],
+	ctx: WidgetCtx,
+): void => {
+	const limit = ctx.repliesPerThread;
+	const initial = limit > 0 && replies.length > limit ? limit : replies.length;
+	for (let i = 0; i < initial; i++) {
+		container.appendChild(buildThread(replies[i]!, ctx));
+	}
+	if (initial < replies.length) {
+		const hidden = replies.slice(initial);
+		const more = el("button", "gr-showmore") as HTMLButtonElement;
+		more.type = "button";
+		more.textContent = `Show ${plural(hidden.length, "more reply", "more replies")}`;
+		more.addEventListener("click", () => {
+			for (const r of hidden) {
+				container.insertBefore(buildThread(r, ctx), more);
+			}
+			more.remove();
+		});
+		container.appendChild(more);
+	}
+};
+
 const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	const wrap = el("div", "gr-thread");
 	wrap.dataset.id = n.id;
@@ -1290,8 +1372,17 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	wrap.appendChild(buildComment(n, ctx));
 	if (n.replies.length > 0) {
 		const replies = el("div", "gr-replies");
-		for (const r of n.replies) replies.appendChild(buildThread(r, ctx));
-		wrap.appendChild(replies);
+		renderReplyList(replies, n.replies, ctx);
+		// Per-comment collapse toggle; auto-collapsed when this node is nested
+		// at/deeper than the configured depth (0 = never auto-collapse).
+		const startCollapsed =
+			ctx.autoCollapseDepth > 0 && n.depth >= ctx.autoCollapseDepth;
+		const toggle = buildCollapseToggle(
+			replies,
+			countDescendants(n),
+			startCollapsed,
+		);
+		wrap.append(toggle, replies);
 	}
 	return wrap;
 };
@@ -1626,6 +1717,10 @@ const loadOnce = async (
 	let downvotesEnabled = true;
 	let pageReactionsEnabled = false;
 	let pageVotesEnabled = false;
+	// Defaults mirror the server (src/lib/settings.ts) so a failed/absent
+	// config fetch degrades gracefully to the same behavior.
+	let repliesPerThread = 3;
+	let autoCollapseDepth = 3;
 	try {
 		const cfgRes = await fetch(`${apiBase}/api/v1/config`, {
 			credentials: "include",
@@ -1642,6 +1737,8 @@ const loadOnce = async (
 				downvotes_enabled?: boolean;
 				page_reactions_enabled?: boolean;
 				page_votes_enabled?: boolean;
+				replies_per_thread?: number;
+				auto_collapse_depth?: number;
 			};
 			siteKey = cfg.turnstile_site_key ?? null;
 			editWindowMinutes = cfg.edit_window_minutes ?? 5;
@@ -1655,6 +1752,10 @@ const loadOnce = async (
 			downvotesEnabled = cfg.downvotes_enabled !== false;
 			pageReactionsEnabled = cfg.page_reactions_enabled === true;
 			pageVotesEnabled = cfg.page_votes_enabled === true;
+			if (typeof cfg.replies_per_thread === "number")
+				repliesPerThread = cfg.replies_per_thread;
+			if (typeof cfg.auto_collapse_depth === "number")
+				autoCollapseDepth = cfg.auto_collapse_depth;
 		}
 	} catch {
 		// /api/v1/config is optional; the widget still renders without Turnstile
@@ -1693,6 +1794,8 @@ const loadOnce = async (
 		downvotesEnabled,
 		pageReactionsEnabled,
 		pageVotesEnabled,
+		repliesPerThread,
+		autoCollapseDepth,
 		reload,
 	};
 	// Article-level engagement bar sits at the very top, above the composer.

--- a/tests/admin-settings.test.ts
+++ b/tests/admin-settings.test.ts
@@ -1,0 +1,270 @@
+/**
+ * POST /admin/settings write-path tests.
+ *
+ * The render side (settings page HTML) and the read side (loadFlags /
+ * loadNumbers) are covered elsewhere; this exercises the handler that
+ * PERSISTS operator overrides — specifically the numeric branch added with
+ * configurable pagination:
+ *
+ *   - numbers are validated, clamped into [min,max], and stored as text;
+ *   - a non-numeric value is rejected 400 (`invalid_number:<key>`);
+ *   - unknown keys are ignored (whitelist);
+ *   - the numbers cache is busted but the flag cache is left alone when only
+ *     numbers change (independent cache entries);
+ *   - the write is audited;
+ *   - "reset" clears both flag AND number keys.
+ *
+ * No Miniflare: hand-rolled D1 + KV stubs route by SQL substring / key, in
+ * the same style as votes.test.ts. The admin gate (session → admin user) and
+ * the same-origin CSRF check are satisfied with a seeded session + Origin
+ * header.
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { admin } from "../src/routes/admin";
+import type { Bindings } from "../src/index";
+
+const SID = "testsessionid";
+const ADMIN_ID = "01HADMIN0000000000000000AB";
+
+// D1 double: serves the admin user for the auth gate and captures every
+// .run() (setSetting INSERTs, deleteSettings DELETE, audit INSERT) so tests
+// can assert what was persisted.
+const makeDb = () => {
+	const runs: { sql: string; binds: unknown[] }[] = [];
+	const chain = (sql: string) => ({
+		_binds: [] as unknown[],
+		bind(...args: unknown[]) {
+			this._binds = args;
+			return this;
+		},
+		async first() {
+			if (sql.includes("FROM users WHERE id")) {
+				return {
+					id: ADMIN_ID,
+					provider: "github",
+					provider_id: "1",
+					name: "Op",
+					email: "op@example.com",
+					avatar_url: null,
+					is_admin: 1,
+					is_banned: 0,
+					role: "admin",
+					created_at: 1_700_000_000_000,
+				};
+			}
+			return null;
+		},
+		async all() {
+			return { results: [] };
+		},
+		async run() {
+			runs.push({ sql, binds: this._binds });
+			return { meta: { changes: 1 } };
+		},
+	});
+	return { db: { prepare: (sql: string) => chain(sql) }, runs };
+};
+
+const makeKv = (seed: Record<string, string> = {}) => {
+	const store = new Map<string, string>(Object.entries(seed));
+	const deletedKeys: string[] = [];
+	return {
+		store,
+		deletedKeys,
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			deletedKeys.push(key);
+			store.delete(key);
+		},
+	};
+};
+
+const mkEnv = () => {
+	const { db, runs } = makeDb();
+	// Seed the version-check cache with a back-off entry so the admin
+	// middleware's fire-and-forget refresh never attempts a GitHub fetch.
+	const kv = makeKv({
+		"meta:latest-release": JSON.stringify({ kind: "null", fetchedAt: 1 }),
+		"meta:recent-releases": JSON.stringify({ kind: "null", fetchedAt: 1 }),
+	});
+	const sessions = {
+		async get(key: string) {
+			if (key === `sess:${SID}`) {
+				return JSON.stringify({
+					user_id: ADMIN_ID,
+					expires_at: 4_102_444_800_000, // year 2100
+				});
+			}
+			return null;
+		},
+		async put() {},
+		async delete() {},
+	};
+	const env = {
+		DB: db,
+		TREE_CACHE: kv,
+		SESSIONS: sessions,
+	} as unknown as Bindings;
+	return { env, kv, runs };
+};
+
+const execCtx = { waitUntil: () => {}, passThroughOnException: () => {} };
+
+const postSettings = (
+	env: Bindings,
+	body: unknown,
+	opts: { cookie?: boolean; origin?: string | null } = {},
+) => {
+	const { cookie = true, origin = "http://localhost" } = opts;
+	const app = new Hono<{ Bindings: Bindings }>().route("/admin", admin);
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (cookie) headers.cookie = `garrul_sess=${SID}`;
+	if (origin) headers.origin = origin;
+	return app.request(
+		"/admin/settings",
+		{ method: "POST", headers, body: JSON.stringify(body) },
+		env as unknown as Record<string, unknown>,
+		execCtx as unknown as ExecutionContext,
+	);
+};
+
+// settings INSERT binds are (key, value, updated_at).
+const settingWrites = (runs: { sql: string; binds: unknown[] }[]) =>
+	runs
+		.filter((r) => r.sql.includes("INSERT INTO settings"))
+		.map((r) => [r.binds[0], r.binds[1]] as [string, string]);
+
+describe("POST /admin/settings — numeric writes", () => {
+	it("stores an in-range number as text and busts only the numbers cache", async () => {
+		const { env, kv, runs } = mkEnv();
+		const res = await postSettings(env, { numbers: { comments_per_page: 10 } });
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { numbers: Record<string, number> };
+		expect(json.numbers.comments_per_page).toBe(10);
+
+		expect(settingWrites(runs)).toContainEqual(["comments_per_page", "10"]);
+		// Independent cache entries: numbers busted, flags untouched.
+		expect(kv.deletedKeys).toContain("settings:numbers");
+		expect(kv.deletedKeys).not.toContain("settings:flags");
+	});
+
+	it("clamps an over-max value before storing", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { comments_per_page: 1_000_000 },
+		});
+		expect(res.status).toBe(200);
+		// max is 200.
+		expect(settingWrites(runs)).toContainEqual(["comments_per_page", "200"]);
+	});
+
+	it("clamps a negative value up to the minimum", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { replies_per_thread: -5 },
+		});
+		expect(res.status).toBe(200);
+		// min is 0.
+		expect(settingWrites(runs)).toContainEqual(["replies_per_thread", "0"]);
+	});
+
+	it("accepts a numeric string and truncates a decimal", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { auto_collapse_depth: "2", comments_per_page: 12.9 },
+		});
+		expect(res.status).toBe(200);
+		const writes = settingWrites(runs);
+		expect(writes).toContainEqual(["auto_collapse_depth", "2"]);
+		expect(writes).toContainEqual(["comments_per_page", "12"]);
+	});
+
+	it("rejects a non-numeric value with 400 invalid_number:<key>", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { comments_per_page: "lots" },
+		});
+		expect(res.status).toBe(400);
+		const json = (await res.json()) as { error: string };
+		expect(json.error).toBe("invalid_number:comments_per_page");
+		// Nothing persisted on the rejected request.
+		expect(settingWrites(runs)).toHaveLength(0);
+	});
+
+	it("ignores unknown number keys (whitelist)", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { comments_per_page: 15, bogus_setting: 99 },
+		});
+		expect(res.status).toBe(200);
+		const writes = settingWrites(runs);
+		expect(writes).toContainEqual(["comments_per_page", "15"]);
+		expect(writes.some(([k]) => k === "bogus_setting")).toBe(false);
+	});
+
+	it("400s when only unknown keys are supplied", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, { numbers: { bogus_setting: 99 } });
+		expect(res.status).toBe(400);
+		expect(settingWrites(runs)).toHaveLength(0);
+	});
+
+	it("audits the settings update", async () => {
+		const { env, runs } = mkEnv();
+		await postSettings(env, { numbers: { comments_per_page: 10 } });
+		const audit = runs.find((r) => r.sql.includes("INSERT INTO audit_log"));
+		expect(audit).toBeDefined();
+		expect(audit!.binds).toContain("settings.update");
+		expect(audit!.binds).toContain(ADMIN_ID);
+	});
+});
+
+describe("POST /admin/settings — reset", () => {
+	it("clears both flag and number keys and busts both caches", async () => {
+		const { env, kv, runs } = mkEnv();
+		const res = await postSettings(env, { reset: true });
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { reset: boolean };
+		expect(json.reset).toBe(true);
+
+		const del = runs.find((r) => r.sql.includes("DELETE FROM settings"));
+		expect(del).toBeDefined();
+		// The delete binds every flag + number key.
+		expect(del!.binds).toContain("comments_enabled");
+		expect(del!.binds).toContain("comments_per_page");
+		expect(del!.binds).toContain("auto_collapse_depth");
+
+		expect(kv.deletedKeys).toContain("settings:flags");
+		expect(kv.deletedKeys).toContain("settings:numbers");
+	});
+});
+
+describe("POST /admin/settings — gate", () => {
+	it("401s without a session cookie", async () => {
+		const { env } = mkEnv();
+		const res = await postSettings(env, { numbers: { comments_per_page: 10 } }, {
+			cookie: false,
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("403s on an Origin mismatch (CSRF)", async () => {
+		const { env } = mkEnv();
+		const res = await postSettings(
+			env,
+			{ numbers: { comments_per_page: 10 } },
+			{ origin: "https://evil.example.com" },
+		);
+		expect(res.status).toBe(403);
+		const json = (await res.json()) as { error: string };
+		expect(json.error).toBe("origin_mismatch");
+	});
+});

--- a/tests/admin-settings.test.ts
+++ b/tests/admin-settings.test.ts
@@ -210,11 +210,23 @@ describe("POST /admin/settings — numeric writes", () => {
 		expect(writes.some(([k]) => k === "bogus_setting")).toBe(false);
 	});
 
-	it("400s when only unknown keys are supplied", async () => {
+	it("400s settings_required when only unknown keys are supplied", async () => {
 		const { env, runs } = mkEnv();
 		const res = await postSettings(env, { numbers: { bogus_setting: 99 } });
 		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: string }).error).toBe(
+			"settings_required",
+		);
 		expect(settingWrites(runs)).toHaveLength(0);
+	});
+
+	it("400s settings_required when neither flags nor numbers are present", async () => {
+		const { env } = mkEnv();
+		const res = await postSettings(env, { something: "else" });
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: string }).error).toBe(
+			"settings_required",
+		);
 	});
 
 	it("audits the settings update", async () => {

--- a/tests/comments-pagination.test.ts
+++ b/tests/comments-pagination.test.ts
@@ -1,0 +1,305 @@
+/**
+ * GET /api/v1/comments pagination tests.
+ *
+ * Covers the configurable page-size behavior added alongside the collapsible-
+ * replies work:
+ *
+ *   1. `comments_per_page` (DB > env > default 25) drives the server-side
+ *      top-level slice — the default, an env override, and a DB-row override.
+ *   2. `sort=new` walks pages via the ULID `before` cursor (id < cursor).
+ *   3. `sort=top` now PAGINATES too (composite score:id cursor), so a small
+ *      page size no longer hides top-voted threads past the first page.
+ *   4. The first-page KV cache key varies with the page size, so a size change
+ *      can't serve a stale-sized slice.
+ *
+ * No Miniflare: a hand-rolled D1 stub routes by SQL substring (same style as
+ * votes.test.ts) plus an in-memory KV double for TREE_CACHE/SESSIONS.
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { comments } from "../src/routes/api.comments";
+import type { Bindings } from "../src/index";
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+// Deterministic, order-preserving 26-char ULID-shaped id: higher n sorts
+// lexicographically higher (and matches the handler's ULID_RE). Left-padded
+// with '0' (the lowest alphabet char) so ordering by id === ordering by n.
+const mkUlid = (n: number): string => {
+	let s = "";
+	let v = n;
+	if (v === 0) s = "0";
+	while (v > 0) {
+		s = CROCKFORD[v % 32] + s;
+		v = Math.floor(v / 32);
+	}
+	return s.padStart(26, "0");
+};
+
+type CommentRow = {
+	id: string;
+	post_slug: string;
+	parent_id: string | null;
+	user_id: string;
+	body_md: string;
+	body_html: string;
+	renderer_version: number;
+	status: string;
+	edited_at: number | null;
+	deleted_at: number | null;
+	ip_hash: string | null;
+	user_agent: string | null;
+	created_at: number;
+	score_up: number;
+	score_down: number;
+};
+
+// Build N top-level comments, oldest first (created_at and id both ascending
+// with index). `scores[i]` optionally sets the net up-votes for the top-sort
+// tests; unset → 0.
+const makeComments = (n: number, scores: number[] = []): CommentRow[] =>
+	Array.from({ length: n }, (_, i) => ({
+		id: mkUlid(i + 1),
+		post_slug: "hello",
+		parent_id: null,
+		user_id: "01HU000000000000000000",
+		body_md: `c${i}`,
+		body_html: `<p>c${i}</p>`,
+		renderer_version: 1,
+		status: "approved",
+		edited_at: null,
+		deleted_at: null,
+		ip_hash: null,
+		user_agent: null,
+		created_at: 1000 + i,
+		score_up: scores[i] ?? 0,
+		score_down: 0,
+	}));
+
+const makeKv = () => {
+	const store = new Map<string, string>();
+	return {
+		store,
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+// D1 double routing by SQL substring. `settings` carries the numeric overrides
+// for loadNumbers(); the rest feed the GET list handler.
+const makeDb = (rows: CommentRow[], settings: Record<string, string> = {}) => {
+	const all = async (sql: string) => {
+		if (sql.includes("key, value FROM settings")) {
+			return {
+				results: Object.entries(settings).map(([key, value]) => ({
+					key,
+					value,
+				})),
+			};
+		}
+		if (sql.includes("FROM comments") && sql.includes("status NOT IN")) {
+			return { results: rows };
+		}
+		if (sql.includes("FROM users WHERE id IN")) {
+			return {
+				results: [
+					{
+						id: "01HU000000000000000000",
+						provider: "anon",
+						provider_id: null,
+						name: "anon",
+						email: null,
+						avatar_url: null,
+						is_admin: 0,
+						is_banned: 0,
+						role: "user",
+						created_at: 1_700_000_000_000,
+					},
+				],
+			};
+		}
+		if (sql.includes("FROM reactions")) {
+			return { results: [] };
+		}
+		return { results: [] };
+	};
+	const first = async (sql: string) => {
+		if (sql.includes("FROM posts WHERE slug")) {
+			return { slug: "hello", title: "Hello", url: null, created_at: 1 };
+		}
+		return null;
+	};
+	const chain = (sql: string) => ({
+		bind() {
+			return this;
+		},
+		all: () => all(sql),
+		first: () => first(sql),
+	});
+	return { prepare: (sql: string) => chain(sql) };
+};
+
+const mkEnv = (rows: CommentRow[], settings: Record<string, string> = {}, envVars: Record<string, string> = {}) => {
+	const kv = makeKv();
+	const env = {
+		DB: makeDb(rows, settings),
+		TREE_CACHE: kv,
+		SESSIONS: { get: async () => null },
+		...envVars,
+	} as unknown as Bindings;
+	return { env, kv };
+};
+
+type ListResp = {
+	threads: { id: string; score_up: number; score_down: number }[];
+	next_cursor: string | null;
+};
+
+const get = async (env: Bindings, query: string): Promise<ListResp> => {
+	const app = new Hono<{ Bindings: Bindings }>().route("/", comments);
+	const res = await app.request(
+		`/?${query}`,
+		{},
+		env as unknown as Record<string, unknown>,
+	);
+	expect(res.status).toBe(200);
+	return (await res.json()) as ListResp;
+};
+
+describe("GET /comments — default page size", () => {
+	it("returns 25 threads + a cursor when there are more", async () => {
+		const { env } = mkEnv(makeComments(30));
+		const page = await get(env, "slug=hello");
+		expect(page.threads).toHaveLength(25);
+		expect(page.next_cursor).not.toBeNull();
+	});
+
+	it("returns everything with a null cursor when under the page size", async () => {
+		const { env } = mkEnv(makeComments(5));
+		const page = await get(env, "slug=hello");
+		expect(page.threads).toHaveLength(5);
+		expect(page.next_cursor).toBeNull();
+	});
+});
+
+describe("GET /comments — configurable page size", () => {
+	it("honors a DB-row comments_per_page override", async () => {
+		const { env } = mkEnv(makeComments(30), { comments_per_page: "10" });
+		const page = await get(env, "slug=hello");
+		expect(page.threads).toHaveLength(10);
+		expect(page.next_cursor).not.toBeNull();
+	});
+
+	it("honors a COMMENTS_PER_PAGE env override", async () => {
+		const { env } = mkEnv(makeComments(30), {}, { COMMENTS_PER_PAGE: "5" });
+		const page = await get(env, "slug=hello");
+		expect(page.threads).toHaveLength(5);
+	});
+
+	it("clamps a hostile DB value so the slice can't explode", async () => {
+		const { env } = mkEnv(makeComments(30), { comments_per_page: "1000000" });
+		const page = await get(env, "slug=hello");
+		// Clamp max is 200; only 30 rows exist, so all 30 come back, no cursor.
+		expect(page.threads).toHaveLength(30);
+		expect(page.next_cursor).toBeNull();
+	});
+});
+
+describe("GET /comments — sort=new cursor walks pages", () => {
+	it("second page returns the remainder and a null cursor", async () => {
+		const { env } = mkEnv(makeComments(30), { comments_per_page: "10" });
+		const first = await get(env, "slug=hello");
+		expect(first.threads).toHaveLength(10);
+		// new-sort is newest-first: page 1 starts at the highest id (c29).
+		expect(first.threads[0]!.id).toBe(mkUlid(30));
+
+		const second = await get(env, `slug=hello&before=${first.next_cursor}`);
+		expect(second.threads).toHaveLength(10);
+		const third = await get(env, `slug=hello&before=${second.next_cursor}`);
+		expect(third.threads).toHaveLength(10);
+		expect(third.next_cursor).toBeNull();
+
+		// No overlap across pages, and they descend.
+		const ids = [...first.threads, ...second.threads, ...third.threads].map(
+			(t) => t.id,
+		);
+		expect(new Set(ids).size).toBe(30);
+		expect(ids[0]).toBe(mkUlid(30));
+		expect(ids[29]).toBe(mkUlid(1));
+	});
+});
+
+describe("GET /comments — sort=top paginates (no hidden threads)", () => {
+	it("returns a page-sized slice ordered by score, with a cursor", async () => {
+		// 10 comments, ascending score 0..9 by index. Top sort should surface
+		// the 2 highest-scoring (c9=9, c8=8) on the first page of size 2.
+		const scores = Array.from({ length: 10 }, (_, i) => i);
+		const { env } = mkEnv(makeComments(10, scores), {
+			comments_per_page: "2",
+		});
+		const first = await get(env, "slug=hello&sort=top");
+		expect(first.threads).toHaveLength(2);
+		expect(first.threads.map((t) => t.score_up)).toEqual([9, 8]);
+		expect(first.next_cursor).not.toBeNull();
+
+		// Walking the composite score:id cursor reaches the lower-scored
+		// threads that a single unpaginated page of size 2 would have hidden.
+		const second = await get(env, `slug=hello&sort=top&before=${first.next_cursor}`);
+		expect(second.threads.map((t) => t.score_up)).toEqual([7, 6]);
+	});
+
+	it("walks every thread across pages with no overlap", async () => {
+		const scores = Array.from({ length: 10 }, (_, i) => i);
+		const { env } = mkEnv(makeComments(10, scores), {
+			comments_per_page: "3",
+		});
+		const seen: string[] = [];
+		let cursor: string | null = null;
+		for (let i = 0; i < 10; i++) {
+			const q = cursor ? `slug=hello&sort=top&before=${cursor}` : "slug=hello&sort=top";
+			const page: ListResp = await get(env, q);
+			seen.push(...page.threads.map((t) => t.id));
+			cursor = page.next_cursor;
+			if (!cursor) break;
+		}
+		expect(new Set(seen).size).toBe(10);
+	});
+});
+
+describe("GET /comments — cache key varies with page size", () => {
+	it("caches the first page under a size-stamped key", async () => {
+		const { env, kv } = mkEnv(makeComments(30), { comments_per_page: "10" });
+		await get(env, "slug=hello");
+		expect(kv.store.has("tree:hello:first:new:n10")).toBe(true);
+		expect(kv.store.has("tree:hello:first:new:n25")).toBe(false);
+	});
+
+	it("a different size resolves to a different cache slot", async () => {
+		const { env: env10, kv: kv10 } = mkEnv(makeComments(30), {
+			comments_per_page: "10",
+		});
+		await get(env10, "slug=hello");
+
+		const { env: env25, kv: kv25 } = mkEnv(makeComments(30));
+		await get(env25, "slug=hello");
+
+		expect(kv10.store.has("tree:hello:first:new:n10")).toBe(true);
+		expect(kv25.store.has("tree:hello:first:new:n25")).toBe(true);
+	});
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -17,8 +17,14 @@ import { Hono } from "hono";
 import {
 	loadFlags,
 	bustFlagsCache,
+	loadNumbers,
+	bustNumbersCache,
+	parseIntSetting,
 	FLAG_KEYS,
+	NUMBER_KEYS,
+	numberBounds,
 	type FlagKey,
+	type NumberKey,
 } from "../src/lib/settings";
 import { reactions } from "../src/routes/api.reactions";
 import { comments } from "../src/routes/api.comments";
@@ -235,6 +241,163 @@ describe("bustFlagsCache", () => {
 		expect(db.reads()).toBe(1);
 		await bustFlagsCache(env);
 		await loadFlags(env);
+		expect(db.reads()).toBe(2);
+	});
+});
+
+// -- numeric display settings ------------------------------------------------
+//
+// loadNumbers() mirrors loadFlags()'s precedence (DB > env > default) and KV
+// cache, but resolves integers with a per-key [min,max] clamp. It caches under
+// its own key ("settings:numbers") so it never disturbs the flag cache entry.
+
+describe("parseIntSetting — clamp + fallback", () => {
+	it("returns the fallback for undefined / empty / junk", () => {
+		expect(parseIntSetting(undefined, 25, 1, 200)).toBe(25);
+		expect(parseIntSetting("", 25, 1, 200)).toBe(25);
+		expect(parseIntSetting("   ", 25, 1, 200)).toBe(25);
+		expect(parseIntSetting("abc", 25, 1, 200)).toBe(25);
+	});
+
+	it("clamps below min and above max", () => {
+		expect(parseIntSetting("-5", 25, 1, 200)).toBe(1);
+		expect(parseIntSetting("0", 25, 1, 200)).toBe(1);
+		expect(parseIntSetting("9999", 25, 1, 200)).toBe(200);
+	});
+
+	it("passes an in-range value through", () => {
+		expect(parseIntSetting("50", 25, 1, 200)).toBe(50);
+	});
+
+	it("parses a leading integer from a decimal-ish string", () => {
+		// Number.parseInt semantics: "12.9" -> 12.
+		expect(parseIntSetting("12.9", 25, 1, 200)).toBe(12);
+	});
+});
+
+describe("loadNumbers — defaults", () => {
+	it("returns built-in defaults when no DB rows and no env vars", async () => {
+		const { env } = mkEnv();
+		const numbers = await loadNumbers(env);
+		expect(numbers).toEqual({
+			comments_per_page: 25,
+			replies_per_thread: 3,
+			auto_collapse_depth: 3,
+		});
+	});
+
+	it("resolves a number for every canonical number key", async () => {
+		const { env } = mkEnv();
+		const numbers = await loadNumbers(env);
+		for (const key of NUMBER_KEYS) {
+			expect(typeof numbers[key as NumberKey]).toBe("number");
+		}
+	});
+
+	it("every default sits within its own clamp bounds", async () => {
+		for (const key of NUMBER_KEYS) {
+			const b = numberBounds(key as NumberKey);
+			expect(b.default).toBeGreaterThanOrEqual(b.min);
+			expect(b.default).toBeLessThanOrEqual(b.max);
+		}
+	});
+});
+
+describe("loadNumbers — env var over default", () => {
+	it("env var overrides the default", async () => {
+		const { env } = mkEnv({}, { COMMENTS_PER_PAGE: "50" });
+		const numbers = await loadNumbers(env);
+		expect(numbers.comments_per_page).toBe(50);
+	});
+
+	it("clamps an out-of-range env value", async () => {
+		const { env } = mkEnv({}, { COMMENTS_PER_PAGE: "9999" });
+		const numbers = await loadNumbers(env);
+		expect(numbers.comments_per_page).toBe(200);
+	});
+
+	it("falls back to default for a junk env value", async () => {
+		const { env } = mkEnv({}, { REPLIES_PER_THREAD: "lots" });
+		const numbers = await loadNumbers(env);
+		expect(numbers.replies_per_thread).toBe(3);
+	});
+});
+
+describe("loadNumbers — DB row over env var", () => {
+	it("DB row beats a conflicting env var", async () => {
+		const { env } = mkEnv(
+			{ comments_per_page: "10" },
+			{ COMMENTS_PER_PAGE: "100" },
+		);
+		const numbers = await loadNumbers(env);
+		expect(numbers.comments_per_page).toBe(10);
+	});
+
+	it("clamps a hostile DB value (no DoS-via-huge-slice)", async () => {
+		const { env } = mkEnv({ comments_per_page: "1000000" });
+		const numbers = await loadNumbers(env);
+		expect(numbers.comments_per_page).toBe(200);
+	});
+
+	it("clamps a negative DB value up to min", async () => {
+		const { env } = mkEnv({ replies_per_thread: "-1" });
+		const numbers = await loadNumbers(env);
+		expect(numbers.replies_per_thread).toBe(0);
+	});
+
+	it("a row for one number does not disturb the others", async () => {
+		const { env } = mkEnv({ comments_per_page: "10" });
+		const numbers = await loadNumbers(env);
+		expect(numbers.comments_per_page).toBe(10);
+		expect(numbers.replies_per_thread).toBe(3);
+		expect(numbers.auto_collapse_depth).toBe(3);
+	});
+});
+
+describe("loadNumbers — KV cache", () => {
+	it("caches under its own key, leaving the flag cache untouched", async () => {
+		const { env, kv } = mkEnv({ comments_per_page: "10" });
+		await loadNumbers(env);
+		expect(kv.store.has("settings:numbers")).toBe(true);
+		expect(kv.store.has("settings:flags")).toBe(false);
+	});
+
+	it("serves a warm cache without touching D1", async () => {
+		const { env, db } = mkEnv({ comments_per_page: "10" });
+		const first = await loadNumbers(env);
+		expect(db.reads()).toBe(1);
+		const second = await loadNumbers(env);
+		expect(db.reads()).toBe(1);
+		expect(second).toEqual(first);
+	});
+
+	it("loadFlags and loadNumbers don't share a cache entry", async () => {
+		const { env } = mkEnv({ comments_enabled: "false", comments_per_page: "10" });
+		const flags = await loadFlags(env);
+		const numbers = await loadNumbers(env);
+		expect(flags.comments_enabled).toBe(false);
+		expect(numbers.comments_per_page).toBe(10);
+	});
+});
+
+describe("bustNumbersCache", () => {
+	it("deletes only the numbers cache entry", async () => {
+		const { env, kv } = mkEnv({ comments_per_page: "10" });
+		await loadFlags(env);
+		await loadNumbers(env);
+		expect(kv.store.has("settings:numbers")).toBe(true);
+		await bustNumbersCache(env);
+		expect(kv.store.has("settings:numbers")).toBe(false);
+		// The flag cache survives an independent numbers bust.
+		expect(kv.store.has("settings:flags")).toBe(true);
+	});
+
+	it("forces a fresh D1 read on the next load", async () => {
+		const { env, db } = mkEnv({ comments_per_page: "10" });
+		await loadNumbers(env);
+		expect(db.reads()).toBe(1);
+		await bustNumbersCache(env);
+		await loadNumbers(env);
 		expect(db.reads()).toBe(2);
 	});
 });

--- a/tests/tree-cache.test.ts
+++ b/tests/tree-cache.test.ts
@@ -1,0 +1,82 @@
+/**
+ * bustTreeCache() invalidation + resilience.
+ *
+ * The helper prefix-lists every first-page cache variant for a slug and
+ * deletes them. It is best-effort: a transient KV failure (list or an
+ * individual delete) must never propagate, because every comment mutation
+ * (post / edit / delete / reaction) awaits it on the user-visible path.
+ */
+import { describe, it, expect } from "vitest";
+import { bustTreeCache } from "../src/lib/tree-cache";
+
+type KvOpts = { failDeleteFor?: Set<string>; failList?: boolean };
+
+const makeKv = (keys: string[], opts: KvOpts = {}) => {
+	const store = new Set(keys);
+	const deleted: string[] = [];
+	return {
+		store,
+		deleted,
+		async list({ prefix }: { prefix: string }) {
+			if (opts.failList) throw new Error("KV list down");
+			return {
+				keys: [...store]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+		async delete(name: string) {
+			if (opts.failDeleteFor?.has(name)) throw new Error("KV delete down");
+			deleted.push(name);
+			store.delete(name);
+		},
+	};
+};
+
+const env = (kv: ReturnType<typeof makeKv>) =>
+	({ TREE_CACHE: kv } as unknown as Parameters<typeof bustTreeCache>[0]);
+
+describe("bustTreeCache", () => {
+	it("deletes every first-page variant for the slug (all sorts + sizes)", async () => {
+		const kv = makeKv([
+			"tree:hello:first:new:n25",
+			"tree:hello:first:top:n25",
+			"tree:hello:first:new:n10",
+			"tree:hello:first", // legacy pre-split key
+		]);
+		await bustTreeCache(env(kv), "hello");
+		expect(kv.deleted.sort()).toEqual([
+			"tree:hello:first",
+			"tree:hello:first:new:n10",
+			"tree:hello:first:new:n25",
+			"tree:hello:first:top:n25",
+		]);
+	});
+
+	it("does not touch other slugs' cache entries", async () => {
+		const kv = makeKv([
+			"tree:hello:first:new:n25",
+			"tree:other:first:new:n25",
+		]);
+		await bustTreeCache(env(kv), "hello");
+		expect(kv.store.has("tree:other:first:new:n25")).toBe(true);
+		expect(kv.store.has("tree:hello:first:new:n25")).toBe(false);
+	});
+
+	it("swallows an individual delete failure (best-effort) and still resolves", async () => {
+		const kv = makeKv(
+			["tree:hello:first:new:n25", "tree:hello:first:top:n25"],
+			{ failDeleteFor: new Set(["tree:hello:first:new:n25"]) },
+		);
+		// Must not reject even though one delete throws.
+		await expect(bustTreeCache(env(kv), "hello")).resolves.toBeUndefined();
+		// The non-failing key was still deleted.
+		expect(kv.deleted).toContain("tree:hello:first:top:n25");
+	});
+
+	it("resolves quietly when the list call itself fails", async () => {
+		const kv = makeKv(["tree:hello:first:new:n25"], { failList: true });
+		await expect(bustTreeCache(env(kv), "hello")).resolves.toBeUndefined();
+		expect(kv.deleted).toHaveLength(0);
+	});
+});

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -53,6 +53,14 @@ OAUTH_CALLBACK_BASE = "https://comments.example.com"
 # Page-level engagement — react / vote on the article itself (default off):
 # PAGE_REACTIONS_ENABLED = "false"
 # PAGE_VOTES_ENABLED = "false"
+# Display & pagination (all optional; clamped server-side). Also editable at
+# runtime from the admin Settings page. Top-level comments per initial load /
+# "Load older" click (default 25, range 1-200 — set 100 for pre-v1.10 behavior):
+# COMMENTS_PER_PAGE = "25"
+# Replies shown per parent before a "Show N more replies" button (0 = all):
+# REPLIES_PER_THREAD = "3"
+# Replies at this nesting depth or deeper start collapsed (0 = never):
+# AUTO_COLLAPSE_DEPTH = "3"
 # Optional: Cloudflare account ID — paired with the CF_API_TOKEN secret to
 # enable the /admin/usage analytics page.
 # CF_ACCOUNT_ID = "0123abcd..."


### PR DESCRIPTION
**Why**

Adds operator-tunable comment pagination and collapsible nested replies so busy threads don’t overwhelm the host page, with numeric settings resolved as **DB row > env var > default** and clamped server-side.

Also includes follow-up fixes from review feedback that changed behavior/details of the implementation:
- `bustTreeCache()` is now fully best-effort (per-key delete failures and list failures are swallowed) so KV issues cannot fail user-visible writes.
- Admin settings write-path error code was corrected from `flags_required` to `settings_required` for both “neither provided” and “only unknown keys” cases.
- Tests were expanded for these cases (`tests/tree-cache.test.ts`, `tests/admin-settings.test.ts`).

Core functionality in this PR remains:
- Configurable `comments_per_page`, `replies_per_thread`, and `auto_collapse_depth`.
- `sort=top` pagination with cursoring and size-stamped cache keys.
- Admin UI/API support for numeric settings.
- Widget-side nested reply collapsing and “show more replies” behavior.
- Config endpoint exposure and related docs updates.

**Linked issue**

none

**Checks**
- [ ] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Updated tests for changed behavior (if it touches API contracts, sanitizer, auth, rate-limit, or depth cap)
- [x] Updated docs (`README.md`, `CLAUDE.md`, `docs/`) if conventions or public behavior changed