### PR TITLE
feat: UI/UX overhaul — admin redesign + widget dark mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,18 +316,32 @@ ancestor.
 | `--garrul-badge-bg`   | `#e0e7ff`                                                | "Verified" badge background            |
 | `--garrul-badge-fg`   | `#1e3a8a`                                                | "Verified" badge text                  |
 | `--garrul-skel`       | `#e7e9ec`                                                | Skeleton-loading placeholder color     |
+| `--garrul-surface`    | `#f7f8fa`                                                | Raised surface fill: composer card, error/notice box |
+| `--garrul-hover`      | `#eef0f3`                                                | Hover background on toolbar/icon buttons |
+| `--garrul-accent-hover` | `#1d4ed8`                                              | Submit button hover background         |
+| `--garrul-vote-active` | `--garrul-badge-bg`                                     | Active vote / reaction highlight (defaults to the badge background) |
+| `--garrul-shadow`     | `0 1px 2px rgba(0,0,0,.06)`                              | Box-shadow on raised surfaces          |
 
-Dark theme starter — override on the host element:
+### Dark mode
+
+The widget ships with a **built-in dark palette**, so hosts no longer have to
+override every variable by hand. By default it follows the visitor's OS/browser
+`prefers-color-scheme`. Pin a theme with `data-theme` on the `#garrul` host:
 
 ```html
 <div id="garrul" data-slug="hello-world" data-api="{{INSTANCE_URL}}"
-  style="--garrul-fg:#f3f4f6;--garrul-bg:#18181b;--garrul-input-bg:#27272a;
-    --garrul-border:#3f3f46;--garrul-muted:#a1a1aa;--garrul-accent:#818cf8;
-    --garrul-accent-fg:#0b0b0e;--garrul-link:#a5b4fc;--garrul-badge-bg:#312e81;
-    --garrul-badge-fg:#c7d2fe;--garrul-skel:#27272a;"></div>
+  data-theme="dark"></div>
 ```
 
-For the full reference and stability policy, see `docs/THEMING.md`.
+| `data-theme` value | Behavior                                |
+| ------------------ | --------------------------------------- |
+| absent / `auto`    | Follow `prefers-color-scheme` (default) |
+| `light`            | Always light                            |
+| `dark`             | Always dark                             |
+
+Host `--garrul-*` overrides still win at every theme level, so the table above
+remains the supported customization surface. For the full reference and
+stability policy, see `docs/THEMING.md`.
 
 ## 6. Iframe fallback
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -51,6 +51,47 @@ Or in a stylesheet:
 | `--garrul-badge-bg`       | `#e0e7ff`                                | "Verified" badge background           |
 | `--garrul-badge-fg`       | `#1e3a8a`                                | "Verified" badge text                 |
 | `--garrul-skel`           | `#e7e9ec`                                | Skeleton-loading placeholder color    |
+| `--garrul-notice`         | `#1e6091`                                | Informational notice messages (e.g. a closed thread) |
+| `--garrul-surface`        | `#f7f8fa`                                | Raised surface fill: composer card, error/notice box |
+| `--garrul-hover`          | `#eef0f3`                                | Hover background on toolbar/icon buttons |
+| `--garrul-accent-hover`   | `#1d4ed8`                                | Submit button hover background        |
+| `--garrul-vote-active`    | `--garrul-badge-bg`                      | Active vote / reaction highlight (defaults to the badge background) |
+| `--garrul-shadow`         | `0 1px 2px rgba(0,0,0,.06)`              | Box-shadow on raised surfaces         |
+
+## Dark mode
+
+The widget ships with a built-in dark palette — hosts no longer have to
+override every variable by hand to support dark backgrounds.
+
+**Automatic (default).** With no configuration, the widget follows the
+visitor's OS/browser preference via `prefers-color-scheme`. A reader on a
+dark system sees the dark palette; a reader on a light system sees light.
+
+**Forced.** Set `data-theme` on the `#garrul` host element to pin a theme
+regardless of OS preference:
+
+```html
+<div id="garrul" data-slug="hello-world" data-theme="dark"></div>
+```
+
+| `data-theme` value      | Behavior                                    |
+| ----------------------- | ------------------------------------------- |
+| absent / `auto`         | Follow `prefers-color-scheme` (default)     |
+| `light`                 | Always light                                |
+| `dark`                  | Always dark                                 |
+
+**Precedence (highest wins):**
+
+1. An explicit `--garrul-*` override you set on the host or an ancestor.
+2. `data-theme="dark"` / `data-theme="light"` on `#garrul`.
+3. The OS `prefers-color-scheme` preference.
+4. The built-in light defaults.
+
+Because every theme level resolves through the public `--garrul-*`
+variables, **your manual overrides always win** — the "How to override"
+stylesheet above (or any subset of it) keeps working unchanged, layering
+on top of whichever base theme is active. Override only the variables you
+care about; the rest fall back to the active theme's defaults.
 
 ## Stability
 

--- a/src/admin-ui/charts.ts
+++ b/src/admin-ui/charts.ts
@@ -1,0 +1,78 @@
+import type { TimelinePoint } from "../db/queries";
+import { escapeHtml } from "./escape";
+
+// Server-rendered inline SVG charts. No JS charting library and no external
+// origin, so the strict admin CSP is unaffected. Colors use CSS variables so
+// charts re-theme with light/dark automatically.
+
+/**
+ * A compact line sparkline. Kept for callers that want the minimal one-line
+ * form; the dashboard uses {@link barChartSvg} for the main timeline.
+ */
+export const sparklineSvg = (points: TimelinePoint[]): string => {
+	if (points.length === 0)
+		return '<div class="muted">No activity in this range.</div>';
+	const w = 320;
+	const h = 60;
+	const pad = 4;
+	const max = Math.max(1, ...points.map((p) => p.count));
+	const step = points.length > 1 ? (w - pad * 2) / (points.length - 1) : 0;
+	const coords = points.map((p, i) => {
+		const x = pad + i * step;
+		const y = h - pad - ((h - pad * 2) * p.count) / max;
+		return `${x.toFixed(1)},${y.toFixed(1)}`;
+	});
+	const path = `M ${coords.join(" L ")}`;
+	const last = points[points.length - 1];
+	const first = points[0];
+	return `
+<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" role="img"
+     aria-label="Comments per day sparkline">
+  <path d="${path}" fill="none" stroke="var(--accent)" stroke-width="1.5"/>
+  <title>${points.length} days · peak ${max}/day</title>
+</svg>
+<div class="muted" style="font-size:0.75rem">
+  ${escapeHtml(first?.day ?? "")} → ${escapeHtml(last?.day ?? "")} · peak ${max}/day
+</div>`;
+};
+
+/**
+ * A responsive bar chart of comments per day. The SVG fills its container
+ * width (`preserveAspectRatio="none"`); each bar carries a `<title>` for a
+ * native hover tooltip. Axis labels live in the HTML caption below, not inside
+ * the stretched SVG, so text never distorts.
+ */
+export const barChartSvg = (points: TimelinePoint[]): string => {
+	if (points.length === 0)
+		return '<div class="muted">No activity in this range.</div>';
+	const h = 120;
+	const pad = 6;
+	const gap = 2;
+	const barW = 10;
+	const n = points.length;
+	const max = Math.max(1, ...points.map((p) => p.count));
+	const innerH = h - pad * 2;
+	const w = n * barW + (n - 1) * gap;
+	const bars = points
+		.map((p, i) => {
+			const bh = (innerH * p.count) / max;
+			const x = i * (barW + gap);
+			const y = h - pad - bh;
+			// Keep a 1px stub for zero days so the baseline reads as data, not a gap.
+			const drawn = p.count > 0 ? Math.max(2, bh) : 1;
+			return `<rect x="${x.toFixed(1)}" y="${(h - pad - drawn).toFixed(1)}" width="${barW}" height="${drawn.toFixed(1)}" rx="1.5" fill="var(--accent)"${p.count === 0 ? ' opacity="0.25"' : ""}><title>${escapeHtml(p.day)} · ${p.count}</title></rect>`;
+		})
+		.join("");
+	const midY = pad + innerH / 2;
+	const first = points[0];
+	const last = points[points.length - 1];
+	return `
+<svg class="chart" viewBox="0 0 ${w} ${h}" width="100%" height="${h}" preserveAspectRatio="none" role="img" aria-label="Comments per day bar chart">
+  <line x1="0" y1="${midY}" x2="${w}" y2="${midY}" stroke="var(--border)" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="0" y1="${h - pad}" x2="${w}" y2="${h - pad}" stroke="var(--border)" stroke-width="1"/>
+  ${bars}
+</svg>
+<div class="muted" style="font-size:0.75rem;margin-top:0.35rem">
+  ${escapeHtml(first?.day ?? "")} → ${escapeHtml(last?.day ?? "")} · peak ${max}/day
+</div>`;
+};

--- a/src/admin-ui/controls.ts
+++ b/src/admin-ui/controls.ts
@@ -1,0 +1,83 @@
+import { escapeHtml } from "./escape";
+
+// Shared form-control renderers for the admin UI. They keep the underlying
+// native inputs (`name`, `x-model`) byte-identical to the old markup so the
+// settings POST contract is unchanged — only the surrounding chrome changes.
+
+export type SwitchOpts = {
+	/** Native input `name` (also the settings key). */
+	name: string;
+	/** Alpine x-model expression, e.g. "flags.comments_enabled". */
+	model: string;
+	label: string;
+	help: string;
+};
+
+/**
+ * A label + help row with a CSS-only toggle switch. The native checkbox is
+ * visually hidden but still drives `name`/`x-model`, so form submission and
+ * Alpine state work exactly as a bare checkbox would.
+ */
+export const renderSwitch = ({ name, model, label, help }: SwitchOpts): string => `
+<label class="switch-row">
+  <span class="switch">
+    <input type="checkbox" name="${escapeHtml(name)}" x-model="${model}">
+    <span class="switch-track"><span class="switch-thumb"></span></span>
+  </span>
+  <span class="field-text">
+    <strong>${escapeHtml(label)}</strong>
+    <span class="muted">${escapeHtml(help)}</span>
+  </span>
+</label>`;
+
+export type StepperOpts = {
+	name: string;
+	/** Alpine x-model expression, e.g. "nums.comments_per_page". */
+	model: string;
+	min: number;
+	max: number;
+	label: string;
+	help: string;
+};
+
+/**
+ * A label + help row with a numeric stepper (− / value / +). The − and +
+ * buttons clamp to [min, max] in Alpine; the input keeps the same `name` and
+ * `x-model.number` binding as the old bare number input. `model` is always a
+ * fixed settings key (never user input), so interpolating it raw into the
+ * @click expressions is safe.
+ */
+export const renderStepper = ({ name, model, min, max, label, help }: StepperOpts): string => `
+<div class="field-row">
+  <span class="stepper">
+    <button type="button" class="stepper-btn" aria-label="Decrease ${escapeHtml(label)}"
+            @click="${model} = Math.max(${min}, (Number(${model}) || 0) - 1)">−</button>
+    <input type="number" name="${escapeHtml(name)}" min="${min}" max="${max}" step="1"
+           x-model.number="${model}">
+    <button type="button" class="stepper-btn" aria-label="Increase ${escapeHtml(label)}"
+            @click="${model} = Math.min(${max}, (Number(${model}) || 0) + 1)">+</button>
+  </span>
+  <span class="field-text">
+    <strong>${escapeHtml(label)}</strong>
+    <span class="muted">${escapeHtml(help)}</span>
+  </span>
+</div>`;
+
+export type TabDef = { id: string; label: string };
+
+/**
+ * A tab strip bound to an Alpine state property. `stateVar` is the property on
+ * the surrounding x-data scope that holds the active tab id (e.g. "tab").
+ */
+export const renderTabs = (stateVar: string, tabs: TabDef[]): string => {
+	const buttons = tabs
+		.map(
+			(t) => `
+  <button type="button" class="tab" role="tab"
+          :class="${stateVar} === '${t.id}' && 'active'"
+          :aria-selected="${stateVar} === '${t.id}'"
+          @click="${stateVar} = '${t.id}'">${escapeHtml(t.label)}</button>`,
+		)
+		.join("");
+	return `<div class="tabs" role="tablist">${buttons}</div>`;
+};

--- a/src/admin-ui/controls.ts
+++ b/src/admin-ui/controls.ts
@@ -65,19 +65,35 @@ export const renderStepper = ({ name, model, min, max, label, help }: StepperOpt
 
 export type TabDef = { id: string; label: string };
 
+// `stateVar` and `t.id` are interpolated raw into Alpine *expression* strings
+// (:class / @click), not just HTML text. HTML-escaping them is NOT sufficient:
+// the HTML parser decodes entities before Alpine evaluates, so an encoded quote
+// would decode back to a real quote and could break out of the JS string into
+// an Alpine expression (which runs under script-src 'unsafe-eval'). These are
+// always developer-defined constants, so enforce that with a strict identifier
+// allowlist — a stray or user-derived value fails loudly instead of injecting.
+const SAFE_STATE_VAR = /^[A-Za-z_$][\w$.]*$/;
+const SAFE_TAB_ID = /^[A-Za-z0-9_-]+$/;
+
 /**
  * A tab strip bound to an Alpine state property. `stateVar` is the property on
  * the surrounding x-data scope that holds the active tab id (e.g. "tab").
  */
 export const renderTabs = (stateVar: string, tabs: TabDef[]): string => {
+	if (!SAFE_STATE_VAR.test(stateVar)) {
+		throw new Error(`renderTabs: unsafe stateVar ${JSON.stringify(stateVar)}`);
+	}
 	const buttons = tabs
-		.map(
-			(t) => `
+		.map((t) => {
+			if (!SAFE_TAB_ID.test(t.id)) {
+				throw new Error(`renderTabs: unsafe tab id ${JSON.stringify(t.id)}`);
+			}
+			return `
   <button type="button" class="tab" role="tab"
           :class="${stateVar} === '${t.id}' && 'active'"
           :aria-selected="${stateVar} === '${t.id}'"
-          @click="${stateVar} = '${t.id}'">${escapeHtml(t.label)}</button>`,
-		)
+          @click="${stateVar} = '${t.id}'">${escapeHtml(t.label)}</button>`;
+		})
 		.join("");
 	return `<div class="tabs" role="tablist">${buttons}</div>`;
 };

--- a/src/admin-ui/controls.ts
+++ b/src/admin-ui/controls.ts
@@ -72,7 +72,10 @@ export type TabDef = { id: string; label: string };
 // an Alpine expression (which runs under script-src 'unsafe-eval'). These are
 // always developer-defined constants, so enforce that with a strict identifier
 // allowlist — a stray or user-derived value fails loudly instead of injecting.
-const SAFE_STATE_VAR = /^[A-Za-z_$][\w$.]*$/;
+// A dot-separated identifier path (e.g. "tab" or "settings.tab"): every
+// segment must itself be a valid identifier. A looser `[\w$.]*` body would also
+// admit malformed paths like `a..b`, `a.`, or `.a`, which defeat the point.
+const SAFE_STATE_VAR = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/;
 const SAFE_TAB_ID = /^[A-Za-z0-9_-]+$/;
 
 /**

--- a/src/admin-ui/controls.ts
+++ b/src/admin-ui/controls.ts
@@ -4,6 +4,26 @@ import { escapeHtml } from "./escape";
 // native inputs (`name`, `x-model`) byte-identical to the old markup so the
 // settings POST contract is unchanged — only the surrounding chrome changes.
 
+// A dot-separated identifier path (e.g. "tab", "flags.comments_enabled"): every
+// segment must itself be a valid identifier. A looser `[\w$.]*` body would also
+// admit malformed paths like `a..b`, `a.`, or `.a`, which defeat the point.
+const SAFE_STATE_VAR = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/;
+const SAFE_TAB_ID = /^[A-Za-z0-9_-]+$/;
+
+// `model`/`stateVar`/`t.id` are interpolated raw into Alpine *expression*
+// strings (x-model / :class / @click), not just HTML text. HTML-escaping them
+// is NOT sufficient: the HTML parser decodes entities before Alpine evaluates,
+// so an encoded quote would decode back to a real quote and could break out of
+// the JS string into an Alpine expression (which runs under script-src
+// 'unsafe-eval'). These are always developer-defined constants, so enforce that
+// with a strict identifier allowlist — a stray or user-derived value fails
+// loudly here instead of injecting silently.
+const assertSafeExpr = (label: string, value: string): void => {
+	if (!SAFE_STATE_VAR.test(value)) {
+		throw new Error(`${label}: unsafe expression ${JSON.stringify(value)}`);
+	}
+};
+
 export type SwitchOpts = {
 	/** Native input `name` (also the settings key). */
 	name: string;
@@ -18,7 +38,9 @@ export type SwitchOpts = {
  * visually hidden but still drives `name`/`x-model`, so form submission and
  * Alpine state work exactly as a bare checkbox would.
  */
-export const renderSwitch = ({ name, model, label, help }: SwitchOpts): string => `
+export const renderSwitch = ({ name, model, label, help }: SwitchOpts): string => {
+	assertSafeExpr("renderSwitch", model);
+	return `
 <label class="switch-row">
   <span class="switch">
     <input type="checkbox" name="${escapeHtml(name)}" x-model="${model}">
@@ -29,6 +51,7 @@ export const renderSwitch = ({ name, model, label, help }: SwitchOpts): string =
     <span class="muted">${escapeHtml(help)}</span>
   </span>
 </label>`;
+};
 
 export type StepperOpts = {
 	name: string;
@@ -43,11 +66,13 @@ export type StepperOpts = {
 /**
  * A label + help row with a numeric stepper (− / value / +). The − and +
  * buttons clamp to [min, max] in Alpine; the input keeps the same `name` and
- * `x-model.number` binding as the old bare number input. `model` is always a
- * fixed settings key (never user input), so interpolating it raw into the
- * @click expressions is safe.
+ * `x-model.number` binding as the old bare number input. `model` is interpolated
+ * raw into the @click expressions, so it is held to the same identifier
+ * allowlist as `renderTabs` (`min`/`max` are numbers and need no guard).
  */
-export const renderStepper = ({ name, model, min, max, label, help }: StepperOpts): string => `
+export const renderStepper = ({ name, model, min, max, label, help }: StepperOpts): string => {
+	assertSafeExpr("renderStepper", model);
+	return `
 <div class="field-row">
   <span class="stepper">
     <button type="button" class="stepper-btn" aria-label="Decrease ${escapeHtml(label)}"
@@ -62,30 +87,16 @@ export const renderStepper = ({ name, model, min, max, label, help }: StepperOpt
     <span class="muted">${escapeHtml(help)}</span>
   </span>
 </div>`;
+};
 
 export type TabDef = { id: string; label: string };
-
-// `stateVar` and `t.id` are interpolated raw into Alpine *expression* strings
-// (:class / @click), not just HTML text. HTML-escaping them is NOT sufficient:
-// the HTML parser decodes entities before Alpine evaluates, so an encoded quote
-// would decode back to a real quote and could break out of the JS string into
-// an Alpine expression (which runs under script-src 'unsafe-eval'). These are
-// always developer-defined constants, so enforce that with a strict identifier
-// allowlist — a stray or user-derived value fails loudly instead of injecting.
-// A dot-separated identifier path (e.g. "tab" or "settings.tab"): every
-// segment must itself be a valid identifier. A looser `[\w$.]*` body would also
-// admit malformed paths like `a..b`, `a.`, or `.a`, which defeat the point.
-const SAFE_STATE_VAR = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/;
-const SAFE_TAB_ID = /^[A-Za-z0-9_-]+$/;
 
 /**
  * A tab strip bound to an Alpine state property. `stateVar` is the property on
  * the surrounding x-data scope that holds the active tab id (e.g. "tab").
  */
 export const renderTabs = (stateVar: string, tabs: TabDef[]): string => {
-	if (!SAFE_STATE_VAR.test(stateVar)) {
-		throw new Error(`renderTabs: unsafe stateVar ${JSON.stringify(stateVar)}`);
-	}
+	assertSafeExpr("renderTabs", stateVar);
 	const buttons = tabs
 		.map((t) => {
 			if (!SAFE_TAB_ID.test(t.id)) {

--- a/src/admin-ui/icons.ts
+++ b/src/admin-ui/icons.ts
@@ -1,0 +1,46 @@
+// Inline SVG icon set for the admin UI. Icons use `stroke="currentColor"` so
+// they inherit the surrounding text color and theme automatically (no fills to
+// re-theme). Paths are 24×24, MIT-licensed Lucide geometry.
+//
+// Kept dependency-free and inline so the strict admin CSP needs no external
+// image/font origin. Add new entries to ICON_PATHS and reference by name.
+
+const ICON_PATHS: Record<string, string> = {
+	dashboard:
+		'<rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/>',
+	queue:
+		'<path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>',
+	reply:
+		'<polyline points="9 14 4 9 9 4"/><path d="M20 20v-7a4 4 0 0 0-4-4H4"/>',
+	users:
+		'<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+	subscriptions:
+		'<path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/>',
+	webhook:
+		'<path d="M18 16.98h-5.99c-1.1 0-1.95.94-2.48 1.9A4 4 0 1 1 2 17"/><path d="m6 17 3.13-5.78c.53-.97.1-2.18-.5-3.1a4 4 0 1 1 6.89-4.06"/><path d="m12 6 3.13 5.73C15.66 12.7 16.9 13 18 13a4 4 0 0 1 0 8"/>',
+	audit:
+		'<rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M9 12h6"/><path d="M9 16h6"/>',
+	usage: '<path d="M22 12h-4l-3 9L9 3l-3 9H2"/>',
+	operator:
+		'<polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>',
+	settings:
+		'<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>',
+	about:
+		'<circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/>',
+	sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>',
+	moon: '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9z"/>',
+	menu: '<line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>',
+	copy: '<rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+	chevron: '<polyline points="6 9 12 15 18 9"/>',
+};
+
+/**
+ * Render an inline SVG icon by name. Returns an empty string for unknown names.
+ * The `name` is always a literal from {@link ICON_PATHS}, never user input, so
+ * the lookup result is trusted markup.
+ */
+export const icon = (name: keyof typeof ICON_PATHS | string, size = 18): string => {
+	const path = ICON_PATHS[name];
+	if (!path) return "";
+	return `<svg class="icon" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${path}</svg>`;
+};

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -1,7 +1,35 @@
 import type { User } from "../db/queries";
 import type { UpdateInfo } from "../lib/version-check";
 import { escapeHtml } from "./escape";
+import { icon } from "./icons";
 import { ADMIN_CSS, ALPINE_SRI, ALPINE_VERSION } from "./styles";
+
+type NavLink = { href: string; label: string; icon: string };
+type NavSection = { heading: string; links: NavLink[] };
+
+// Build one sidebar section. The section heading renders only when the
+// section has at least one visible link, so mods (who see an empty Manage /
+// System section) don't get dangling headers. `active` adds a SEPARATE
+// `class="... active"` attribute so the `href="..."` substrings the
+// role-gating tests assert on stay byte-identical.
+const renderNavSection = (
+	section: NavSection,
+	activePath: string | undefined,
+): string => {
+	if (section.links.length === 0) return "";
+	const links = section.links
+		.map((l) => {
+			const isActive = activePath === l.href;
+			return `<a href="${l.href}" class="nav-link${isActive ? " active" : ""}"
+       ${isActive ? 'aria-current="page"' : ""}
+       @click="navOpen = false">${icon(l.icon)}<span>${escapeHtml(l.label)}</span></a>`;
+		})
+		.join("");
+	return `<div class="nav-section">
+  <p class="nav-heading">${escapeHtml(section.heading)}</p>
+  ${links}
+</div>`;
+};
 
 const statusTitle = (status: 401 | 403 | 404): string => {
 	if (status === 401) return "Sign in required";
@@ -56,6 +84,8 @@ export const renderUpdateBanner = (info: UpdateInfo | null): string => {
 
 export type LayoutOpts = {
 	usage_link?: boolean;
+	/** Request path of the current page, used to highlight the active nav link. */
+	activePath?: string;
 };
 
 export const layout = (
@@ -72,20 +102,51 @@ export const layout = (
 			: currentUser.role === "mod"
 				? '<span class="pill mod">mod</span>'
 				: "";
-	// Admin-only nav links. Mods see only the queue (plus Dashboard +
-	// About which are always-on) — every other surface requires admin
-	// scope. The Usage link further gates on whether CF_API_TOKEN +
-	// CF_ACCOUNT_ID are configured (see opts.usage_link).
-	const adminOnlyLinks = isAdmin
-		? `
-    <a href="/admin/users">Users</a>
-    <a href="/admin/audit">Audit</a>
-    <a href="/admin/subscriptions">Subscriptions</a>
-    <a href="/admin/webhooks">Webhooks</a>
-    ${opts.usage_link ? '<a href="/admin/usage">Usage</a>' : ""}
-    <a href="/admin/operator">Operator</a>
-    <a href="/admin/settings">Settings</a>`
-		: "";
+	// Sidebar nav, grouped into sections. Mods see only Moderation (plus the
+	// always-on About link) — every Manage/System surface requires admin
+	// scope, so those sections come up empty for mods and renderNavSection
+	// drops their headers. The Usage link further gates on whether
+	// CF_API_TOKEN + CF_ACCOUNT_ID are configured (see opts.usage_link).
+	const manageLinks: NavLink[] = isAdmin
+		? [
+				{ href: "/admin/users", label: "Users", icon: "users" },
+				{
+					href: "/admin/subscriptions",
+					label: "Subscriptions",
+					icon: "subscriptions",
+				},
+				{ href: "/admin/webhooks", label: "Webhooks", icon: "webhook" },
+			]
+		: [];
+	const systemLinks: NavLink[] = isAdmin
+		? [
+				{ href: "/admin/audit", label: "Audit", icon: "audit" },
+				...(opts.usage_link
+					? [{ href: "/admin/usage", label: "Usage", icon: "usage" }]
+					: []),
+				{ href: "/admin/operator", label: "Operator", icon: "operator" },
+				{ href: "/admin/settings", label: "Settings", icon: "settings" },
+			]
+		: [];
+	const navSections: NavSection[] = [
+		{
+			heading: "Moderation",
+			links: [
+				{ href: "/admin", label: "Dashboard", icon: "dashboard" },
+				{ href: "/admin/queue", label: "Queue", icon: "queue" },
+				{ href: "/admin/saved-replies", label: "Replies", icon: "reply" },
+			],
+		},
+		{ heading: "Manage", links: manageLinks },
+		{ heading: "System", links: systemLinks },
+		{
+			heading: "Help",
+			links: [{ href: "/admin/about", label: "About", icon: "about" }],
+		},
+	];
+	const navHtml = navSections
+		.map((s) => renderNavSection(s, opts.activePath))
+		.join("\n");
 	// The theme lives on <html> as data-theme. We can't use the usual inline
 	// <head> script to set it before first paint (admin CSP forbids inline
 	// <script>), so the CSS handles the no-JS case: :root is light and a
@@ -113,20 +174,35 @@ export const layout = (
 </head>
 <body>
 ${renderUpdateBanner(updateInfo)}
-<header>
-  <h1>Garrul Admin</h1>
-  <nav>
-    <a href="/admin">Dashboard</a>
-    <a href="/admin/queue">Queue</a>
-    <a href="/admin/saved-replies">Replies</a>${adminOnlyLinks}
-    <a href="/admin/about">About</a>
-  </nav>
-  <span class="me">${escapeHtml(currentUser.name)} ${rolePill}
-    <button class="help-btn theme-btn" @click="setTheme(theme === 'dark' ? 'light' : 'dark')"
-            :aria-label="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'"
-            x-text="theme === 'dark' ? '☀' : '☾'"></button>
-    <button class="help-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button></span>
-</header>
+<div class="app-shell">
+  <div class="scrim" x-show="navOpen" x-cloak @click="navOpen = false"></div>
+  <aside class="sidebar" :class="navOpen && 'open'">
+    <a href="/admin" class="brand" @click="navOpen = false">${icon("queue", 22)}<span>Garrul</span></a>
+    <nav class="sidebar-nav">
+${navHtml}
+    </nav>
+    <div class="sidebar-footer">
+      <span class="me">${escapeHtml(currentUser.name)} ${rolePill}</span>
+      <span class="footer-actions">
+        <button class="icon-btn" @click="setTheme(theme === 'dark' ? 'light' : 'dark')"
+                :aria-label="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'">
+          <span x-show="theme === 'dark'">${icon("sun")}</span>
+          <span x-show="theme !== 'dark'" x-cloak>${icon("moon")}</span>
+        </button>
+        <button class="icon-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button>
+      </span>
+    </div>
+  </aside>
+  <div class="content">
+    <div class="topbar">
+      <button class="icon-btn hamburger" @click="navOpen = !navOpen" aria-label="Toggle navigation">${icon("menu")}</button>
+      <h1>${escapeHtml(title)}</h1>
+    </div>
+    <main>
+${body}
+    </main>
+  </div>
+</div>
 <div class="toast-tray" role="status" aria-live="polite" aria-atomic="true"
      x-data="{ items: [] }"
      @toast.window="items.push({ id: Date.now() + Math.random(), text: $event.detail.text, kind: $event.detail.kind || 'ok' }); setTimeout(() => { items.shift(); }, 4000)">
@@ -142,9 +218,6 @@ ${renderUpdateBanner(updateInfo)}
     <dt><kbd>Esc</kbd></dt><dd>Close help</dd>
   </dl>
 </div>
-<main>
-${body}
-</main>
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@${ALPINE_VERSION}/dist/cdn.min.js"
         integrity="${ALPINE_SRI}"
         crossorigin="anonymous"

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -86,19 +86,32 @@ export const layout = (
     <a href="/admin/operator">Operator</a>
     <a href="/admin/settings">Settings</a>`
 		: "";
+	// The theme lives on <html> as data-theme. We can't use the usual inline
+	// <head> script to set it before first paint (admin CSP forbids inline
+	// <script>), so the CSS handles the no-JS case: :root is light and a
+	// prefers-color-scheme block flips to dark, so the first paint already
+	// respects the OS preference. Alpine then reconciles the stored choice on
+	// x-init. localStorage key matches the renderUpdateBanner convention.
 	return `
 <!doctype html>
-<html lang="en">
+<html lang="en"
+      x-data="{
+        theme: localStorage.getItem('garrul.theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'),
+        helpOpen: false,
+        navOpen: false,
+        setTheme(t) { this.theme = t; localStorage.setItem('garrul.theme', t); document.documentElement.setAttribute('data-theme', t); }
+      }"
+      x-init="document.documentElement.setAttribute('data-theme', theme)"
+      @keydown.window.slash.prevent="(() => { const el = document.querySelector('input[type=text],input[type=search]'); if (el) el.focus(); })()"
+      @keydown.window.question-mark.prevent="helpOpen = !helpOpen"
+      @keydown.window.escape="helpOpen = false">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(title)} — Garrul Admin</title>
 <style>${ADMIN_CSS}</style>
 </head>
-<body x-data="{ helpOpen: false }"
-      @keydown.window.slash.prevent="(() => { const el = document.querySelector('input[type=text],input[type=search]'); if (el) el.focus(); })()"
-      @keydown.window.question-mark.prevent="helpOpen = !helpOpen"
-      @keydown.window.escape="helpOpen = false">
+<body>
 ${renderUpdateBanner(updateInfo)}
 <header>
   <h1>Garrul Admin</h1>
@@ -108,7 +121,11 @@ ${renderUpdateBanner(updateInfo)}
     <a href="/admin/saved-replies">Replies</a>${adminOnlyLinks}
     <a href="/admin/about">About</a>
   </nav>
-  <span class="me">${escapeHtml(currentUser.name)} ${rolePill} <button class="help-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button></span>
+  <span class="me">${escapeHtml(currentUser.name)} ${rolePill}
+    <button class="help-btn theme-btn" @click="setTheme(theme === 'dark' ? 'light' : 'dark')"
+            :aria-label="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'"
+            x-text="theme === 'dark' ? '☀' : '☾'"></button>
+    <button class="help-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button></span>
 </header>
 <div class="toast-tray" role="status" aria-live="polite" aria-atomic="true"
      x-data="{ items: [] }"

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -19,7 +19,14 @@ const renderNavSection = (
 	if (section.links.length === 0) return "";
 	const links = section.links
 		.map((l) => {
-			const isActive = activePath === l.href;
+			// The dashboard root ("/admin") is a prefix of every admin path, so it
+			// must match exactly; all other links highlight on their sub-pages too
+			// (e.g. /admin/users/:id keeps "Users" active) via a prefix match.
+			const isActive =
+				activePath !== undefined &&
+				(l.href === "/admin"
+					? activePath === "/admin"
+					: activePath === l.href || activePath.startsWith(`${l.href}/`));
 			return `<a href="${l.href}" class="nav-link${isActive ? " active" : ""}"
        ${isActive ? 'aria-current="page"' : ""}
        @click="navOpen = false">${icon(l.icon)}<span>${escapeHtml(l.label)}</span></a>`;

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -202,8 +202,9 @@ ${navHtml}
       <span class="me">${escapeHtml(currentUser.name)} ${rolePill}</span>
       <span class="footer-actions">
         <button class="icon-btn" @click="setTheme(theme === 'dark' ? 'light' : 'dark')"
+                aria-label="Toggle theme"
                 :aria-label="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'">
-          <span x-show="theme === 'dark'">${icon("sun")}</span>
+          <span x-show="theme === 'dark'" x-cloak>${icon("sun")}</span>
           <span x-show="theme !== 'dark'" x-cloak>${icon("moon")}</span>
         </button>
         <button class="icon-btn" @click="helpOpen = !helpOpen" aria-label="Keyboard shortcuts">?</button>

--- a/src/admin-ui/layout.ts
+++ b/src/admin-ui/layout.ts
@@ -47,12 +47,22 @@ export const accessDeniedHtml = (
 <meta charset="utf-8">
 <title>${statusTitle(status)} — Garrul Admin</title>
 <style>
+  /* Light default; flip to dark on OS preference. Mirrors the admin theme
+     tokens but standalone (this page renders before the app shell / Alpine,
+     and the admin CSP forbids the usual inline no-FOUC script). */
+  :root { --bg: #f6f8fa; --fg: #1b2733; --muted: #5c6b7a;
+          --accent: #2563eb; --code-bg: #f0f3f6; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #0b0d10; --fg: #e7eaf0; --muted: #8a93a6;
+            --accent: #6aa9ff; --code-bg: #1e2530; }
+  }
   body { font-family: system-ui, -apple-system, Segoe UI, sans-serif;
-         background: #0b0d10; color: #e7eaf0; max-width: 480px;
+         background: var(--bg); color: var(--fg); max-width: 480px;
          margin: 4rem auto; padding: 0 1rem; line-height: 1.55; }
   h1 { margin-top: 0; }
-  a { color: #6aa9ff; }
-  code { background: #1e2530; padding: 0.1rem 0.3rem; border-radius: 3px; }
+  a { color: var(--accent); }
+  .muted { color: var(--muted); }
+  code { background: var(--code-bg); padding: 0.1rem 0.3rem; border-radius: 3px; }
 </style>
 </head>
 <body>

--- a/src/admin-ui/pages/dashboard.ts
+++ b/src/admin-ui/pages/dashboard.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../db/queries";
 import { spamSummary } from "../components/spam-summary";
 import { identiconSvg } from "../../lib/identicon";
+import { barChartSvg } from "../charts";
 import { escapeHtml } from "../escape";
 
 export type DashboardData = {
@@ -19,33 +20,6 @@ export type DashboardData = {
 	oldest_pending: { id: string; created_at: number } | null;
 	spam_rate: SpamRate;
 	by_host: CommentsByHostRow[];
-};
-
-const sparklineSvg = (points: TimelinePoint[]): string => {
-	if (points.length === 0)
-		return '<div class="muted">No activity in this range.</div>';
-	const w = 320;
-	const h = 60;
-	const pad = 4;
-	const max = Math.max(1, ...points.map((p) => p.count));
-	const step = points.length > 1 ? (w - pad * 2) / (points.length - 1) : 0;
-	const coords = points.map((p, i) => {
-		const x = pad + i * step;
-		const y = h - pad - ((h - pad * 2) * p.count) / max;
-		return `${x.toFixed(1)},${y.toFixed(1)}`;
-	});
-	const path = `M ${coords.join(" L ")}`;
-	const last = points[points.length - 1];
-	const first = points[0];
-	return `
-<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" role="img"
-     aria-label="Comments per day sparkline">
-  <path d="${path}" fill="none" stroke="var(--accent)" stroke-width="1.5"/>
-  <title>${points.length} days · peak ${max}/day</title>
-</svg>
-<div class="muted" style="font-size:0.75rem">
-  ${escapeHtml(first?.day ?? "")} → ${escapeHtml(last?.day ?? "")} · peak ${max}/day
-</div>`;
 };
 
 const relAge = (ts: number, now: number = Date.now()): string => {
@@ -136,6 +110,37 @@ const byHostPanel = (rows: CommentsByHostRow[]): string => {
 </div>`;
 };
 
+// Best-effort public origin for the embed snippet. PUBLIC_BASE_URL is the
+// operator-configured canonical URL of this Worker; if it's unset (e.g. a
+// fresh dev instance) we fall back to a clearly-placeholder host so the
+// snippet still reads correctly and the operator knows what to replace.
+const embedOrigin = (env: Bindings): string => {
+	const raw = (env.PUBLIC_BASE_URL || "").trim().replace(/\/+$/, "");
+	return raw || "https://comments.example.com";
+};
+
+const embedCard = (env: Bindings): string => {
+	const origin = escapeHtml(embedOrigin(env));
+	// The snippet is shown verbatim AND copied from $refs.embed.textContent,
+	// so it must be valid host markup with entities the browser decodes back
+	// to real characters on copy. data-slug is a placeholder the operator
+	// swaps per page.
+	const snippet = `&lt;div id="garrul" data-slug="YOUR_PAGE_SLUG" data-api="${origin}"&gt;&lt;/div&gt;
+&lt;script src="${origin}/embed.js" defer&gt;&lt;/script&gt;`;
+	return `
+<div class="card" x-data>
+  <div class="card-head">
+    <h3>Embed on your site</h3>
+    <button class="btn btn-secondary"
+            @click="navigator.clipboard && navigator.clipboard.writeText($refs.embed.textContent).then(
+              () => $dispatch('toast', { text: 'Embed code copied' }),
+              () => $dispatch('toast', { text: 'Copy failed', kind: 'bad' }))">Copy</button>
+  </div>
+  <p class="muted">Paste this where comments should appear. Set <code>data-slug</code> to a stable per-page id.</p>
+  <pre class="embed-snippet" x-ref="embed"><code>${snippet}</code></pre>
+</div>`;
+};
+
 export const renderDashboard = (
 	data: DashboardData,
 	env: Bindings,
@@ -145,11 +150,11 @@ export const renderDashboard = (
 <div class="card">
   <h2>Overview</h2>
   <div class="stat-grid">
-    <div class="stat"><div class="v">${stats.total_comments}</div><div class="l">total comments</div></div>
-    <div class="stat"><div class="v">${stats.pending_comments}</div><div class="l">pending</div></div>
-    <div class="stat"><div class="v">${stats.spam_comments}</div><div class="l">spam</div></div>
+    <div class="stat accent"><div class="v">${stats.total_comments}</div><div class="l">total comments</div></div>
+    <div class="stat${stats.pending_comments > 0 ? " warn" : ""}"><div class="v">${stats.pending_comments}</div><div class="l">pending</div></div>
+    <div class="stat${stats.spam_comments > 0 ? " bad" : ""}"><div class="v">${stats.spam_comments}</div><div class="l">spam</div></div>
     <div class="stat"><div class="v">${stats.total_users}</div><div class="l">users</div></div>
-    <div class="stat"><div class="v">${stats.banned_users}</div><div class="l">banned</div></div>
+    <div class="stat${stats.banned_users > 0 ? " bad" : ""}"><div class="v">${stats.banned_users}</div><div class="l">banned</div></div>
     <div class="stat">
       <div class="v" style="font-size:1.1rem">${oldestPendingCell(oldest_pending)}</div>
       <div class="l">oldest pending</div>
@@ -162,9 +167,11 @@ export const renderDashboard = (
   <p class="muted">Anti-spam: ${spamSummary(env)}. See <a href="/admin/settings">Settings</a> to change.</p>
 </div>
 
+${embedCard(env)}
+
 <div class="card">
   <h3>Comments per day (30d)</h3>
-  ${sparklineSvg(timeline)}
+  ${barChartSvg(timeline)}
 </div>
 
 <div class="dash-cols">

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -6,7 +6,16 @@ import {
 	type ResolvedNumbers,
 	numberBounds,
 } from "../../lib/settings";
+import { renderStepper, renderSwitch, renderTabs } from "../controls";
 import { escapeHtml } from "../escape";
+
+// Settings tabs. Email / Moderation tabs can slot in here later without
+// touching the panel-toggle wiring (each panel just keys off `tab`).
+const TABS = [
+	{ id: "features", label: "Features" },
+	{ id: "display", label: "Display" },
+	{ id: "config", label: "Configuration" },
+];
 
 // Operator-facing labels + help for each runtime feature flag. Order here is
 // the order rendered in the toggles card.
@@ -101,31 +110,27 @@ export const renderSettings = (
 	// value (DB override > env > default). Saving writes an explicit DB row
 	// per flag (overriding env); "Reset to defaults" clears the rows so the
 	// env vars / built-in defaults apply again.
-	const toggles = FLAG_META.map((f) => {
-		const on = flags[f.key];
-		return `
-    <div class="flag-row">
-      <label>
-        <input type="checkbox" name="${f.key}" x-model="flags.${f.key}">
-        <strong>${escapeHtml(f.label)}</strong>
-      </label>
-      <span class="muted">${escapeHtml(f.help)}</span>
-    </div>`;
-	}).join("");
+	const toggles = FLAG_META.map((f) =>
+		renderSwitch({
+			name: f.key,
+			model: `flags.${f.key}`,
+			label: f.label,
+			help: f.help,
+		}),
+	).join("");
 
-	// Numeric display settings. Each input reflects the resolved effective
+	// Numeric display settings. Each stepper reflects the resolved effective
 	// value; min/max mirror the server-side clamp (numberBounds).
 	const numberInputs = NUMBER_META.map((f) => {
 		const b = numberBounds(f.key);
-		return `
-    <div class="flag-row">
-      <label>
-        <input type="number" name="${f.key}" min="${b.min}" max="${b.max}" step="1"
-               x-model.number="nums.${f.key}" style="width:5rem">
-        <strong>${escapeHtml(f.label)}</strong>
-      </label>
-      <span class="muted">${escapeHtml(f.help)}</span>
-    </div>`;
+		return renderStepper({
+			name: f.key,
+			model: `nums.${f.key}`,
+			min: b.min,
+			max: b.max,
+			label: f.label,
+			help: f.help,
+		});
 	}).join("");
 
 	const initial = JSON.stringify(
@@ -136,7 +141,8 @@ export const renderSettings = (
 	);
 
 	return `
-<div class="card" x-data="{
+<div x-data="{
+  tab: 'features',
   busy: false,
   flags: ${escapeHtml(initial)},
   nums: ${escapeHtml(numInitial)},
@@ -180,40 +186,47 @@ export const renderSettings = (
     }
   },
 }">
-  <h2>Features</h2>
-  <p class="muted">Toggle features without a redeploy. A toggle here overrides
-  the matching env var (<code>VOTING_ENABLED</code>, <code>REACTIONS_ENABLED</code>,
-  …); "Reset to defaults" clears the overrides so the env vars / built-in
-  defaults apply again.</p>
+  ${renderTabs("tab", TABS)}
+
   <form @submit.prevent="save()">
-    ${toggles}
-    <h3 style="margin-top:1.25rem">Display &amp; pagination</h3>
-    <p class="muted">Control how many comments load at once and how nested
-    replies collapse. Smaller values keep a busy thread from pushing the rest
-    of the page down.</p>
-    ${numberInputs}
-    <p style="margin-top:1rem">
-      <button type="submit" :disabled="busy">Save settings</button>
+    <div class="card" x-show="tab === 'features'">
+      <h2>Features</h2>
+      <p class="muted">Toggle features without a redeploy. A toggle here overrides
+      the matching env var (<code>VOTING_ENABLED</code>, <code>REACTIONS_ENABLED</code>,
+      …); "Reset to defaults" clears the overrides so the env vars / built-in
+      defaults apply again.</p>
+      ${toggles}
+    </div>
+
+    <div class="card" x-show="tab === 'display'" x-cloak>
+      <h2>Display &amp; pagination</h2>
+      <p class="muted">Control how many comments load at once and how nested
+      replies collapse. Smaller values keep a busy thread from pushing the rest
+      of the page down.</p>
+      ${numberInputs}
+    </div>
+
+    <p class="settings-actions" x-show="tab !== 'config'">
+      <button type="submit" class="btn-primary" :disabled="busy">Save settings</button>
       <button type="button" class="secondary" @click="reset()" :disabled="busy">Reset to defaults</button>
     </p>
   </form>
-</div>
-<div class="card">
-  <h2>Configuration</h2>
-  <p class="muted">These remain environment variables. Change them with
-  <code>wrangler secret put NAME</code> (or edit <code>wrangler.toml</code>
-  <code>[vars]</code> for non-secrets) and redeploy.</p>
-  <table>
-    <thead><tr><th>Variable</th><th>Value</th></tr></thead>
-    <tbody>${body}</tbody>
-  </table>
-</div>
-<div class="card">
-  <h3>Bindings</h3>
-  <ul>
-    <li><code>DB</code> — D1 database (comments, users, reactions, posts)</li>
-    <li><code>RATE_LIMITS</code>, <code>OAUTH_STATE</code>, <code>SESSIONS</code>, <code>TREE_CACHE</code> — KV namespaces</li>
-    <li><code>ANALYTICS</code> — Workers Analytics Engine dataset (optional)</li>
-  </ul>
+
+  <div class="card" x-show="tab === 'config'" x-cloak>
+    <h2>Configuration</h2>
+    <p class="muted">These remain environment variables. Change them with
+    <code>wrangler secret put NAME</code> (or edit <code>wrangler.toml</code>
+    <code>[vars]</code> for non-secrets) and redeploy.</p>
+    <table>
+      <thead><tr><th>Variable</th><th>Value</th></tr></thead>
+      <tbody>${body}</tbody>
+    </table>
+    <h3>Bindings</h3>
+    <ul>
+      <li><code>DB</code> — D1 database (comments, users, reactions, posts)</li>
+      <li><code>RATE_LIMITS</code>, <code>OAUTH_STATE</code>, <code>SESSIONS</code>, <code>TREE_CACHE</code> — KV namespaces</li>
+      <li><code>ANALYTICS</code> — Workers Analytics Engine dataset (optional)</li>
+    </ul>
+  </div>
 </div>`;
 };

--- a/src/admin-ui/pages/usage.ts
+++ b/src/admin-ui/pages/usage.ts
@@ -46,7 +46,7 @@ const usageBar = (used: number, ceiling: number, label: string): string => {
     <span class="muted">${fmt(used)} / ${fmt(ceiling)}</span>
   </div>
   <svg viewBox="0 0 200 14" preserveAspectRatio="none"
-       style="width:100%;height:14px;background:var(--card-soft);border-radius:3px"
+       style="width:100%;height:14px;background:var(--surface-2);border-radius:3px"
        role="img" aria-label="${escapeHtml(`${label}: ${p.toFixed(1)}%`)}">
     <rect x="0" y="0" width="${p * 2}" height="14" fill="${c}"/>
   </svg>

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -84,6 +84,11 @@ body { margin: 0; background: var(--bg); color: var(--text);
        font: 14px/1.5 system-ui, -apple-system, Segoe UI, sans-serif; }
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+/* Consistent keyboard focus ring across all interactive chrome. The switch
+   input manages its own ring (it's visually hidden), so exclude it here. */
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px;
+                 border-radius: var(--radius-sm); }
+.switch input:focus-visible { outline: none; }
 /* ── App shell: fixed sidebar + scrolling content ───────────────────────── */
 .app-shell { display: flex; min-height: 100vh; }
 .sidebar { position: sticky; top: 0; align-self: flex-start; flex: 0 0 240px;
@@ -258,7 +263,7 @@ code { background: var(--surface-2); padding: 0.1rem 0.3rem; border-radius: 3px;
          padding: 0.6rem 0.9rem; box-shadow: var(--shadow-lg);
          max-width: 320px; font-size: 0.85rem; }
 .toast.bad { border-left-color: var(--bad); }
-.help-popover { position: fixed; top: 3.5rem; right: 1rem;
+.help-popover { position: fixed; bottom: 1rem; left: 1rem;
                 background: var(--surface); border: 1px solid var(--border);
                 border-radius: var(--radius); padding: 1rem 1.25rem; min-width: 220px;
                 z-index: 900; box-shadow: var(--shadow-lg); }

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -35,11 +35,7 @@ export const ADMIN_CSS = `
    Light is the default (:root). Dark is opt-in via [data-theme="dark"] on
    <html>. When the operator has made no explicit choice, the OS preference
    wins via the prefers-color-scheme block below (scoped to :not([data-theme])
-   so an explicit data-theme="light" always beats a dark OS).
-
-   --panel / --fg are transitional aliases for the old token names so existing
-   component CSS keeps working during the redesign; they're removed once every
-   reference is migrated. */
+   so an explicit data-theme="light" always beats a dark OS). */
 :root {
   --bg: #f6f8fa; --surface: #ffffff; --surface-2: #f0f3f6;
   --border: #e2e7ec; --border-strong: #cdd5dd;
@@ -51,7 +47,6 @@ export const ADMIN_CSS = `
   --shadow: 0 1px 2px rgba(16,24,40,.06), 0 1px 3px rgba(16,24,40,.10);
   --shadow-lg: 0 8px 28px rgba(16,24,40,.16);
   --radius: 10px; --radius-sm: 7px;
-  --panel: var(--surface); --fg: var(--text);
 }
 [data-theme="dark"] {
   --bg: #0b0d10; --surface: #131820; --surface-2: #0f141b;
@@ -64,7 +59,6 @@ export const ADMIN_CSS = `
   --shadow: 0 1px 2px rgba(0,0,0,.4);
   --shadow-lg: 0 8px 28px rgba(0,0,0,.55);
   --radius: 10px; --radius-sm: 7px;
-  --panel: var(--surface); --fg: var(--text);
 }
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -332,6 +332,7 @@ kbd { background: var(--surface-2); border: 1px solid var(--border);
 .tab:hover { color: var(--text); border-color: transparent; }
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 .chart { display: block; width: 100%; }
+.settings-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1rem; }
 
 /* Below 880px the sidebar becomes an off-canvas drawer toggled by the
    hamburger; a scrim covers the content behind it. navOpen drives both. */

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -31,10 +31,53 @@ export const ADMIN_CSP = [
 ].join("; ");
 
 export const ADMIN_CSS = `
+/* ── Design tokens ──────────────────────────────────────────────────────
+   Light is the default (:root). Dark is opt-in via [data-theme="dark"] on
+   <html>. When the operator has made no explicit choice, the OS preference
+   wins via the prefers-color-scheme block below (scoped to :not([data-theme])
+   so an explicit data-theme="light" always beats a dark OS).
+
+   --panel / --fg are transitional aliases for the old token names so existing
+   component CSS keeps working during the redesign; they're removed once every
+   reference is migrated. */
 :root {
-  --bg: #0b0d10; --panel: #131820; --border: #1e2530; --text: #e7eaf0;
-  --muted: #8a93a6; --accent: #6aa9ff; --warn: #f7b955; --bad: #ef6a6a;
-  --ok: #4ad295;
+  --bg: #f6f8fa; --surface: #ffffff; --surface-2: #f0f3f6;
+  --border: #e2e7ec; --border-strong: #cdd5dd;
+  --text: #1b2733; --muted: #5c6b7a;
+  --accent: #2563eb; --accent-fg: #ffffff; --accent-weak: #e8f0fe;
+  --ok: #15803d; --ok-weak: #e7f6ec;
+  --warn: #b45309; --warn-weak: #fdf2e3;
+  --bad: #dc2626; --bad-weak: #fdeaea;
+  --shadow: 0 1px 2px rgba(16,24,40,.06), 0 1px 3px rgba(16,24,40,.10);
+  --shadow-lg: 0 8px 28px rgba(16,24,40,.16);
+  --radius: 10px; --radius-sm: 7px;
+  --panel: var(--surface); --fg: var(--text);
+}
+[data-theme="dark"] {
+  --bg: #0b0d10; --surface: #131820; --surface-2: #0f141b;
+  --border: #1e2530; --border-strong: #2a3340;
+  --text: #e7eaf0; --muted: #8a93a6;
+  --accent: #6aa9ff; --accent-fg: #0b0d10; --accent-weak: #16243a;
+  --ok: #4ad295; --ok-weak: #11251c;
+  --warn: #f7b955; --warn-weak: #2a2113;
+  --bad: #ef6a6a; --bad-weak: #2a1717;
+  --shadow: 0 1px 2px rgba(0,0,0,.4);
+  --shadow-lg: 0 8px 28px rgba(0,0,0,.55);
+  --radius: 10px; --radius-sm: 7px;
+  --panel: var(--surface); --fg: var(--text);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --bg: #0b0d10; --surface: #131820; --surface-2: #0f141b;
+    --border: #1e2530; --border-strong: #2a3340;
+    --text: #e7eaf0; --muted: #8a93a6;
+    --accent: #6aa9ff; --accent-fg: #0b0d10; --accent-weak: #16243a;
+    --ok: #4ad295; --ok-weak: #11251c;
+    --warn: #f7b955; --warn-weak: #2a2113;
+    --bad: #ef6a6a; --bad-weak: #2a1717;
+    --shadow: 0 1px 2px rgba(0,0,0,.4);
+    --shadow-lg: 0 8px 28px rgba(0,0,0,.55);
+  }
 }
 * { box-sizing: border-box; }
 body { margin: 0; background: var(--bg); color: var(--text);
@@ -101,8 +144,8 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .bulk-cell { width: 32px; }
 .score-cell { width: 70px; text-align: center; font-variant-numeric: tabular-nums; }
 .score { font-weight: 600; }
-.score-pos { color: #15803d; }
-.score-neg { color: #b91c1c; }
+.score-pos { color: var(--ok); }
+.score-neg { color: var(--bad); }
 .bulk-bar { position: sticky; bottom: 0; display: flex; align-items: center;
             gap: 0.5rem; padding: 0.75rem 1rem; background: var(--panel);
             border-top: 1px solid var(--border); margin: 1rem -1rem -1rem;
@@ -123,8 +166,8 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
               width: 100%; padding: 0.5rem 0.75rem; background: transparent;
               border: none; color: var(--fg); text-align: left; cursor: pointer; }
 .reply-pick:hover { background: var(--bg); }
-.reply-pick.active { background: var(--accent); color: var(--bg); }
-.reply-pick.active .muted { color: var(--bg); opacity: 0.85; }
+.reply-pick.active { background: var(--accent); color: var(--accent-fg); }
+.reply-pick.active .muted { color: var(--accent-fg); opacity: 0.85; }
 .comment-card { border: 1px solid var(--border); border-radius: 6px;
                 padding: 0.75rem; margin: 0.5rem 0; }
 .comment-card-head { display: flex; justify-content: space-between;

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -123,40 +123,68 @@ a:hover { text-decoration: underline; }
 .hamburger { display: none; }
 .scrim { display: none; }
 main { width: 100%; max-width: 1100px; margin: 1.5rem auto; padding: 0 1.25rem; }
-.card { background: var(--panel); border: 1px solid var(--border);
-        border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1rem; }
-.stat-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
-.stat { background: var(--bg); border: 1px solid var(--border);
-        border-radius: 6px; padding: 0.75rem 1rem; }
-.stat .v { font-size: 1.5rem; font-weight: 600; }
-.stat .l { color: var(--muted); font-size: 0.8rem; }
+.card { background: var(--surface); border: 1px solid var(--border);
+        border-radius: var(--radius); padding: 1rem 1.25rem; margin-bottom: 1rem;
+        box-shadow: var(--shadow); }
+.card h2, .card h3 { margin-top: 0; }
+.stat-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.stat { background: var(--surface); border: 1px solid var(--border);
+        border-radius: var(--radius); padding: 0.85rem 1.1rem; box-shadow: var(--shadow); }
+.stat .v { font-size: 2rem; font-weight: 700; line-height: 1.1;
+           font-variant-numeric: tabular-nums; color: var(--text); }
+.stat .l { color: var(--muted); font-size: 0.8rem; margin-top: 0.15rem; }
+/* Status variants: tinted wash + colored value. */
+.stat.ok { background: var(--ok-weak); border-color: transparent; }
+.stat.ok .v { color: var(--ok); }
+.stat.warn { background: var(--warn-weak); border-color: transparent; }
+.stat.warn .v { color: var(--warn); }
+.stat.bad { background: var(--bad-weak); border-color: transparent; }
+.stat.bad .v { color: var(--bad); }
+.stat.accent { background: var(--accent-weak); border-color: transparent; }
+.stat.accent .v { color: var(--accent); }
 table { width: 100%; border-collapse: collapse; }
-th, td { padding: 0.5rem 0.5rem; border-bottom: 1px solid var(--border);
+th, td { padding: 0.55rem 0.5rem; border-bottom: 1px solid var(--border);
          text-align: left; vertical-align: top; }
-th { color: var(--muted); font-weight: 500; font-size: 0.8rem; text-transform: uppercase; }
+th { color: var(--muted); font-weight: 600; font-size: 0.72rem; text-transform: uppercase;
+     letter-spacing: 0.04em; position: sticky; top: 0; background: var(--surface);
+     z-index: 1; }
+tbody tr:nth-child(even) { background: var(--surface-2); }
+tbody tr:hover { background: var(--accent-weak); }
 .row-body { color: var(--text); max-width: 480px; overflow-wrap: anywhere; }
 .row-body .md { font-size: 0.9rem; }
-.pill { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px;
-        font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em;
-        border: 1px solid var(--border); color: var(--muted); }
-.pill.approved { color: var(--ok); border-color: var(--ok); }
-.pill.pending { color: var(--warn); border-color: var(--warn); }
-.pill.spam, .pill.deleted, .pill.banned { color: var(--bad); border-color: var(--bad); }
-.pill.admin { color: var(--accent); border-color: var(--accent); }
-.pill.mod { color: var(--warn); border-color: var(--warn); }
-button, .btn { background: var(--bg); color: var(--text); border: 1px solid var(--border);
-               padding: 0.3rem 0.6rem; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
-button:hover { border-color: var(--accent); }
-button.bad { color: var(--bad); }
-button.bad:hover { border-color: var(--bad); }
-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.pill { display: inline-block; padding: 0.12rem 0.5rem; border-radius: 999px;
+        font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+        border: 1px solid transparent; background: var(--surface-2); color: var(--muted); }
+.pill.approved { color: var(--ok); background: var(--ok-weak); }
+.pill.pending { color: var(--warn); background: var(--warn-weak); }
+.pill.spam, .pill.deleted, .pill.banned { color: var(--bad); background: var(--bad-weak); }
+.pill.admin { color: var(--accent); background: var(--accent-weak); }
+.pill.mod { color: var(--warn); background: var(--warn-weak); }
+button, .btn { display: inline-flex; align-items: center; gap: 0.4rem;
+               background: var(--surface); color: var(--text); border: 1px solid var(--border);
+               padding: 0.35rem 0.7rem; border-radius: var(--radius-sm); cursor: pointer;
+               font-size: 0.85rem; font-weight: 500; transition: background 0.12s, border-color 0.12s; }
+button:hover, .btn:hover { border-color: var(--border-strong); background: var(--surface-2); }
+/* Primary: filled accent. */
+button.btn-primary, .btn-primary { background: var(--accent); color: var(--accent-fg);
+                                   border-color: var(--accent); }
+button.btn-primary:hover, .btn-primary:hover { filter: brightness(1.05);
+                                               border-color: var(--accent); background: var(--accent); }
+/* Secondary alias keeps existing class="secondary" markup working. */
+button.btn-secondary, .btn-secondary, button.secondary, .secondary {
+  background: var(--surface-2); color: var(--text); border-color: var(--border); }
+/* Danger; .bad is the historical alias used in <td class="actions"> rows. */
+button.btn-danger, .btn-danger, button.bad, .btn.bad { color: var(--bad); }
+button.btn-danger:hover, .btn-danger:hover, button.bad:hover, .btn.bad:hover {
+  border-color: var(--bad); background: var(--bad-weak); }
+button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .actions { display: flex; gap: 0.4rem; }
 .author-cell { display: flex; gap: 0.5rem; align-items: center; color: inherit;
                text-decoration: none; max-width: 180px; }
 .author-cell:hover .author-name { text-decoration: underline; }
 .author-avatar { display: inline-block; width: 28px; height: 28px;
                  border-radius: 50%; overflow: hidden; flex: 0 0 auto;
-                 background: var(--bg); }
+                 background: var(--surface-2); }
 .author-avatar img, .author-avatar svg { width: 100%; height: 100%;
                                           display: block; border-radius: 50%; }
 .author-meta { display: flex; flex-direction: column; min-width: 0;
@@ -166,9 +194,12 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .author-sub { font-size: 0.7rem; }
 .filter-bar { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
 .filter-bar input[type=text], .filter-bar input[type=date] {
-                                background: var(--bg); border: 1px solid var(--border);
+                                background: var(--surface); border: 1px solid var(--border);
                                 color: var(--text); padding: 0.4rem 0.6rem;
-                                border-radius: 6px; }
+                                border-radius: var(--radius-sm); }
+.filter-bar input[type=text]:focus, .filter-bar input[type=date]:focus {
+                                outline: 2px solid var(--accent); outline-offset: 1px;
+                                border-color: var(--accent); }
 .filter-bar input[type=text] { min-width: 200px; }
 .filter-bar.queue-filter { flex-wrap: wrap; }
 .filter-bar.queue-filter input[type=text] { min-width: 140px; }
@@ -180,25 +211,25 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .score-pos { color: var(--ok); }
 .score-neg { color: var(--bad); }
 .bulk-bar { position: sticky; bottom: 0; display: flex; align-items: center;
-            gap: 0.5rem; padding: 0.75rem 1rem; background: var(--panel);
+            gap: 0.5rem; padding: 0.75rem 1rem; background: var(--surface);
             border-top: 1px solid var(--border); margin: 1rem -1rem -1rem;
-            border-radius: 0 0 8px 8px; }
+            border-radius: 0 0 var(--radius) var(--radius); box-shadow: var(--shadow-lg); }
 .bulk-bar span:first-child { font-weight: 600; margin-right: auto; }
 [x-cloak] { display: none !important; }
 .reply-modal { position: fixed; inset: 0; background: rgba(0,0,0,0.55);
                display: flex; align-items: flex-start; justify-content: center;
                padding-top: 6vh; z-index: 1100; }
-.reply-modal-inner { background: var(--panel); border: 1px solid var(--border);
-                     border-radius: 8px; padding: 1.25rem; width: min(560px, 92vw);
-                     max-height: 85vh; overflow: auto; box-shadow: 0 12px 32px rgba(0,0,0,0.45); }
+.reply-modal-inner { background: var(--surface); border: 1px solid var(--border);
+                     border-radius: var(--radius); padding: 1.25rem; width: min(560px, 92vw);
+                     max-height: 85vh; overflow: auto; box-shadow: var(--shadow-lg); }
 .reply-list { list-style: none; padding: 0; margin: 0 0 0.75rem; max-height: 30vh;
               overflow: auto; border: 1px solid var(--border); border-radius: 6px; }
 .reply-list li { border-bottom: 1px solid var(--border); }
 .reply-list li:last-child { border-bottom: none; }
 .reply-pick { display: flex; justify-content: space-between; gap: 0.75rem;
               width: 100%; padding: 0.5rem 0.75rem; background: transparent;
-              border: none; color: var(--fg); text-align: left; cursor: pointer; }
-.reply-pick:hover { background: var(--bg); }
+              border: none; color: var(--text); text-align: left; cursor: pointer; }
+.reply-pick:hover { background: var(--surface-2); }
 .reply-pick.active { background: var(--accent); color: var(--accent-fg); }
 .reply-pick.active .muted { color: var(--accent-fg); opacity: 0.85; }
 .comment-card { border: 1px solid var(--border); border-radius: 6px;
@@ -210,25 +241,25 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .user-meta { flex: 1; min-width: 0; }
 .user-stats { display: flex; gap: 2rem; margin-top: 1rem;
               padding-top: 1rem; border-top: 1px solid var(--border); }
-code { background: var(--bg); padding: 0.1rem 0.3rem; border-radius: 3px;
+code { background: var(--surface-2); padding: 0.1rem 0.3rem; border-radius: 3px;
        font-family: ui-monospace, monospace; font-size: 0.85em; }
 .toast-tray { position: fixed; right: 1rem; bottom: 1rem; display: flex;
               flex-direction: column; gap: 0.5rem; z-index: 1000;
               pointer-events: none; }
-.toast { background: var(--panel); border: 1px solid var(--border);
-         border-left: 3px solid var(--ok); border-radius: 6px;
-         padding: 0.6rem 0.9rem; box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+.toast { background: var(--surface); border: 1px solid var(--border);
+         border-left: 3px solid var(--ok); border-radius: var(--radius-sm);
+         padding: 0.6rem 0.9rem; box-shadow: var(--shadow-lg);
          max-width: 320px; font-size: 0.85rem; }
 .toast.bad { border-left-color: var(--bad); }
 .help-popover { position: fixed; top: 3.5rem; right: 1rem;
-                background: var(--panel); border: 1px solid var(--border);
-                border-radius: 8px; padding: 1rem 1.25rem; min-width: 220px;
-                z-index: 900; box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
+                background: var(--surface); border: 1px solid var(--border);
+                border-radius: var(--radius); padding: 1rem 1.25rem; min-width: 220px;
+                z-index: 900; box-shadow: var(--shadow-lg); }
 .help-popover dl { display: grid; grid-template-columns: auto 1fr;
                    gap: 0.4rem 0.8rem; margin: 0; }
 .help-popover dt { font-weight: 500; }
 .help-popover dd { margin: 0; color: var(--muted); }
-kbd { background: var(--bg); border: 1px solid var(--border);
+kbd { background: var(--surface-2); border: 1px solid var(--border);
       border-radius: 4px; padding: 0.05rem 0.4rem;
       font-family: ui-monospace, monospace; font-size: 0.8em; }
 .dash-cols { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -84,12 +84,45 @@ body { margin: 0; background: var(--bg); color: var(--text);
        font: 14px/1.5 system-ui, -apple-system, Segoe UI, sans-serif; }
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
-header { background: var(--panel); border-bottom: 1px solid var(--border);
-         padding: 0.75rem 1rem; display: flex; gap: 1.5rem; align-items: center; }
-header h1 { font-size: 1rem; margin: 0; }
-header nav { display: flex; gap: 1rem; flex: 1; }
-header .me { color: var(--muted); }
-main { max-width: 1100px; margin: 1.5rem auto; padding: 0 1rem; }
+/* ── App shell: fixed sidebar + scrolling content ───────────────────────── */
+.app-shell { display: flex; min-height: 100vh; }
+.sidebar { position: sticky; top: 0; align-self: flex-start; flex: 0 0 240px;
+           width: 240px; height: 100vh; background: var(--surface);
+           border-right: 1px solid var(--border); display: flex;
+           flex-direction: column; overflow-y: auto; z-index: 50; }
+.brand { display: flex; align-items: center; gap: 0.5rem; padding: 1rem 1.1rem;
+         font-size: 1.1rem; font-weight: 700; color: var(--text);
+         text-decoration: none; }
+.brand:hover { text-decoration: none; }
+.brand .icon { color: var(--accent); }
+.sidebar-nav { flex: 1; padding: 0.25rem 0.6rem; }
+.nav-section { margin-bottom: 1rem; }
+.nav-heading { margin: 0.5rem 0.6rem 0.35rem; font-size: 0.68rem; font-weight: 600;
+               text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+.nav-link { display: flex; align-items: center; gap: 0.6rem; padding: 0.45rem 0.6rem;
+            border-radius: var(--radius-sm); color: var(--text); font-size: 0.9rem;
+            text-decoration: none; }
+.nav-link .icon { color: var(--muted); transition: color 0.12s; }
+.nav-link:hover { background: var(--surface-2); text-decoration: none; }
+.nav-link.active { background: var(--accent-weak); color: var(--accent); font-weight: 600; }
+.nav-link.active .icon { color: var(--accent); }
+.sidebar-footer { display: flex; align-items: center; gap: 0.5rem;
+                  padding: 0.75rem 1.1rem; border-top: 1px solid var(--border); }
+.sidebar-footer .me { color: var(--muted); font-size: 0.85rem; flex: 1; min-width: 0;
+                      display: flex; align-items: center; gap: 0.4rem; }
+.footer-actions { display: flex; gap: 0.3rem; flex: 0 0 auto; }
+.icon-btn { display: inline-flex; align-items: center; justify-content: center;
+            min-width: 30px; height: 30px; padding: 0 0.4rem; background: transparent;
+            border: 1px solid transparent; border-radius: var(--radius-sm); color: var(--muted); }
+.icon-btn:hover { background: var(--surface-2); color: var(--text); border-color: transparent; }
+.content { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.topbar { display: flex; align-items: center; gap: 0.6rem; padding: 0.6rem 1.25rem;
+          border-bottom: 1px solid var(--border); background: var(--surface);
+          position: sticky; top: 0; z-index: 40; }
+.topbar h1 { font-size: 1.05rem; margin: 0; font-weight: 600; }
+.hamburger { display: none; }
+.scrim { display: none; }
+main { width: 100%; max-width: 1100px; margin: 1.5rem auto; padding: 0 1.25rem; }
 .card { background: var(--panel); border: 1px solid var(--border);
         border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1rem; }
 .stat-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
@@ -187,7 +220,6 @@ code { background: var(--bg); padding: 0.1rem 0.3rem; border-radius: 3px;
          padding: 0.6rem 0.9rem; box-shadow: 0 2px 8px rgba(0,0,0,0.4);
          max-width: 320px; font-size: 0.85rem; }
 .toast.bad { border-left-color: var(--bad); }
-.help-btn { margin-left: 0.4rem; padding: 0.1rem 0.5rem; font-size: 0.8rem; }
 .help-popover { position: fixed; top: 3.5rem; right: 1rem;
                 background: var(--panel); border: 1px solid var(--border);
                 border-radius: 8px; padding: 1rem 1.25rem; min-width: 220px;
@@ -205,11 +237,11 @@ kbd { background: var(--bg); border: 1px solid var(--border);
 .dash-list li:last-child { border-bottom: 0; }
 .banner { display: flex; gap: 1rem; align-items: center; justify-content: space-between;
           padding: 0.6rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; }
-.banner.update { background: #2a1f08; color: #f7d77a; border-bottom-color: #4a3a14; }
-.banner.update a { color: #ffd57a; text-decoration: underline; }
-.banner.update code { background: rgba(0,0,0,0.25); color: inherit; }
-.banner.update button { background: transparent; color: inherit; border-color: #4a3a14; }
-.banner.update button:hover { border-color: #f7d77a; }
+.banner.update { background: var(--warn-weak); color: var(--warn); border-bottom-color: var(--border-strong); }
+.banner.update a { color: var(--warn); text-decoration: underline; }
+.banner.update code { background: rgba(0,0,0,0.08); color: inherit; }
+.banner.update button { background: transparent; color: inherit; border-color: var(--border-strong); }
+.banner.update button:hover { border-color: var(--warn); }
 .link-list { list-style: none; padding: 0; margin: 0.5rem 0; display: grid;
              gap: 0.25rem; }
 .link-list li { padding: 0.15rem 0; }
@@ -263,10 +295,21 @@ kbd { background: var(--bg); border: 1px solid var(--border);
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 .chart { display: block; width: 100%; }
 
+/* Below 880px the sidebar becomes an off-canvas drawer toggled by the
+   hamburger; a scrim covers the content behind it. navOpen drives both. */
+@media (max-width: 880px) {
+  .sidebar { position: fixed; top: 0; left: 0; height: 100vh;
+             transform: translateX(-100%); transition: transform 0.2s ease;
+             box-shadow: var(--shadow-lg); }
+  .sidebar.open { transform: translateX(0); }
+  .scrim { display: block; position: fixed; inset: 0; z-index: 45;
+           background: rgba(0,0,0,0.45); }
+  .hamburger { display: inline-flex; }
+}
+
 @media (max-width: 720px) {
-  header { flex-wrap: wrap; gap: 0.5rem; padding: 0.5rem 0.75rem; }
-  header nav { flex-wrap: wrap; gap: 0.5rem 0.75rem; font-size: 0.9rem; }
-  header .me { margin-left: auto; font-size: 0.85rem; }
+  .topbar { padding: 0.5rem 0.75rem; }
+  .topbar h1 { font-size: 0.95rem; }
   main { margin: 0.75rem auto; padding: 0 0.6rem; }
   .card { padding: 0.75rem 0.85rem; border-radius: 6px; }
   .card table { display: block; overflow-x: auto; }

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -224,6 +224,45 @@ kbd { background: var(--bg); border: 1px solid var(--border);
 .release-body { font-size: 0.9rem; }
 .release-body p:first-child { margin-top: 0; }
 .release-body p:last-child { margin-bottom: 0; }
+/* ── Shared controls (icons, switches, steppers, tabs, charts) ──────────── */
+.icon { display: inline-block; vertical-align: -0.18em; flex: 0 0 auto; }
+.field-row, .switch-row { display: flex; gap: 0.75rem; align-items: flex-start;
+                          padding: 0.6rem 0; border-bottom: 1px solid var(--border); }
+.field-row:last-child, .switch-row:last-child { border-bottom: 0; }
+.switch-row { cursor: pointer; }
+.field-text { display: flex; flex-direction: column; gap: 0.1rem; min-width: 0; }
+.field-text .muted { font-size: 0.8rem; }
+.switch { position: relative; display: inline-flex; flex: 0 0 auto; margin-top: 0.1rem; }
+.switch input { position: absolute; inset: 0; width: 100%; height: 100%;
+                margin: 0; opacity: 0; cursor: pointer; }
+.switch-track { width: 38px; height: 22px; border-radius: 999px;
+                background: var(--border-strong); transition: background 0.15s;
+                display: inline-block; position: relative; }
+.switch-thumb { position: absolute; top: 2px; left: 2px; width: 18px; height: 18px;
+                border-radius: 50%; background: #fff; transition: transform 0.15s;
+                box-shadow: 0 1px 2px rgba(0,0,0,0.35); }
+.switch input:checked + .switch-track { background: var(--accent); }
+.switch input:checked + .switch-track .switch-thumb { transform: translateX(16px); }
+.switch input:focus-visible + .switch-track { outline: 2px solid var(--accent); outline-offset: 2px; }
+.stepper { display: inline-flex; align-items: stretch; flex: 0 0 auto;
+           border: 1px solid var(--border); border-radius: var(--radius-sm);
+           overflow: hidden; background: var(--surface-2); }
+.stepper-btn { background: transparent; border: 0; border-radius: 0;
+               padding: 0 0.6rem; font-size: 1rem; line-height: 1; color: var(--muted); }
+.stepper-btn:hover { background: var(--accent-weak); color: var(--text); border-color: transparent; }
+.stepper input[type=number] { width: 3.5rem; border: 0; border-left: 1px solid var(--border);
+                              border-right: 1px solid var(--border); background: var(--surface);
+                              color: var(--text); text-align: center; padding: 0.35rem 0.25rem;
+                              font-variant-numeric: tabular-nums; }
+.tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid var(--border);
+        margin-bottom: 1rem; flex-wrap: wrap; }
+.tab { background: transparent; border: 0; border-bottom: 2px solid transparent;
+       border-radius: 0; padding: 0.5rem 0.75rem; color: var(--muted);
+       font-size: 0.9rem; cursor: pointer; }
+.tab:hover { color: var(--text); border-color: transparent; }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+.chart { display: block; width: 100%; }
+
 @media (max-width: 720px) {
   header { flex-wrap: wrap; gap: 0.5rem; padding: 0.5rem 0.75rem; }
   header nav { flex-wrap: wrap; gap: 0.5rem 0.75rem; font-size: 0.9rem; }

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -332,6 +332,13 @@ kbd { background: var(--surface-2); border: 1px solid var(--border);
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 .chart { display: block; width: 100%; }
 .settings-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1rem; }
+/* Usage page bars (Cloudflare dashboard) and the queue audit strip. */
+.usage-row { margin: 0.75rem 0; }
+.usage-row:first-of-type { margin-top: 0.25rem; }
+.usage-label { display: flex; justify-content: space-between; align-items: baseline;
+               gap: 0.5rem; margin-bottom: 0.3rem; font-size: 0.9rem; }
+.usage-label .muted { font-variant-numeric: tabular-nums; }
+.audit-strip { font-size: 0.8rem; margin-top: 0.4rem; }
 
 /* Below 880px the sidebar becomes an off-canvas drawer toggled by the
    hamburger; a scrim covers the content behind it. navOpen drives both. */

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -127,6 +127,13 @@ main { width: 100%; max-width: 1100px; margin: 1.5rem auto; padding: 0 1.25rem; 
         border-radius: var(--radius); padding: 1rem 1.25rem; margin-bottom: 1rem;
         box-shadow: var(--shadow); }
 .card h2, .card h3 { margin-top: 0; }
+.card-head { display: flex; align-items: center; justify-content: space-between;
+             gap: 1rem; margin-bottom: 0.5rem; }
+.card-head h2, .card-head h3 { margin: 0; }
+.embed-snippet { background: var(--surface-2); border: 1px solid var(--border);
+                 border-radius: var(--radius-sm); padding: 0.75rem 0.9rem; margin: 0;
+                 overflow-x: auto; font-size: 0.82rem; line-height: 1.5; }
+.embed-snippet code { background: transparent; padding: 0; }
 .stat-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 .stat { background: var(--surface); border: 1px solid var(--border);
         border-radius: var(--radius); padding: 0.85rem 1.1rem; box-shadow: var(--shadow); }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -157,6 +157,7 @@ const renderPage = (
 ): string =>
 	layout(title, body, user, updateInfo, {
 		usage_link: isUsageConfigured(c.env),
+		activePath: c.req.path,
 	});
 
 // Gate the admin-area pages and APIs. `level: "admin"` is the historical

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -178,7 +178,14 @@ const STYLE_CSS = `
 	padding: 0.5rem 0.7rem;
 }
 .gr-form textarea { min-height: 6em; resize: vertical; }
-.gr-compose { display: flex; flex-direction: column; gap: 0.4rem; }
+.gr-compose {
+	display: flex; flex-direction: column; gap: 0.4rem;
+	background: var(--gr-surface);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
+	padding: 0.6rem;
+	box-shadow: var(--gr-shadow);
+}
 .gr-compose textarea[hidden] { display: none; }
 .gr-tabs { display: flex; gap: 0.25rem; }
 .gr-tab {
@@ -222,7 +229,14 @@ const STYLE_CSS = `
 	cursor: pointer;
 	align-self: flex-start;
 }
-.gr-toolbar-btn:hover { border-color: var(--gr-accent); }
+.gr-toolbar-btn:hover { background: var(--gr-hover); border-color: var(--gr-accent); }
+/* One focus ring for every interactive control in the shadow tree. */
+button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-visible {
+	outline: 2px solid var(--gr-accent);
+	outline-offset: 2px;
+}
+.gr-md-hint { font-size: 0.8em; color: var(--gr-muted); }
+.gr-md-hint[hidden] { display: none; }
 .gr-preview p { margin: 0.3em 0; }
 .gr-preview a { color: var(--gr-link); }
 .gr-form .gr-honeypot { position: absolute; left: -9999px; top: -9999px; }
@@ -246,6 +260,7 @@ const STYLE_CSS = `
 	cursor: pointer;
 	align-self: flex-start;
 }
+.gr-form button:hover:not([disabled]) { background: var(--gr-accent-hover); }
 .gr-form button[disabled] { opacity: 0.6; cursor: progress; }
 .gr-error { color: var(--gr-error); font-size: 0.9em; }
 .gr-error.is-notice { color: var(--gr-notice); }
@@ -393,6 +408,7 @@ const STYLE_CSS = `
 	padding: 0.4rem 0.8rem;
 	cursor: pointer;
 }
+.gr-signin button:hover { background: var(--gr-hover); border-color: var(--gr-accent); }
 .gr-signed { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; color: var(--gr-muted); font-size: 0.9em; }
 .gr-signed .gr-signed-name { color: var(--gr-fg); font-weight: 600; }
 .gr-signed button {
@@ -539,6 +555,7 @@ const buildWritePreview = (
 	tabs.append(writeTab, previewTab);
 
 	const toolbar = buildToolbar(textarea);
+	const hint = el("span", "gr-md-hint", "Styling with Markdown is supported");
 	const pane = el("div", "gr-preview");
 	pane.hidden = true;
 
@@ -548,6 +565,7 @@ const buildWritePreview = (
 		writeTab.setAttribute("aria-selected", "true");
 		previewTab.setAttribute("aria-selected", "false");
 		toolbar.hidden = false;
+		hint.hidden = false;
 		textarea.hidden = false;
 		pane.hidden = true;
 	};
@@ -558,6 +576,7 @@ const buildWritePreview = (
 		previewTab.setAttribute("aria-selected", "true");
 		writeTab.setAttribute("aria-selected", "false");
 		toolbar.hidden = true;
+		hint.hidden = true;
 		textarea.hidden = true;
 		pane.hidden = false;
 		const body = textarea.value.trim();
@@ -587,7 +606,7 @@ const buildWritePreview = (
 		void showPreview();
 	});
 
-	wrap.append(tabs, toolbar, textarea, pane);
+	wrap.append(tabs, toolbar, textarea, hint, pane);
 	return wrap;
 };
 

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -262,7 +262,15 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 }
 .gr-form button:hover:not([disabled]) { background: var(--gr-accent-hover); }
 .gr-form button[disabled] { opacity: 0.6; cursor: progress; }
-.gr-error { color: var(--gr-error); font-size: 0.9em; }
+.gr-error {
+	color: var(--gr-error);
+	font-size: 0.9em;
+	background: var(--gr-surface);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
+	padding: 0.5rem 0.7rem;
+}
+.gr-error[hidden] { display: none; }
 .gr-error.is-notice { color: var(--gr-notice); }
 .gr-list { display: flex; flex-direction: column; gap: 1rem; }
 .gr-thread { display: flex; flex-direction: column; gap: 0.75rem; }
@@ -377,7 +385,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 	color: var(--gr-accent-fg);
 	border-color: var(--gr-accent);
 }
-.gr-empty { color: var(--gr-muted); margin: 0; }
+.gr-empty { color: var(--gr-muted); margin: 0; text-align: center; padding: 1.5rem 1rem; }
 .gr-loadmore {
 	font: inherit;
 	background: transparent;

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -109,11 +109,63 @@ const STYLE_CSS = `
 	--gr-badge-bg: var(--garrul-badge-bg, #e0e7ff);
 	--gr-badge-fg: var(--garrul-badge-fg, #1e3a8a);
 	--gr-skel: var(--garrul-skel, #e7e9ec);
+	/* Additive vars (new in this release; non-breaking). See docs/THEMING.md. */
+	--gr-surface: var(--garrul-surface, #f7f8fa);
+	--gr-hover: var(--garrul-hover, #eef0f3);
+	--gr-accent-hover: var(--garrul-accent-hover, #1d4ed8);
+	--gr-vote-active: var(--garrul-vote-active, var(--gr-badge-bg));
+	--gr-shadow: var(--garrul-shadow, 0 1px 2px rgba(0,0,0,.06));
 	font-family: var(--gr-font);
 	color: var(--gr-fg);
 	background: var(--gr-bg);
 	font-size: var(--gr-font-size);
 	line-height: 1.5;
+}
+/* Built-in dark mode. Each --gr-* is redefined with a DARK fallback but still
+   reads the public --garrul-* first, so a host's explicit override keeps
+   winning in dark too. Precedence (highest first): host --garrul-* override >
+   data-theme="dark"|"light" > OS prefers-color-scheme > light default.
+   Zero JS: CSS reacts to a static data-theme attribute the host may set on
+   #garrul (like data-slug). The media block excludes data-theme="light" so an
+   explicit light choice always beats a dark OS; the [data-theme="dark"] rule
+   forces dark regardless of OS and, coming later in source order, wins. */
+@media (prefers-color-scheme: dark) {
+	:host(:not([data-theme="light"])) {
+		--gr-fg: var(--garrul-fg, #e6e8eb);
+		--gr-input-bg: var(--garrul-input-bg, #1b1f24);
+		--gr-border: var(--garrul-border, #2e353d);
+		--gr-muted: var(--garrul-muted, #9aa3b0);
+		--gr-accent: var(--garrul-accent, #3b82f6);
+		--gr-accent-fg: var(--garrul-accent-fg, #ffffff);
+		--gr-link: var(--garrul-link, #6aa9ff);
+		--gr-error: var(--garrul-error, #f08a8a);
+		--gr-notice: var(--garrul-notice, #6cb6e8);
+		--gr-badge-bg: var(--garrul-badge-bg, #1e2a44);
+		--gr-badge-fg: var(--garrul-badge-fg, #c9d9f5);
+		--gr-skel: var(--garrul-skel, #2a2f36);
+		--gr-surface: var(--garrul-surface, #1b1f24);
+		--gr-hover: var(--garrul-hover, #23282e);
+		--gr-accent-hover: var(--garrul-accent-hover, #2563eb);
+		--gr-shadow: var(--garrul-shadow, 0 1px 2px rgba(0,0,0,.5));
+	}
+}
+:host([data-theme="dark"]) {
+	--gr-fg: var(--garrul-fg, #e6e8eb);
+	--gr-input-bg: var(--garrul-input-bg, #1b1f24);
+	--gr-border: var(--garrul-border, #2e353d);
+	--gr-muted: var(--garrul-muted, #9aa3b0);
+	--gr-accent: var(--garrul-accent, #3b82f6);
+	--gr-accent-fg: var(--garrul-accent-fg, #ffffff);
+	--gr-link: var(--garrul-link, #6aa9ff);
+	--gr-error: var(--garrul-error, #f08a8a);
+	--gr-notice: var(--garrul-notice, #6cb6e8);
+	--gr-badge-bg: var(--garrul-badge-bg, #1e2a44);
+	--gr-badge-fg: var(--garrul-badge-fg, #c9d9f5);
+	--gr-skel: var(--garrul-skel, #2a2f36);
+	--gr-surface: var(--garrul-surface, #1b1f24);
+	--gr-hover: var(--garrul-hover, #23282e);
+	--gr-accent-hover: var(--garrul-accent-hover, #2563eb);
+	--gr-shadow: var(--garrul-shadow, 0 1px 2px rgba(0,0,0,.5));
 }
 * { box-sizing: border-box; }
 .gr-root { display: flex; flex-direction: column; gap: 1rem; }

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -269,7 +269,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 .gr-replies { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 0.5rem; padding-left: 1.25rem; border-left: 2px solid var(--gr-border); }
 .gr-comment { display: flex; gap: 0.75rem; }
 .gr-comment[data-flat="1"] .gr-flatten { font-size: 0.85em; color: var(--gr-muted); margin-right: 0.3em; }
-.gr-avatar { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 50%; overflow: hidden; }
+.gr-avatar { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 50%; overflow: hidden; background: var(--gr-surface); box-shadow: 0 0 0 1px var(--gr-border); }
 .gr-avatar svg, .gr-avatar img { width: 100%; height: 100%; display: block; }
 .gr-main { flex: 1; min-width: 0; }
 .gr-meta { display: flex; gap: 0.5rem; align-items: baseline; flex-wrap: wrap; }
@@ -282,6 +282,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 	border-radius: 999px;
 }
 .gr-time { color: var(--gr-muted); font-size: 0.85em; }
+.gr-edited { color: var(--gr-muted); font-size: 0.85em; font-style: italic; }
 .gr-body { margin: 0.25rem 0 0; }
 .gr-body p { margin: 0.3em 0; }
 .gr-body a { color: var(--gr-link); }
@@ -320,7 +321,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 	line-height: 1.5;
 }
 .gr-reaction[data-mine="1"] {
-	background: var(--gr-badge-bg);
+	background: var(--gr-vote-active);
 	color: var(--gr-badge-fg);
 	border-color: var(--gr-accent);
 }
@@ -343,7 +344,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 }
 .gr-vote:hover { color: var(--gr-link); }
 .gr-vote[data-mine="1"] {
-	background: var(--gr-badge-bg);
+	background: var(--gr-vote-active);
 	color: var(--gr-badge-fg);
 	border-color: var(--gr-accent);
 }
@@ -358,6 +359,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 	border-radius: var(--gr-radius);
 	padding: 0.2rem 0.4rem;
 }
+.gr-sort select:hover { border-color: var(--gr-accent); }
 .gr-reply-form { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
 .gr-reply-form textarea { min-height: 4em; }
 .gr-reply-form .gr-reply-actions { display: flex; gap: 0.5rem; }
@@ -397,6 +399,7 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 	align-self: flex-start;
 }
 .gr-collapse { color: var(--gr-muted); }
+.gr-collapse:hover { color: var(--gr-link); }
 .gr-showmore { color: var(--gr-link); margin-top: 0.25rem; }
 .gr-signin { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
 .gr-signin button {
@@ -1361,8 +1364,8 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	if (n.author.provider !== "anon") {
 		meta.appendChild(el("span", "gr-verified", "verified"));
 	}
-	const timeText = `${fmtTime(n.created_at)}${n.edited_at ? " · edited" : ""}`;
-	meta.appendChild(el("span", "gr-time", timeText));
+	meta.appendChild(el("span", "gr-time", fmtTime(n.created_at)));
+	if (n.edited_at) meta.appendChild(el("span", "gr-edited", "· edited"));
 
 	const body = el("div", "gr-body");
 	if (n.status === "deleted") {
@@ -1926,7 +1929,7 @@ const loadOnce = async (
 	// Sort selector only when voting is on (no scores to rank without it).
 	if (votingEnabled) {
 		const sortWrap = el("div", "gr-sort");
-		const label = el("label", undefined, "Sort: ");
+		const label = el("label", undefined, "Sort by ");
 		const sel = el("select") as HTMLSelectElement;
 		const newOpt = el("option") as HTMLOptionElement;
 		newOpt.value = "new";

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -88,10 +88,31 @@ const STYLE_CSS = `
 :host {
 	all: initial;
 	display: block;
-	font-family: var(--garrul-font, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif);
-	color: var(--garrul-fg, #1a1a1a);
-	background: var(--garrul-bg, transparent);
-	font-size: var(--garrul-font-size, 15px);
+	/* Private theme layer. Every rule below uses these --gr-* vars; each one
+	   chains through the public, semver-protected --garrul-* contract var (so a
+	   host's explicit override always wins) down to a light default. Dark mode
+	   redefines ONLY these --gr-* values — the public vars are never renamed or
+	   given new meaning. In light mode this is pixel-identical to the old CSS. */
+	--gr-font: var(--garrul-font, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif);
+	--gr-fg: var(--garrul-fg, #1a1a1a);
+	--gr-bg: var(--garrul-bg, transparent);
+	--gr-font-size: var(--garrul-font-size, 15px);
+	--gr-input-bg: var(--garrul-input-bg, #fff);
+	--gr-border: var(--garrul-border, #d0d3d8);
+	--gr-radius: var(--garrul-radius, 6px);
+	--gr-muted: var(--garrul-muted, #6b7280);
+	--gr-accent: var(--garrul-accent, #2563eb);
+	--gr-accent-fg: var(--garrul-accent-fg, #fff);
+	--gr-link: var(--garrul-link, #2563eb);
+	--gr-error: var(--garrul-error, #b91c1c);
+	--gr-notice: var(--garrul-notice, #1e6091);
+	--gr-badge-bg: var(--garrul-badge-bg, #e0e7ff);
+	--gr-badge-fg: var(--garrul-badge-fg, #1e3a8a);
+	--gr-skel: var(--garrul-skel, #e7e9ec);
+	font-family: var(--gr-font);
+	color: var(--gr-fg);
+	background: var(--gr-bg);
+	font-size: var(--gr-font-size);
 	line-height: 1.5;
 }
 * { box-sizing: border-box; }
@@ -99,9 +120,9 @@ const STYLE_CSS = `
 .gr-form { display: flex; flex-direction: column; gap: 0.5rem; }
 .gr-form input, .gr-form textarea {
 	font: inherit; color: inherit;
-	background: var(--garrul-input-bg, #fff);
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	border-radius: var(--garrul-radius, 6px);
+	background: var(--gr-input-bg);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
 	padding: 0.5rem 0.7rem;
 }
 .gr-form textarea { min-height: 6em; resize: vertical; }
@@ -112,25 +133,25 @@ const STYLE_CSS = `
 	font: inherit;
 	font-size: 0.85em;
 	background: transparent;
-	color: var(--garrul-muted, #6b7280);
+	color: var(--gr-muted);
 	border: 1px solid transparent;
-	border-radius: var(--garrul-radius, 6px) var(--garrul-radius, 6px) 0 0;
+	border-radius: var(--gr-radius) var(--gr-radius) 0 0;
 	padding: 0.3rem 0.7rem;
 	cursor: pointer;
 	align-self: flex-start;
 }
 .gr-tab.gr-tab-active {
-	color: var(--garrul-fg, #1a1a1a);
-	border-color: var(--garrul-border, #d0d3d8);
-	border-bottom-color: var(--garrul-input-bg, #fff);
-	background: var(--garrul-input-bg, #fff);
+	color: var(--gr-fg);
+	border-color: var(--gr-border);
+	border-bottom-color: var(--gr-input-bg);
+	background: var(--gr-input-bg);
 	font-weight: 600;
 }
 .gr-preview {
 	min-height: 6em;
-	background: var(--garrul-input-bg, #fff);
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	border-radius: var(--garrul-radius, 6px);
+	background: var(--gr-input-bg);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
 	padding: 0.5rem 0.7rem;
 }
 .gr-preview[hidden] { display: none; }
@@ -141,17 +162,17 @@ const STYLE_CSS = `
 	font-size: 0.85em;
 	line-height: 1.4;
 	min-width: 1.9em;
-	background: var(--garrul-input-bg, #fff);
-	color: var(--garrul-fg, #1a1a1a);
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	border-radius: var(--garrul-radius, 6px);
+	background: var(--gr-input-bg);
+	color: var(--gr-fg);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
 	padding: 0.2rem 0.45rem;
 	cursor: pointer;
 	align-self: flex-start;
 }
-.gr-toolbar-btn:hover { border-color: var(--garrul-accent, #2563eb); }
+.gr-toolbar-btn:hover { border-color: var(--gr-accent); }
 .gr-preview p { margin: 0.3em 0; }
-.gr-preview a { color: var(--garrul-link, #2563eb); }
+.gr-preview a { color: var(--gr-link); }
 .gr-form .gr-honeypot { position: absolute; left: -9999px; top: -9999px; }
 .gr-form .gr-notify { display: flex; align-items: center; gap: 0.4rem; font-size: 0.9em; cursor: pointer; }
 .gr-form .gr-notify .gr-notify-cb { width: auto; }
@@ -165,66 +186,66 @@ const STYLE_CSS = `
 }
 .gr-form button {
 	font: inherit;
-	background: var(--garrul-accent, #2563eb);
-	color: var(--garrul-accent-fg, #fff);
+	background: var(--gr-accent);
+	color: var(--gr-accent-fg);
 	border: none;
-	border-radius: var(--garrul-radius, 6px);
+	border-radius: var(--gr-radius);
 	padding: 0.55rem 1rem;
 	cursor: pointer;
 	align-self: flex-start;
 }
 .gr-form button[disabled] { opacity: 0.6; cursor: progress; }
-.gr-error { color: var(--garrul-error, #b91c1c); font-size: 0.9em; }
-.gr-error.is-notice { color: var(--garrul-notice, #1e6091); }
+.gr-error { color: var(--gr-error); font-size: 0.9em; }
+.gr-error.is-notice { color: var(--gr-notice); }
 .gr-list { display: flex; flex-direction: column; gap: 1rem; }
 .gr-thread { display: flex; flex-direction: column; gap: 0.75rem; }
-.gr-replies { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 0.5rem; padding-left: 1.25rem; border-left: 2px solid var(--garrul-border, #d0d3d8); }
+.gr-replies { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 0.5rem; padding-left: 1.25rem; border-left: 2px solid var(--gr-border); }
 .gr-comment { display: flex; gap: 0.75rem; }
-.gr-comment[data-flat="1"] .gr-flatten { font-size: 0.85em; color: var(--garrul-muted, #6b7280); margin-right: 0.3em; }
+.gr-comment[data-flat="1"] .gr-flatten { font-size: 0.85em; color: var(--gr-muted); margin-right: 0.3em; }
 .gr-avatar { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 50%; overflow: hidden; }
 .gr-avatar svg, .gr-avatar img { width: 100%; height: 100%; display: block; }
 .gr-main { flex: 1; min-width: 0; }
 .gr-meta { display: flex; gap: 0.5rem; align-items: baseline; flex-wrap: wrap; }
 .gr-name { font-weight: 600; }
 .gr-verified {
-	background: var(--garrul-badge-bg, #e0e7ff);
-	color: var(--garrul-badge-fg, #1e3a8a);
+	background: var(--gr-badge-bg);
+	color: var(--gr-badge-fg);
 	font-size: 0.75em;
 	padding: 0.05em 0.4em;
 	border-radius: 999px;
 }
-.gr-time { color: var(--garrul-muted, #6b7280); font-size: 0.85em; }
+.gr-time { color: var(--gr-muted); font-size: 0.85em; }
 .gr-body { margin: 0.25rem 0 0; }
 .gr-body p { margin: 0.3em 0; }
-.gr-body a { color: var(--garrul-link, #2563eb); }
-.gr-deleted { color: var(--garrul-muted, #6b7280); font-style: italic; }
+.gr-body a { color: var(--gr-link); }
+.gr-deleted { color: var(--gr-muted); font-style: italic; }
 .gr-actions { display: flex; gap: 0.75rem; margin-top: 0.35rem; font-size: 0.85em; }
 .gr-actions button {
 	font: inherit;
 	background: transparent;
-	color: var(--garrul-muted, #6b7280);
+	color: var(--gr-muted);
 	border: none;
 	padding: 0;
 	cursor: pointer;
 }
-.gr-actions button:hover { color: var(--garrul-link, #2563eb); }
+.gr-actions button:hover { color: var(--gr-link); }
 .gr-page-engage {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
 	gap: 0.75rem 1.25rem;
 	padding-bottom: 0.5rem;
-	border-bottom: 1px solid var(--garrul-border, #d0d3d8);
+	border-bottom: 1px solid var(--gr-border);
 }
 .gr-page-reactions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 .gr-page-votes { display: flex; align-items: center; gap: 0.4rem; }
-.gr-page-vote-label { color: var(--garrul-muted, #6b7280); font-size: 0.9em; }
+.gr-page-vote-label { color: var(--gr-muted); font-size: 0.9em; }
 .gr-reactions { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-top: 0.4rem; }
 .gr-reaction {
 	font: inherit;
-	background: var(--garrul-input-bg, #fff);
-	color: var(--garrul-fg, #1a1a1a);
-	border: 1px solid var(--garrul-border, #d0d3d8);
+	background: var(--gr-input-bg);
+	color: var(--gr-fg);
+	border: 1px solid var(--gr-border);
 	border-radius: 999px;
 	padding: 0.05em 0.55em;
 	font-size: 0.85em;
@@ -232,17 +253,17 @@ const STYLE_CSS = `
 	line-height: 1.5;
 }
 .gr-reaction[data-mine="1"] {
-	background: var(--garrul-badge-bg, #e0e7ff);
-	color: var(--garrul-badge-fg, #1e3a8a);
-	border-color: var(--garrul-accent, #2563eb);
+	background: var(--gr-badge-bg);
+	color: var(--gr-badge-fg);
+	border-color: var(--gr-accent);
 }
 .gr-reaction-count { margin-left: 0.25em; font-variant-numeric: tabular-nums; }
 .gr-votes { display: flex; align-items: center; gap: 0.3rem; margin-top: 0.4rem; font-size: 0.85em; }
 .gr-vote {
 	font: inherit;
-	background: var(--garrul-input-bg, #fff);
-	color: var(--garrul-muted, #6b7280);
-	border: 1px solid var(--garrul-border, #d0d3d8);
+	background: var(--gr-input-bg);
+	color: var(--gr-muted);
+	border: 1px solid var(--gr-border);
 	border-radius: 999px;
 	width: 1.8em;
 	height: 1.8em;
@@ -253,21 +274,21 @@ const STYLE_CSS = `
 	align-items: center;
 	justify-content: center;
 }
-.gr-vote:hover { color: var(--garrul-link, #2563eb); }
+.gr-vote:hover { color: var(--gr-link); }
 .gr-vote[data-mine="1"] {
-	background: var(--garrul-badge-bg, #e0e7ff);
-	color: var(--garrul-badge-fg, #1e3a8a);
-	border-color: var(--garrul-accent, #2563eb);
+	background: var(--gr-badge-bg);
+	color: var(--gr-badge-fg);
+	border-color: var(--gr-accent);
 }
 .gr-vote[disabled] { opacity: 0.6; cursor: progress; }
 .gr-vote-score { font-variant-numeric: tabular-nums; min-width: 1.2em; text-align: center; }
-.gr-sort { display: flex; gap: 0.4rem; align-items: center; font-size: 0.85em; color: var(--garrul-muted, #6b7280); margin-top: 0.5rem; }
+.gr-sort { display: flex; gap: 0.4rem; align-items: center; font-size: 0.85em; color: var(--gr-muted); margin-top: 0.5rem; }
 .gr-sort select {
 	font: inherit;
-	background: var(--garrul-input-bg, #fff);
-	color: var(--garrul-fg, #1a1a1a);
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	border-radius: var(--garrul-radius, 6px);
+	background: var(--gr-input-bg);
+	color: var(--gr-fg);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
 	padding: 0.2rem 0.4rem;
 }
 .gr-reply-form { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
@@ -275,25 +296,25 @@ const STYLE_CSS = `
 .gr-reply-form .gr-reply-actions { display: flex; gap: 0.5rem; }
 .gr-reply-form .gr-reply-actions button {
 	font: inherit;
-	border-radius: var(--garrul-radius, 6px);
+	border-radius: var(--gr-radius);
 	padding: 0.4rem 0.9rem;
 	cursor: pointer;
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	background: var(--garrul-input-bg, #fff);
-	color: var(--garrul-fg, #1a1a1a);
+	border: 1px solid var(--gr-border);
+	background: var(--gr-input-bg);
+	color: var(--gr-fg);
 }
 .gr-reply-form .gr-reply-actions button[type="submit"] {
-	background: var(--garrul-accent, #2563eb);
-	color: var(--garrul-accent-fg, #fff);
-	border-color: var(--garrul-accent, #2563eb);
+	background: var(--gr-accent);
+	color: var(--gr-accent-fg);
+	border-color: var(--gr-accent);
 }
-.gr-empty { color: var(--garrul-muted, #6b7280); margin: 0; }
+.gr-empty { color: var(--gr-muted); margin: 0; }
 .gr-loadmore {
 	font: inherit;
 	background: transparent;
-	color: var(--garrul-link, #2563eb);
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	border-radius: var(--garrul-radius, 6px);
+	color: var(--gr-link);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
 	padding: 0.5rem 1rem;
 	cursor: pointer;
 	align-self: center;
@@ -308,30 +329,30 @@ const STYLE_CSS = `
 	cursor: pointer;
 	align-self: flex-start;
 }
-.gr-collapse { color: var(--garrul-muted, #6b7280); }
-.gr-showmore { color: var(--garrul-link, #2563eb); margin-top: 0.25rem; }
+.gr-collapse { color: var(--gr-muted); }
+.gr-showmore { color: var(--gr-link); margin-top: 0.25rem; }
 .gr-signin { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
 .gr-signin button {
 	font: inherit;
-	background: var(--garrul-input-bg, #fff);
-	color: var(--garrul-fg, #1a1a1a);
-	border: 1px solid var(--garrul-border, #d0d3d8);
-	border-radius: var(--garrul-radius, 6px);
+	background: var(--gr-input-bg);
+	color: var(--gr-fg);
+	border: 1px solid var(--gr-border);
+	border-radius: var(--gr-radius);
 	padding: 0.4rem 0.8rem;
 	cursor: pointer;
 }
-.gr-signed { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; color: var(--garrul-muted, #6b7280); font-size: 0.9em; }
-.gr-signed .gr-signed-name { color: var(--garrul-fg, #1a1a1a); font-weight: 600; }
+.gr-signed { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; color: var(--gr-muted); font-size: 0.9em; }
+.gr-signed .gr-signed-name { color: var(--gr-fg); font-weight: 600; }
 .gr-signed button {
 	font: inherit;
 	background: transparent;
-	color: var(--garrul-link, #2563eb);
+	color: var(--gr-link);
 	border: none;
 	padding: 0;
 	cursor: pointer;
 	text-decoration: underline;
 }
-.gr-skel { background: var(--garrul-skel, #e7e9ec); border-radius: 6px; animation: gr-pulse 1.2s ease-in-out infinite; }
+.gr-skel { background: var(--gr-skel); border-radius: 6px; animation: gr-pulse 1.2s ease-in-out infinite; }
 .gr-skel-line { height: 0.9em; }
 .gr-skel-avatar { width: 40px; height: 40px; border-radius: 50%; }
 @keyframes gr-pulse {
@@ -340,7 +361,7 @@ const STYLE_CSS = `
 }
 .gr-attribution {
 	font-size: 0.8em;
-	color: var(--garrul-muted, #6b7280);
+	color: var(--gr-muted);
 	text-align: right;
 	margin: 0.5rem 0 0;
 }

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -281,6 +281,15 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 }
 .gr-error[hidden] { display: none; }
 .gr-error.is-notice { color: var(--gr-notice); }
+/* Composer submit errors are inline (text only) — a box-in-a-box reads too
+   heavy next to the composer. The :not(.is-notice) guard keeps the boxed
+   styling for the in-form "awaiting moderation" notice, which reuses this
+   same element by toggling .is-notice. */
+.gr-error.is-inline:not(.is-notice) {
+	background: transparent;
+	border: 0;
+	padding: 0;
+}
 .gr-list { display: flex; flex-direction: column; gap: 1rem; }
 .gr-thread { display: flex; flex-direction: column; gap: 0.75rem; }
 .gr-replies { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 0.5rem; padding-left: 1.25rem; border-left: 2px solid var(--gr-border); }
@@ -1273,7 +1282,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	actions.append(submit, cancel);
 	wrap.appendChild(actions);
 
-	const errBox = el("div", "gr-error");
+	const errBox = el("div", "gr-error is-inline");
 	errBox.hidden = true;
 	wrap.appendChild(errBox);
 
@@ -1632,7 +1641,7 @@ const buildForm = (
 	const submit = el("button", undefined, "Post comment");
 	submit.type = "submit";
 
-	const errBox = el("div", "gr-error");
+	const errBox = el("div", "gr-error is-inline");
 	errBox.hidden = true;
 
 	form.append(submit, errBox);

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -186,6 +186,15 @@ const STYLE_CSS = `
 	padding: 0.6rem;
 	box-shadow: var(--gr-shadow);
 }
+/* Nested reply/edit composers sit inside an already-bordered thread, so drop
+   the card chrome (surface fill, border, shadow, padding) to avoid a box in a
+   box — they blend into the thread instead of stacking another raised card. */
+.gr-compose.gr-compose-nested {
+	background: transparent;
+	border: 0;
+	box-shadow: none;
+	padding: 0;
+}
 .gr-compose textarea[hidden] { display: none; }
 .gr-tabs { display: flex; gap: 0.25rem; }
 .gr-tab {
@@ -551,8 +560,9 @@ const buildToolbar = (ta: HTMLTextAreaElement): HTMLElement => {
 const buildWritePreview = (
 	textarea: HTMLTextAreaElement,
 	apiBase: string,
+	compact = false,
 ): HTMLElement => {
-	const wrap = el("div", "gr-compose");
+	const wrap = el("div", compact ? "gr-compose gr-compose-nested" : "gr-compose");
 	const tabs = el("div", "gr-tabs");
 	tabs.setAttribute("role", "tablist");
 	const writeTab = el("button", "gr-tab gr-tab-active", "Write");
@@ -1191,7 +1201,7 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	cancel.type = "button";
 	cancel.addEventListener("click", () => wrap.remove());
 	actions.append(save, cancel);
-	wrap.append(buildWritePreview(ta, ctx.apiBase), actions);
+	wrap.append(buildWritePreview(ta, ctx.apiBase, true), actions);
 	wrap.addEventListener("submit", async (e) => {
 		e.preventDefault();
 		save.disabled = true;
@@ -1231,7 +1241,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 		nameInput.required = true;
 		wrap.appendChild(nameInput);
 	}
-	wrap.appendChild(buildWritePreview(ta, ctx.apiBase));
+	wrap.appendChild(buildWritePreview(ta, ctx.apiBase, true));
 
 	// Honeypot: mirrors the top-level form's anti-spam input. Hidden offscreen
 	// via .gr-honeypot, readonly to defeat browser autofill, tabIndex -1 so

--- a/tests/admin-controls-charts.test.ts
+++ b/tests/admin-controls-charts.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Render/security tests for the shared admin control + chart helpers.
+ *
+ * renderTabs interpolates `stateVar` and each tab `id` raw into Alpine
+ * *expression* strings (:class / @click), where HTML-escaping is not enough
+ * (the parser decodes entities before Alpine evaluates). The identifier
+ * allowlist must therefore reject anything that isn't a plain identifier.
+ *
+ * barChartSvg renders `point.day`, which derives from stored data, into an
+ * SVG <title>; it must be HTML-escaped, and the empty-data path must degrade
+ * to a plain message rather than an empty/again broken SVG.
+ */
+import { describe, it, expect } from "vitest";
+import { renderTabs } from "../src/admin-ui/controls";
+import { barChartSvg, sparklineSvg } from "../src/admin-ui/charts";
+
+describe("renderTabs", () => {
+	it("renders a tab strip bound to the state var", () => {
+		const html = renderTabs("tab", [
+			{ id: "features", label: "Features" },
+			{ id: "display", label: "Display" },
+		]);
+		expect(html).toContain('role="tablist"');
+		expect(html).toContain("tab === 'features'");
+		expect(html).toContain("tab = 'display'");
+		expect(html).toContain(">Features</button>");
+	});
+
+	it("escapes the human-facing tab label", () => {
+		const html = renderTabs("tab", [
+			{ id: "x", label: `<script>alert(1)</script>` },
+		]);
+		expect(html).not.toContain("<script>");
+		expect(html).toContain("&lt;script&gt;");
+	});
+
+	it("throws on a tab id that is not a plain identifier", () => {
+		expect(() =>
+			renderTabs("tab", [{ id: "x'); alert(1); //", label: "Evil" }]),
+		).toThrow(/unsafe tab id/);
+	});
+
+	it("throws on a state var that is not a plain identifier", () => {
+		expect(() =>
+			renderTabs("tab'); alert(1); //", [{ id: "x", label: "X" }]),
+		).toThrow(/unsafe stateVar/);
+	});
+
+	it("accepts dotted state-var paths but rejects spaces/quotes", () => {
+		expect(() => renderTabs("settings.tab", [{ id: "a", label: "A" }])).not.toThrow();
+		expect(() => renderTabs("a b", [{ id: "a", label: "A" }])).toThrow(
+			/unsafe stateVar/,
+		);
+	});
+});
+
+describe("barChartSvg", () => {
+	it("renders one bar per point with an SVG chart", () => {
+		const html = barChartSvg([
+			{ day: "2026-01-01", count: 3 },
+			{ day: "2026-01-02", count: 5 },
+		]);
+		expect(html).toContain("<svg");
+		expect((html.match(/<rect /g) ?? []).length).toBe(2);
+		expect(html).toContain("peak 5/day");
+	});
+
+	it("escapes hostile day strings in the bar <title>", () => {
+		const html = barChartSvg([
+			{ day: `"><script>alert(1)</script>`, count: 1 },
+		]);
+		expect(html).not.toContain("<script>");
+		expect(html).toContain("&lt;script&gt;");
+	});
+
+	it("degrades to a plain message on empty data", () => {
+		const html = barChartSvg([]);
+		expect(html).not.toContain("<svg");
+		expect(html).toContain("No activity in this range.");
+	});
+});
+
+describe("sparklineSvg", () => {
+	it("degrades to a plain message on empty data", () => {
+		const html = sparklineSvg([]);
+		expect(html).not.toContain("<svg");
+		expect(html).toContain("No activity in this range.");
+	});
+
+	it("escapes hostile day strings in the caption", () => {
+		const html = sparklineSvg([
+			{ day: `"><script>alert(1)</script>`, count: 2 },
+		]);
+		expect(html).not.toContain("<script>");
+		expect(html).toContain("&lt;script&gt;");
+	});
+});

--- a/tests/admin-controls-charts.test.ts
+++ b/tests/admin-controls-charts.test.ts
@@ -11,7 +11,11 @@
  * to a plain message rather than an empty/again broken SVG.
  */
 import { describe, it, expect } from "vitest";
-import { renderTabs } from "../src/admin-ui/controls";
+import {
+	renderSwitch,
+	renderStepper,
+	renderTabs,
+} from "../src/admin-ui/controls";
 import { barChartSvg, sparklineSvg } from "../src/admin-ui/charts";
 
 describe("renderTabs", () => {
@@ -43,22 +47,79 @@ describe("renderTabs", () => {
 	it("throws on a state var that is not a plain identifier", () => {
 		expect(() =>
 			renderTabs("tab'); alert(1); //", [{ id: "x", label: "X" }]),
-		).toThrow(/unsafe stateVar/);
+		).toThrow(/unsafe expression/);
 	});
 
 	it("accepts dotted state-var paths but rejects spaces/quotes", () => {
 		expect(() => renderTabs("settings.tab", [{ id: "a", label: "A" }])).not.toThrow();
 		expect(() => renderTabs("a b", [{ id: "a", label: "A" }])).toThrow(
-			/unsafe stateVar/,
+			/unsafe expression/,
 		);
 	});
 
 	it("rejects malformed dotted paths (empty segments)", () => {
 		for (const bad of ["a..b", "a.", ".a", "a.b.", ".", "a..b.c"]) {
 			expect(() => renderTabs(bad, [{ id: "a", label: "A" }])).toThrow(
-				/unsafe stateVar/,
+				/unsafe expression/,
 			);
 		}
+	});
+});
+
+describe("renderSwitch", () => {
+	it("renders a checkbox bound to the model", () => {
+		const html = renderSwitch({
+			name: "comments_enabled",
+			model: "flags.comments_enabled",
+			label: "Comments",
+			help: "Allow new comments",
+		});
+		expect(html).toContain('name="comments_enabled"');
+		expect(html).toContain('x-model="flags.comments_enabled"');
+		expect(html).toContain("<strong>Comments</strong>");
+	});
+
+	it("throws when the model is not a plain identifier path", () => {
+		// `model` lands in an Alpine x-model expression (unsafe-eval), so a
+		// quote-breakout must fail loudly rather than escape into the expression.
+		expect(() =>
+			renderSwitch({
+				name: "ok",
+				model: "x'); alert(1); //",
+				label: "Evil",
+				help: "",
+			}),
+		).toThrow(/unsafe expression/);
+	});
+});
+
+describe("renderStepper", () => {
+	it("renders a numeric input bound to the model", () => {
+		const html = renderStepper({
+			name: "comments_per_page",
+			model: "nums.comments_per_page",
+			min: 1,
+			max: 100,
+			label: "Per page",
+			help: "How many comments per page",
+		});
+		expect(html).toContain('name="comments_per_page"');
+		expect(html).toContain('x-model.number="nums.comments_per_page"');
+		expect(html).toContain('min="1"');
+		expect(html).toContain('max="100"');
+	});
+
+	it("throws when the model is not a plain identifier path", () => {
+		expect(() =>
+			renderStepper({
+				name: "ok",
+				model: "x') + alert(1) + ('",
+				min: 0,
+				max: 10,
+				label: "Evil",
+				help: "",
+			}),
+		).toThrow(/unsafe expression/);
 	});
 });
 

--- a/tests/admin-controls-charts.test.ts
+++ b/tests/admin-controls-charts.test.ts
@@ -52,6 +52,14 @@ describe("renderTabs", () => {
 			/unsafe stateVar/,
 		);
 	});
+
+	it("rejects malformed dotted paths (empty segments)", () => {
+		for (const bad of ["a..b", "a.", ".a", "a.b.", ".", "a..b.c"]) {
+			expect(() => renderTabs(bad, [{ id: "a", label: "A" }])).toThrow(
+				/unsafe stateVar/,
+			);
+		}
+	});
 });
 
 describe("barChartSvg", () => {

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -15,9 +15,16 @@ import {
 	type SubscriptionsFilters,
 } from "../src/admin-ui/pages/subscriptions";
 import { renderOperator } from "../src/admin-ui/pages/operator";
+import { renderSettings } from "../src/admin-ui/pages/settings";
 import { MAX_XML_BYTES } from "../src/lib/disqus-import";
 import { renderDashboard } from "../src/admin-ui/pages/dashboard";
 import { renderUpdateBanner } from "../src/admin-ui/layout";
+import {
+	FLAG_KEYS,
+	NUMBER_KEYS,
+	type ResolvedFlags,
+	type ResolvedNumbers,
+} from "../src/lib/settings";
 import type {
 	AdminComment,
 	ADMIN_ACTIONS,
@@ -579,5 +586,50 @@ describe("renderDashboard", () => {
 		);
 		expect(html).not.toContain("<svg/onload=alert(1)>");
 		expect(html).toContain("&lt;svg/onload=alert(1)&gt;");
+	});
+});
+
+describe("renderSettings field-name contract", () => {
+	// The render side (this form) and the write side (POST /admin/settings,
+	// which whitelists FLAG_KEYS / NUMBER_KEYS) are wired independently. A typo
+	// or rename on only one side would silently break form submission while
+	// both suites still pass, so pin the rendered name/x-model bindings to the
+	// exact keys the handler persists.
+	const flags = Object.fromEntries(
+		FLAG_KEYS.map((k) => [k, false]),
+	) as ResolvedFlags;
+	const numbers = Object.fromEntries(
+		NUMBER_KEYS.map((k) => [k, 10]),
+	) as ResolvedNumbers;
+	const html = renderSettings({} as Bindings, flags, numbers);
+
+	it("emits a switch for every flag key the POST handler whitelists", () => {
+		for (const key of FLAG_KEYS) {
+			// `name` drives any native submit; `x-model` (= flags.<key>) is what
+			// the Alpine JSON submit actually reads — pin both.
+			expect(html).toContain(`name="${key}"`);
+			expect(html).toContain(`x-model="flags.${key}"`);
+		}
+	});
+
+	it("emits a stepper for every number key the POST handler whitelists", () => {
+		for (const key of NUMBER_KEYS) {
+			expect(html).toContain(`name="${key}"`);
+			expect(html).toContain(`x-model.number="nums.${key}"`);
+		}
+	});
+
+	it("does not emit a settings input bound to an unknown key", () => {
+		// Catches a stray control whose name isn't in the whitelist (would be
+		// silently dropped by the handler). Every checkbox/number input name
+		// must be a known flag or number key.
+		const known = new Set<string>([...FLAG_KEYS, ...NUMBER_KEYS]);
+		const inputNames = [
+			...html.matchAll(/<input\b[^>]*\bname="([^"]+)"/g),
+		].map((m) => m[1]);
+		expect(inputNames.length).toBeGreaterThan(0);
+		for (const name of inputNames) {
+			expect(known.has(name)).toBe(true);
+		}
 	});
 });

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -493,8 +493,9 @@ describe("renderDashboard", () => {
 		);
 		expect(html).toContain("12.0%");
 		expect(html).toContain("/admin/comments/01HOLDEST");
-		// sparkline path renders both days
-		expect(html).toContain("<path");
+		// the comments-per-day bar chart renders a <rect> bar per day
+		expect(html).toContain("<rect");
+		expect(html).toContain("Comments per day bar chart");
 	});
 
 	it("renders an empty-state message when there is no timeline", () => {

--- a/tests/role-gating.test.ts
+++ b/tests/role-gating.test.ts
@@ -195,6 +195,63 @@ describe("admin layout role-aware nav", () => {
 	});
 });
 
+describe("admin layout active-link highlighting", () => {
+	const admin = makeUser({ role: "admin", is_admin: true, name: "Admin" });
+
+	// Read the class attribute of the *nav* anchor for an exact href. The
+	// trailing quote in `href="${href}"` makes the match exact (so `/admin`
+	// won't also match `/admin/users`), and requiring `class="nav-link..."`
+	// skips the brand/logo anchor, which also points at `/admin`.
+	const navLinkClass = (html: string, href: string): string => {
+		const m = html.match(
+			new RegExp(`href="${href.replace(/[/]/g, "\\/")}"\\s+class="(nav-link[^"]*)"`),
+		);
+		if (!m) throw new Error(`no nav link for ${href}`);
+		return m[1];
+	};
+	const isActive = (html: string, href: string): boolean =>
+		navLinkClass(html, href).split(/\s+/).includes("active");
+
+	it("does not mark any link active without an activePath", () => {
+		const html = layout("test", "<p>x</p>", admin, null);
+		expect(isActive(html, "/admin")).toBe(false);
+		expect(isActive(html, "/admin/users")).toBe(false);
+	});
+
+	it("matches the dashboard root exactly, not as a prefix", () => {
+		// "/admin" is a prefix of every admin path, so it must NOT light up on
+		// sub-pages — otherwise Dashboard would always look active.
+		const onSub = layout("test", "<p>x</p>", admin, null, {
+			activePath: "/admin/users",
+		});
+		expect(isActive(onSub, "/admin")).toBe(false);
+		expect(isActive(onSub, "/admin/users")).toBe(true);
+
+		const onRoot = layout("test", "<p>x</p>", admin, null, {
+			activePath: "/admin",
+		});
+		expect(isActive(onRoot, "/admin")).toBe(true);
+		expect(isActive(onRoot, "/admin/users")).toBe(false);
+	});
+
+	it("keeps a section active on its sub-pages (prefix match)", () => {
+		const html = layout("test", "<p>x</p>", admin, null, {
+			activePath: "/admin/users/01HU00000000000000000000A",
+		});
+		expect(isActive(html, "/admin/users")).toBe(true);
+		expect(isActive(html, "/admin/queue")).toBe(false);
+	});
+
+	it("requires a slash boundary so sibling prefixes don't spuriously match", () => {
+		// "/admin/queuexyz" shares a string prefix with "/admin/queue" but is a
+		// different route; the `${href}/` guard must keep Queue inactive.
+		const html = layout("test", "<p>x</p>", admin, null, {
+			activePath: "/admin/queuexyz",
+		});
+		expect(isActive(html, "/admin/queue")).toBe(false);
+	});
+});
+
 describe("countAdmins", () => {
 	it("counts users WHERE role = 'admin' (not is_admin)", async () => {
 		let captured: { sql: string; binds: unknown[] } | null = null;

--- a/tests/role-gating.test.ts
+++ b/tests/role-gating.test.ts
@@ -198,16 +198,20 @@ describe("admin layout role-aware nav", () => {
 describe("admin layout active-link highlighting", () => {
 	const admin = makeUser({ role: "admin", is_admin: true, name: "Admin" });
 
-	// Read the class attribute of the *nav* anchor for an exact href. The
-	// trailing quote in `href="${href}"` makes the match exact (so `/admin`
-	// won't also match `/admin/users`), and requiring `class="nav-link..."`
-	// skips the brand/logo anchor, which also points at `/admin`.
+	// Read the class attribute of the *nav* anchor for an exact href. Plain
+	// string scanning (not a regex built from the href, which would need
+	// metacharacter escaping): the `"` after href and the ` class="` that
+	// immediately follows make the match exact (so `/admin` won't also match
+	// `/admin/users`), and requiring the class to start with `nav-link` skips
+	// the brand/logo anchor, which also points at `/admin`.
 	const navLinkClass = (html: string, href: string): string => {
-		const m = html.match(
-			new RegExp(`href="${href.replace(/[/]/g, "\\/")}"\\s+class="(nav-link[^"]*)"`),
-		);
-		if (!m) throw new Error(`no nav link for ${href}`);
-		return m[1];
+		const marker = `href="${href}" class="`;
+		for (let at = html.indexOf(marker); at !== -1; at = html.indexOf(marker, at + 1)) {
+			const start = at + marker.length;
+			const cls = html.slice(start, html.indexOf('"', start));
+			if (cls.startsWith("nav-link")) return cls;
+		}
+		throw new Error(`no nav link for ${href}`);
 	};
 	const isActive = (html: string, href: string): boolean =>
 		navLinkClass(html, href).split(/\s+/).includes("active");


### PR DESCRIPTION
## Summary

A full UI/UX overhaul of **both** Garrul surfaces — the admin UI and the embeddable widget — closing the visual-polish gap against Bulla (admin) and remark42 (widget). Functionality, the admin CSP model, and the widget's semver-protected theming contract are all preserved; the work is presentation-only.

### Admin
- **Light/dark design-token system** with light as the new default; theme toggle via Alpine on `<html>` with a `prefers-color-scheme` no-FOUC default (CSP-safe — no inline `<head>` script).
- **Top nav → left sidebar app shell** with inline-SVG icons, sectioned + role-gated nav, responsive off-canvas drawer, and active-link highlighting (now matches on sub-pages too).
- New shared helpers: `icons.ts`, `controls.ts` (switch/stepper/tabs), `charts.ts` (server-rendered SVG bar chart + sparkline — no charting CDN).
- Redesigned dashboard (stat-card variants, real bar chart, embed-code copy card) and **tabbed settings** with toggle switches + steppers (POST contract unchanged).
- Component restyle (cards/buttons/pills/tables/modal/toast) re-pointed to the tokens; themed access-denied page; styled the previously-orphaned usage bars + queue audit strip.

### Widget
- **Built-in dark mode** via a private `--gr-*` variable layer that chains through every public `--garrul-*` var, so host overrides keep winning at every theme level. Reacts to `prefers-color-scheme` and a `data-theme="auto|light|dark"` attribute — zero JS.
- 5 new additive (non-breaking) theming vars documented in `docs/THEMING.md`.
- Polished composer/toolbar, thread/controls, and skeleton/empty/error states; lighter nested reply/edit composers and inline composer-submit errors.

## Constraints honored
- **Admin CSP** unchanged (byte-identical): no inline scripts, all interactivity via Alpine attribute directives; Alpine pin + SRI untouched; no new external origins.
- **Widget theming contract**: no `--garrul-*` rename/removal/repurpose — only additive vars.
- **Bundle budget**: `embed.js` ~10.4 KB gzipped (ceiling 20 KB).
- All existing admin HTML-contract tests still pass.

## Testing
- `npm test` → **529 passing** (39 files), incl. new coverage for the `renderTabs` injection guard and chart escaping/empty-data.
- `npm run typecheck` (both tsconfigs) clean.
- `npm run build:embed && npm run size` → 10.4 KB gz, under budget.

## Security
Per-feature passes plus a dedicated audit commit. Verified: no inline `<script>` introduced; `activePath` is used only in boolean comparisons (never interpolated into markup); all data-derived strings (chart day labels, tab labels) go through `escapeHtml`; `renderTabs` enforces an identifier allowlist for values that reach Alpine expressions; widget XSS posture unchanged (untrusted text via `textContent`, only sanitized `body_html` parsed); theme/localStorage keys hold no PII.

## Not done in this PR
Visual rendering was **not** verified in a live browser (the optional local preview tool was intentionally dropped). Recommend a manual pass across both themes + the widget `data-theme` matrix before/after merge.
