### PR TITLE
feat(oauth): add Facebook, X, and Discord social logins (+ PKCE)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -17,6 +17,8 @@ GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 FACEBOOK_CLIENT_ID=""
 FACEBOOK_CLIENT_SECRET=""
+TWITTER_CLIENT_ID=""
+TWITTER_CLIENT_SECRET=""
 
 # Email — Resend default. Leave blank to disable notification sends locally.
 RESEND_API_KEY=""

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -19,6 +19,8 @@ FACEBOOK_CLIENT_ID=""
 FACEBOOK_CLIENT_SECRET=""
 TWITTER_CLIENT_ID=""
 TWITTER_CLIENT_SECRET=""
+DISCORD_CLIENT_ID=""
+DISCORD_CLIENT_SECRET=""
 
 # Email — Resend default. Leave blank to disable notification sends locally.
 RESEND_API_KEY=""

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -15,6 +15,8 @@ GH_CLIENT_ID=""
 GH_CLIENT_SECRET=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
+FACEBOOK_CLIENT_ID=""
+FACEBOOK_CLIENT_SECRET=""
 
 # Email — Resend default. Leave blank to disable notification sends locally.
 RESEND_API_KEY=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ Good fit: **static blogs, docs sites, marketing sites** that want
 threaded comments without a CMS; teams who want **first-party data
 ownership** (D1, not a SaaS); embeds that should be **tracker-free**
 (no analytics pixels, one HttpOnly session cookie); auth needs that
-**GitHub/Google OAuth + anonymous-with-Turnstile** covers.
+**GitHub / Google / Facebook / X / Discord OAuth +
+anonymous-with-Turnstile** covers.
 
 Not a fit: high-volume **forums** (sub-forums, pinned megathreads,
 thousands of concurrent posters); sites that need **real-time updates**

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Workers + D1 + KV + Turnstile. One Worker per site, no per-comment
 billing, your data stays in your account.
 
 - **Threaded comments** with markdown, reactions, edit/delete window
-- **OAuth sign-in** (GitHub + Google) + anonymous posting with rate
-  limiting and Turnstile
+- **OAuth sign-in** (GitHub, Google, Facebook, X, Discord) + anonymous
+  posting with rate limiting and Turnstile
 - **Embeddable widget** (~17 KB) with Shadow-DOM isolation, theme
   variables, and an iframe alternative
 - **Email digests**, RSS feeds, comment counts, permalinks

--- a/docs/privacy-policy.template.md
+++ b/docs/privacy-policy.template.md
@@ -22,8 +22,8 @@ When you post a comment, the following is stored:
   for rate limiting and (if applicable) anonymous-author identity.
 - A **timestamp**.
 
-If you signed in with **OAuth** (GitHub or Google), we additionally
-store:
+If you signed in with **OAuth** (GitHub, Google, Facebook, X, or
+Discord), we additionally store:
 
 - Your **email address** as returned by the provider (we never read
   your inbox or anything else from the provider).

--- a/docs/tos.template.md
+++ b/docs/tos.template.md
@@ -47,7 +47,7 @@ try to give one when reasonable.
 ## Account and email
 
 If you sign in with OAuth, your provider's terms also apply (GitHub,
-Google).
+Google, Facebook, X, Discord).
 
 If you opt in to email notifications, we'll send digest emails to
 the address you provide. Each email contains an unsubscribe link.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,15 +116,39 @@ Fix sequence:
 If that still fails, the widget falls back to a top-level redirect
 when popup is blocked. The user navigates manually back to the blog.
 
-### "redirect_uri_mismatch" on GitHub or Google
+### "redirect_uri_mismatch" (any provider)
 
 The redirect URI registered in your OAuth app must exactly match
 `OAUTH_CALLBACK_BASE` + `/api/v1/auth/<provider>/callback`. No trailing
-slash, no `www.` if your worker doesn't serve `www.`.
+slash, no `www.` if your worker doesn't serve `www.`. The `<provider>`
+path segment is the internal id, which differs from the display name in
+one case — X uses `twitter`:
+
+- GitHub → `/api/v1/auth/github/callback`
+- Google → `/api/v1/auth/google/callback`
+- Facebook → `/api/v1/auth/facebook/callback`
+- X → `/api/v1/auth/twitter/callback`
+- Discord → `/api/v1/auth/discord/callback`
 
 GitHub OAuth apps allow exactly one callback URL. For staging +
 production, register two OAuth apps and switch credentials per
 deployment.
+
+### Supported providers / why no Instagram
+
+Configured providers are GitHub, Google, Facebook, X (Twitter), and
+Discord. A provider's sign-in button appears only when **both** its
+`*_CLIENT_ID` and `*_CLIENT_SECRET` are set.
+
+- **X (Twitter)** uses OAuth 2.0 with PKCE and returns **no email** — X
+  users sign in with name + avatar only. Because `ADMIN_EMAILS`
+  auto-promotion matches on a verified email, X accounts can't be
+  auto-promoted to admin; promote them from the admin Users page
+  instead.
+- **Instagram is intentionally not supported.** Meta shut down the
+  Instagram Basic Display API (Dec 2024); the replacement login flows
+  are aimed at business/creator accounts, return no email, and aren't
+  suited to a "sign in to comment" use case.
 
 ### Google sign-in works for me but not for other users
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 1,
@@ -45,6 +45,36 @@
       "name": "GOOGLE_CLIENT_SECRET",
       "required": false,
       "addedIn": "1.0.0"
+    },
+    {
+      "name": "FACEBOOK_CLIENT_ID",
+      "required": false,
+      "addedIn": "1.13.0"
+    },
+    {
+      "name": "FACEBOOK_CLIENT_SECRET",
+      "required": false,
+      "addedIn": "1.13.0"
+    },
+    {
+      "name": "TWITTER_CLIENT_ID",
+      "required": false,
+      "addedIn": "1.13.0"
+    },
+    {
+      "name": "TWITTER_CLIENT_SECRET",
+      "required": false,
+      "addedIn": "1.13.0"
+    },
+    {
+      "name": "DISCORD_CLIENT_ID",
+      "required": false,
+      "addedIn": "1.13.0"
+    },
+    {
+      "name": "DISCORD_CLIENT_SECRET",
+      "required": false,
+      "addedIn": "1.13.0"
     },
     {
       "name": "RESEND_API_KEY",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -163,8 +163,11 @@ echo "These prompt one at a time. Skip any you don't have yet."
 put_random_secret JWT_SECRET     "auto-generated 32-byte secret; reserved for future JWT use (sessions are KV-backed)"
 put_random_secret IP_HASH_SECRET "auto-generated 32-byte HMAC pepper for IP hashing — generate once and keep it"
 put_secret_pair "Turnstile"     "from dash.cloudflare.com → Turnstile"            TURNSTILE_SITE_KEY  TURNSTILE_SECRET
-put_secret_pair "GitHub OAuth"  "from github.com/settings/developers"             GH_CLIENT_ID        GH_CLIENT_SECRET
-put_secret_pair "Google OAuth"  "from console.cloud.google.com → OAuth credentials" GOOGLE_CLIENT_ID  GOOGLE_CLIENT_SECRET
+put_secret_pair "GitHub OAuth"   "from github.com/settings/developers"             GH_CLIENT_ID        GH_CLIENT_SECRET
+put_secret_pair "Google OAuth"   "from console.cloud.google.com → OAuth credentials" GOOGLE_CLIENT_ID  GOOGLE_CLIENT_SECRET
+put_secret_pair "Facebook OAuth" "from developers.facebook.com → Facebook Login"   FACEBOOK_CLIENT_ID  FACEBOOK_CLIENT_SECRET
+put_secret_pair "X/Twitter OAuth" "from developer.x.com → OAuth 2.0 (no email)"    TWITTER_CLIENT_ID   TWITTER_CLIENT_SECRET
+put_secret_pair "Discord OAuth"  "from discord.com/developers → OAuth2"            DISCORD_CLIENT_ID   DISCORD_CLIENT_SECRET
 put_secret RESEND_API_KEY        "from resend.com/api-keys"
 put_secret WEBHOOK_URL           "optional fire-and-forget POST on new comment"
 

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -86,6 +86,7 @@ export const renderSettings = (
 		["TURNSTILE_SITE_KEY", env.TURNSTILE_SITE_KEY ? "(set)" : "(unset)"],
 		["GH_CLIENT_ID", env.GH_CLIENT_ID ? "(set)" : "(unset)"],
 		["GOOGLE_CLIENT_ID", env.GOOGLE_CLIENT_ID ? "(set)" : "(unset)"],
+		["FACEBOOK_CLIENT_ID", env.FACEBOOK_CLIENT_ID ? "(set)" : "(unset)"],
 		[
 			"OAUTH_CALLBACK_BASE",
 			env.OAUTH_CALLBACK_BASE ?? "(falls back to request origin)",

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -87,6 +87,7 @@ export const renderSettings = (
 		["GH_CLIENT_ID", env.GH_CLIENT_ID ? "(set)" : "(unset)"],
 		["GOOGLE_CLIENT_ID", env.GOOGLE_CLIENT_ID ? "(set)" : "(unset)"],
 		["FACEBOOK_CLIENT_ID", env.FACEBOOK_CLIENT_ID ? "(set)" : "(unset)"],
+		["TWITTER_CLIENT_ID", env.TWITTER_CLIENT_ID ? "(set)" : "(unset)"],
 		[
 			"OAUTH_CALLBACK_BASE",
 			env.OAUTH_CALLBACK_BASE ?? "(falls back to request origin)",

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -88,6 +88,7 @@ export const renderSettings = (
 		["GOOGLE_CLIENT_ID", env.GOOGLE_CLIENT_ID ? "(set)" : "(unset)"],
 		["FACEBOOK_CLIENT_ID", env.FACEBOOK_CLIENT_ID ? "(set)" : "(unset)"],
 		["TWITTER_CLIENT_ID", env.TWITTER_CLIENT_ID ? "(set)" : "(unset)"],
+		["DISCORD_CLIENT_ID", env.DISCORD_CLIENT_ID ? "(set)" : "(unset)"],
 		[
 			"OAUTH_CALLBACK_BASE",
 			env.OAUTH_CALLBACK_BASE ?? "(falls back to request origin)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ export type Bindings = {
 	GOOGLE_CLIENT_SECRET: string;
 	FACEBOOK_CLIENT_ID: string;
 	FACEBOOK_CLIENT_SECRET: string;
+	TWITTER_CLIENT_ID: string;
+	TWITTER_CLIENT_SECRET: string;
 	OAUTH_CALLBACK_BASE: string;
 	RESEND_API_KEY: string;
 	EMAIL_FROM: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ export type Bindings = {
 	GH_CLIENT_SECRET: string;
 	GOOGLE_CLIENT_ID: string;
 	GOOGLE_CLIENT_SECRET: string;
+	FACEBOOK_CLIENT_ID: string;
+	FACEBOOK_CLIENT_SECRET: string;
 	OAUTH_CALLBACK_BASE: string;
 	RESEND_API_KEY: string;
 	EMAIL_FROM: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ export type Bindings = {
 	FACEBOOK_CLIENT_SECRET: string;
 	TWITTER_CLIENT_ID: string;
 	TWITTER_CLIENT_SECRET: string;
+	DISCORD_CLIENT_ID: string;
+	DISCORD_CLIENT_SECRET: string;
 	OAUTH_CALLBACK_BASE: string;
 	RESEND_API_KEY: string;
 	EMAIL_FROM: string;

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -34,8 +34,17 @@ type ProviderConfig = {
 	authorize_url: string;
 	token_url: string;
 	scope: string;
-	client_id_env: "GH_CLIENT_ID" | "GOOGLE_CLIENT_ID";
-	client_secret_env: "GH_CLIENT_SECRET" | "GOOGLE_CLIENT_SECRET";
+	client_id_env: string;
+	client_secret_env: string;
+	// PKCE (RFC 7636). Required by X/Twitter; harmless for the others. When
+	// true, /start mints a code_verifier + S256 challenge and the token
+	// exchange replays the verifier.
+	pkce?: boolean;
+	// How the token endpoint authenticates the client. "body" (default) puts
+	// client_secret in the POST body; "basic" sends an HTTP Basic header
+	// (client_id:client_secret) and keeps the secret out of the body — X's
+	// confidential-client token endpoint requires this.
+	token_auth?: "body" | "basic";
 	fetch_profile: (access_token: string) => Promise<ProviderProfile>;
 };
 
@@ -137,6 +146,27 @@ export const randomHex = (n: number): string => {
 	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 };
 
+// PKCE (RFC 7636). The verifier is a high-entropy secret minted at /start,
+// stashed server-side in the KV state payload (never sent to the browser),
+// and replayed at the token exchange to prove the client that redeems the
+// code is the same one that started the flow. 32 random bytes → 64 hex chars,
+// well within PKCE's 43–128-char unreserved-charset range.
+export const genCodeVerifier = (): string => randomHex(32);
+
+// SHA-256(verifier), base64url-encoded without padding — the `S256` challenge
+// sent in the authorize redirect. Workers ship crypto.subtle + btoa natively.
+export const computeCodeChallenge = async (
+	verifier: string,
+): Promise<string> => {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(verifier),
+	);
+	let bin = "";
+	for (const b of new Uint8Array(digest)) bin += String.fromCharCode(b);
+	return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
 // Length-independent constant-time string compare. The browser_token /
 // handoff tokens we mint are fixed-length hex, so the early length
 // branch doesn't leak useful information to an attacker. A naive `===`
@@ -164,6 +194,10 @@ export type StatePayload = {
 	// /api/v1/auth/:provider/start; pre-existing state payloads in KV
 	// from before this column shipped may lack it.
 	browser_token?: string;
+	// PKCE code_verifier for providers with `pkce: true` (e.g. X/Twitter).
+	// Lives only here in KV — never sent to the browser — and is replayed at
+	// the token exchange. Absent for non-PKCE providers.
+	code_verifier?: string;
 };
 
 const STATE_TTL = 600; // 10 minutes
@@ -247,6 +281,7 @@ export const buildAuthorizeUrl = (
 	client_id: string,
 	redirect_uri: string,
 	state: string,
+	code_challenge?: string,
 ): string => {
 	const cfg = PROVIDERS[provider];
 	const params = new URLSearchParams({
@@ -256,6 +291,10 @@ export const buildAuthorizeUrl = (
 		scope: cfg.scope,
 		state,
 	});
+	if (code_challenge) {
+		params.set("code_challenge", code_challenge);
+		params.set("code_challenge_method", "S256");
+	}
 	if (provider === "google") {
 		// Force the account chooser when re-authorizing.
 		params.set("prompt", "select_account");
@@ -269,21 +308,32 @@ export const exchangeCodeForToken = async (
 	client_id: string,
 	client_secret: string,
 	redirect_uri: string,
+	code_verifier?: string,
 ): Promise<string> => {
 	const cfg = PROVIDERS[provider];
 	const body = new URLSearchParams({
 		client_id,
-		client_secret,
 		code,
 		redirect_uri,
 		grant_type: "authorization_code",
 	});
+	const headers: Record<string, string> = {
+		accept: "application/json",
+		"content-type": "application/x-www-form-urlencoded",
+	};
+	// PKCE providers replay the verifier minted at /start (RFC 7636 §4.5).
+	if (code_verifier) body.set("code_verifier", code_verifier);
+	if (cfg.token_auth === "basic") {
+		// X/Twitter's confidential-client token endpoint authenticates via an
+		// HTTP Basic header, not a body param. Keeping the secret out of the
+		// body also keeps it off any body-logging path.
+		headers.authorization = `Basic ${btoa(`${client_id}:${client_secret}`)}`;
+	} else {
+		body.set("client_secret", client_secret);
+	}
 	const res = await fetch(cfg.token_url, {
 		method: "POST",
-		headers: {
-			accept: "application/json",
-			"content-type": "application/x-www-form-urlencoded",
-		},
+		headers,
 		body,
 	});
 	if (!res.ok) {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -21,7 +21,12 @@
  * read.
  */
 
-export type ProviderId = "github" | "google" | "facebook" | "twitter";
+export type ProviderId =
+	| "github"
+	| "google"
+	| "facebook"
+	| "twitter"
+	| "discord";
 
 export type ProviderProfile = {
 	provider_id: string; // stable per-provider user id (string form)
@@ -167,6 +172,34 @@ const fetchTwitterProfile = async (
 	};
 };
 
+// Discord. Standard auth-code flow. Trust the email only when Discord flags
+// it `verified` (mirrors the GitHub verified-email handling); the avatar is
+// assembled from the CDN hash.
+const fetchDiscordProfile = async (
+	token: string,
+): Promise<ProviderProfile> => {
+	const res = await fetch("https://discord.com/api/users/@me", {
+		headers: { authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) throw new Error(`discord me ${res.status}`);
+	const u = (await res.json()) as {
+		id: string;
+		username: string;
+		global_name?: string | null;
+		email?: string | null;
+		verified?: boolean;
+		avatar?: string | null;
+	};
+	return {
+		provider_id: u.id,
+		email: u.verified ? (u.email ?? null) : null,
+		name: u.global_name?.trim() || u.username,
+		avatar_url: u.avatar
+			? `https://cdn.discordapp.com/avatars/${u.id}/${u.avatar}.png`
+			: null,
+	};
+};
+
 export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
 	github: {
 		authorize_url: "https://github.com/login/oauth/authorize",
@@ -202,10 +235,22 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
 		token_auth: "basic",
 		fetch_profile: fetchTwitterProfile,
 	},
+	discord: {
+		authorize_url: "https://discord.com/oauth2/authorize",
+		token_url: "https://discord.com/api/oauth2/token",
+		scope: "identify email",
+		client_id_env: "DISCORD_CLIENT_ID",
+		client_secret_env: "DISCORD_CLIENT_SECRET",
+		fetch_profile: fetchDiscordProfile,
+	},
 };
 
 export const isProvider = (s: string): s is ProviderId =>
-	s === "github" || s === "google" || s === "facebook" || s === "twitter";
+	s === "github" ||
+	s === "google" ||
+	s === "facebook" ||
+	s === "twitter" ||
+	s === "discord";
 
 const randomState = (): string => {
 	const bytes = new Uint8Array(24);

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -21,7 +21,7 @@
  * read.
  */
 
-export type ProviderId = "github" | "google";
+export type ProviderId = "github" | "google" | "facebook";
 
 export type ProviderProfile = {
 	provider_id: string; // stable per-provider user id (string form)
@@ -112,6 +112,31 @@ const fetchGoogleProfile = async (token: string): Promise<ProviderProfile> => {
 	};
 };
 
+// Facebook Login (Graph API). Returns email only for accounts with a
+// confirmed email that grant the `email` scope; Graph omits unverified
+// addresses, so we treat a returned address as trusted.
+const fetchFacebookProfile = async (
+	token: string,
+): Promise<ProviderProfile> => {
+	const res = await fetch(
+		"https://graph.facebook.com/v21.0/me?fields=id,name,email,picture.type(large)",
+		{ headers: { authorization: `Bearer ${token}` } },
+	);
+	if (!res.ok) throw new Error(`facebook me ${res.status}`);
+	const u = (await res.json()) as {
+		id: string;
+		name?: string;
+		email?: string;
+		picture?: { data?: { url?: string } };
+	};
+	return {
+		provider_id: u.id,
+		email: u.email ?? null,
+		name: u.name?.trim() || u.email || "user",
+		avatar_url: u.picture?.data?.url ?? null,
+	};
+};
+
 export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
 	github: {
 		authorize_url: "https://github.com/login/oauth/authorize",
@@ -129,10 +154,18 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
 		client_secret_env: "GOOGLE_CLIENT_SECRET",
 		fetch_profile: fetchGoogleProfile,
 	},
+	facebook: {
+		authorize_url: "https://www.facebook.com/v21.0/dialog/oauth",
+		token_url: "https://graph.facebook.com/v21.0/oauth/access_token",
+		scope: "email public_profile",
+		client_id_env: "FACEBOOK_CLIENT_ID",
+		client_secret_env: "FACEBOOK_CLIENT_SECRET",
+		fetch_profile: fetchFacebookProfile,
+	},
 };
 
 export const isProvider = (s: string): s is ProviderId =>
-	s === "github" || s === "google";
+	s === "github" || s === "google" || s === "facebook";
 
 const randomState = (): string => {
 	const bytes = new Uint8Array(24);

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -21,7 +21,7 @@
  * read.
  */
 
-export type ProviderId = "github" | "google" | "facebook";
+export type ProviderId = "github" | "google" | "facebook" | "twitter";
 
 export type ProviderProfile = {
 	provider_id: string; // stable per-provider user id (string form)
@@ -137,6 +137,36 @@ const fetchFacebookProfile = async (
 	};
 };
 
+// X/Twitter (API v2). OAuth2 with mandatory PKCE and HTTP Basic token auth.
+// The v2 API exposes no email under these scopes, so email is always null —
+// users sign in with name + avatar only (the schema allows a null email).
+const fetchTwitterProfile = async (
+	token: string,
+): Promise<ProviderProfile> => {
+	const res = await fetch(
+		"https://api.twitter.com/2/users/me?user.fields=profile_image_url",
+		{ headers: { authorization: `Bearer ${token}` } },
+	);
+	if (!res.ok) throw new Error(`twitter me ${res.status}`);
+	const { data } = (await res.json()) as {
+		data?: {
+			id: string;
+			name?: string;
+			username?: string;
+			profile_image_url?: string;
+		};
+	};
+	if (!data?.id) throw new Error("twitter me: no user id");
+	return {
+		provider_id: data.id,
+		email: null,
+		name: data.name?.trim() || data.username || "user",
+		// Default avatar is the 48px "_normal" variant; dropping the suffix
+		// yields the original full-size image.
+		avatar_url: data.profile_image_url?.replace("_normal", "") ?? null,
+	};
+};
+
 export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
 	github: {
 		authorize_url: "https://github.com/login/oauth/authorize",
@@ -162,10 +192,20 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
 		client_secret_env: "FACEBOOK_CLIENT_SECRET",
 		fetch_profile: fetchFacebookProfile,
 	},
+	twitter: {
+		authorize_url: "https://twitter.com/i/oauth2/authorize",
+		token_url: "https://api.twitter.com/2/oauth2/token",
+		scope: "tweet.read users.read",
+		client_id_env: "TWITTER_CLIENT_ID",
+		client_secret_env: "TWITTER_CLIENT_SECRET",
+		pkce: true,
+		token_auth: "basic",
+		fetch_profile: fetchTwitterProfile,
+	},
 };
 
 export const isProvider = (s: string): s is ProviderId =>
-	s === "github" || s === "google" || s === "facebook";
+	s === "github" || s === "google" || s === "facebook" || s === "twitter";
 
 const randomState = (): string => {
 	const bytes = new Uint8Array(24);

--- a/src/routes/api.config.ts
+++ b/src/routes/api.config.ts
@@ -37,9 +37,12 @@ config.get("/", async (c) => {
 	const minutes = Number.parseInt(c.env.EDIT_WINDOW_MINUTES, 10);
 	const edit_window_minutes =
 		Number.isFinite(minutes) && minutes > 0 ? minutes : 5;
+	// Provider client-id/secret env-var names are typed as plain strings on
+	// ProviderConfig, so index the bindings through a string-keyed view.
+	const env = c.env as unknown as Record<string, string | undefined>;
 	const providers = (Object.keys(PROVIDERS) as ProviderId[]).filter((p) => {
 		const cfg = PROVIDERS[p];
-		return !!c.env[cfg.client_id_env] && !!c.env[cfg.client_secret_env];
+		return !!env[cfg.client_id_env] && !!env[cfg.client_secret_env];
 	});
 	// Feature flags + numeric display settings, both resolved with
 	// DB-override > env > default precedence.

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -16,10 +16,12 @@ import {
 	PROVIDERS,
 	buildAuthorizeUrl,
 	callbackUrl,
+	computeCodeChallenge,
 	constantTimeEqual,
 	consumeHandoff,
 	consumeState,
 	exchangeCodeForToken,
+	genCodeVerifier,
 	isProvider,
 	issueHandoff,
 	issueState,
@@ -109,11 +111,20 @@ auth.get("/:provider/start", async (c) => {
 	// browser into completing the callback, planting the attacker's
 	// session on the victim (RFC 6749 §10.12 login-CSRF).
 	const browser_token = randomHex(16);
+	// PKCE: providers that require it (X/Twitter) get a per-flow verifier
+	// stashed server-side in the state payload and an S256 challenge in the
+	// authorize redirect. Non-PKCE providers (GitHub/Google/Facebook/Discord)
+	// skip this entirely.
+	const code_verifier = cfg.pkce ? genCodeVerifier() : undefined;
+	const code_challenge = code_verifier
+		? await computeCodeChallenge(code_verifier)
+		: undefined;
 	const state = await issueState(c.env.OAUTH_STATE, {
 		provider,
 		return_origin,
 		created_at: Date.now(),
 		browser_token,
+		...(code_verifier ? { code_verifier } : {}),
 	});
 
 	c.header(
@@ -128,7 +139,13 @@ auth.get("/:provider/start", async (c) => {
 	);
 
 	const redirect = callbackUrl(c.env, c.req.url, provider);
-	const url = buildAuthorizeUrl(provider, clientId, redirect, state);
+	const url = buildAuthorizeUrl(
+		provider,
+		clientId,
+		redirect,
+		state,
+		code_challenge,
+	);
 	writeEvent(c.env.ANALYTICS, "oauth.start", { provider });
 	return c.redirect(url, 302);
 });
@@ -242,6 +259,7 @@ auth.get("/:provider/callback", async (c) => {
 			clientId,
 			clientSecret,
 			redirect,
+			payload.code_verifier,
 		);
 	} catch (err) {
 		log.error("oauth.token", { provider, error: String(err) });

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1513,13 +1513,14 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 // (no server imports) so the union is duplicated here; PROVIDER_LABELS is the
 // single source of which ids the widget will render, and the /config filter
 // keys off it.
-type OAuthProvider = "github" | "google" | "facebook" | "twitter";
+type OAuthProvider = "github" | "google" | "facebook" | "twitter" | "discord";
 
 const PROVIDER_LABELS: Record<OAuthProvider, string> = {
 	github: "GitHub",
 	google: "Google",
 	facebook: "Facebook",
 	twitter: "X",
+	discord: "Discord",
 };
 
 const buildAuthBlock = (

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1509,15 +1509,22 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	return wrap;
 };
 
-const PROVIDER_LABELS: Record<"github" | "google", string> = {
+// Mirror of src/lib/oauth.ts ProviderId. The widget is bundled separately
+// (no server imports) so the union is duplicated here; PROVIDER_LABELS is the
+// single source of which ids the widget will render, and the /config filter
+// keys off it.
+type OAuthProvider = "github" | "google" | "facebook";
+
+const PROVIDER_LABELS: Record<OAuthProvider, string> = {
 	github: "GitHub",
 	google: "Google",
+	facebook: "Facebook",
 };
 
 const buildAuthBlock = (
 	me: Me,
 	apiBase: string,
-	providers: ReadonlyArray<"github" | "google">,
+	providers: ReadonlyArray<OAuthProvider>,
 	onSignedIn: () => void,
 	onSignedOut: () => void,
 ): HTMLElement | null => {
@@ -1649,7 +1656,7 @@ const buildForm = (
 };
 
 const startOauth = (
-	provider: "github" | "google",
+	provider: OAuthProvider,
 	apiBase: string,
 	onSuccess: () => void,
 ): void => {
@@ -1831,7 +1838,7 @@ const loadOnce = async (
 ) => {
 	let siteKey: string | null = null;
 	let editWindowMinutes = 5;
-	let providers: ReadonlyArray<"github" | "google"> = [];
+	let providers: ReadonlyArray<OAuthProvider> = [];
 	let brandingHidden = false;
 	let commentsEnabled = true;
 	let reactionsEnabled = true;
@@ -1864,8 +1871,8 @@ const loadOnce = async (
 			};
 			siteKey = cfg.turnstile_site_key ?? null;
 			editWindowMinutes = cfg.edit_window_minutes ?? 5;
-			providers = (cfg.providers ?? []).filter(
-				(p): p is "github" | "google" => p === "github" || p === "google",
+			providers = (cfg.providers ?? []).filter((p): p is OAuthProvider =>
+				Object.prototype.hasOwnProperty.call(PROVIDER_LABELS, p),
 			);
 			brandingHidden = cfg.branding_hidden === true;
 			commentsEnabled = cfg.comments_enabled !== false;

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1513,12 +1513,13 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 // (no server imports) so the union is duplicated here; PROVIDER_LABELS is the
 // single source of which ids the widget will render, and the /config filter
 // keys off it.
-type OAuthProvider = "github" | "google" | "facebook";
+type OAuthProvider = "github" | "google" | "facebook" | "twitter";
 
 const PROVIDER_LABELS: Record<OAuthProvider, string> = {
 	github: "GitHub",
 	google: "Google",
 	facebook: "Facebook",
+	twitter: "X",
 };
 
 const buildAuthBlock = (

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1510,9 +1510,11 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 };
 
 // Mirror of src/lib/oauth.ts ProviderId. The widget is bundled separately
-// (no server imports) so the union is duplicated here; PROVIDER_LABELS is the
-// single source of which ids the widget will render, and the /config filter
-// keys off it.
+// (no server imports) so the union is duplicated here. The server's
+// /api/v1/config derives the provider list from PROVIDERS + env presence
+// (see src/routes/api.config.ts); PROVIDER_LABELS is the widget-side set of
+// ids it knows how to render, and the widget filters the /config response
+// against it so an unknown id can never reach the button renderer.
 type OAuthProvider = "github" | "google" | "facebook" | "twitter" | "discord";
 
 const PROVIDER_LABELS: Record<OAuthProvider, string> = {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -10,9 +10,11 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
 	buildAuthorizeUrl,
 	callbackUrl,
+	computeCodeChallenge,
 	constantTimeEqual,
 	consumeHandoff,
 	consumeState,
+	genCodeVerifier,
 	isProvider,
 	issueHandoff,
 	issueState,
@@ -91,6 +93,42 @@ describe("issueState / consumeState", () => {
 		});
 		const got = await consumeState(store, state);
 		expect(got?.browser_token).toBe(tok);
+	});
+
+	it("carries the PKCE code_verifier through KV roundtrip", async () => {
+		const verifier = genCodeVerifier();
+		const state = await issueState(store, {
+			provider: "github",
+			return_origin: "https://x.test",
+			created_at: 3,
+			browser_token: "tok",
+			code_verifier: verifier,
+		});
+		const got = await consumeState(store, state);
+		expect(got?.code_verifier).toBe(verifier);
+	});
+});
+
+describe("PKCE helpers", () => {
+	it("genCodeVerifier produces a 64-hex-char string within RFC 7636 limits", () => {
+		const v = genCodeVerifier();
+		expect(v).toMatch(/^[0-9a-f]{64}$/);
+		expect(v.length).toBeGreaterThanOrEqual(43);
+		expect(v.length).toBeLessThanOrEqual(128);
+		expect(genCodeVerifier()).not.toBe(v);
+	});
+
+	it("computeCodeChallenge matches the RFC 7636 §B test vector", async () => {
+		// Appendix B: verifier → base64url(SHA-256(verifier)) without padding.
+		const challenge = await computeCodeChallenge(
+			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		);
+		expect(challenge).toBe("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+	});
+
+	it("produces base64url output (no +, /, or = padding)", async () => {
+		const challenge = await computeCodeChallenge(genCodeVerifier());
+		expect(challenge).not.toMatch(/[+/=]/);
 	});
 });
 
@@ -208,5 +246,29 @@ describe("buildAuthorizeUrl", () => {
 			buildAuthorizeUrl("google", "id", "https://x.test/cb", "s"),
 		);
 		expect(url.searchParams.get("prompt")).toBe("select_account");
+	});
+
+	it("omits PKCE params when no code_challenge is passed", () => {
+		const url = new URL(
+			buildAuthorizeUrl("github", "id", "https://x.test/cb", "s"),
+		);
+		expect(url.searchParams.get("code_challenge")).toBeNull();
+		expect(url.searchParams.get("code_challenge_method")).toBeNull();
+	});
+
+	it("adds S256 code_challenge when one is passed", () => {
+		const url = new URL(
+			buildAuthorizeUrl(
+				"github",
+				"id",
+				"https://x.test/cb",
+				"s",
+				"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			),
+		);
+		expect(url.searchParams.get("code_challenge")).toBe(
+			"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		);
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
 	});
 });

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -38,10 +38,11 @@ class StubKV {
 const kv = () => new StubKV() as unknown as KVNamespace;
 
 describe("isProvider", () => {
-	it("accepts github and google only", () => {
+	it("accepts known providers and rejects others", () => {
 		expect(isProvider("github")).toBe(true);
 		expect(isProvider("google")).toBe(true);
-		expect(isProvider("twitter")).toBe(false);
+		expect(isProvider("facebook")).toBe(true);
+		expect(isProvider("myspace")).toBe(false);
 		expect(isProvider("")).toBe(false);
 	});
 });

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -6,7 +6,7 @@
  * boundary in fetch_profile / exchangeCodeForToken. Those callers are
  * exercised by integration tests once wrangler-dev is wired in.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
 	buildAuthorizeUrl,
 	callbackUrl,
@@ -14,6 +14,7 @@ import {
 	constantTimeEqual,
 	consumeHandoff,
 	consumeState,
+	exchangeCodeForToken,
 	genCodeVerifier,
 	isProvider,
 	issueHandoff,
@@ -42,6 +43,7 @@ describe("isProvider", () => {
 		expect(isProvider("github")).toBe(true);
 		expect(isProvider("google")).toBe(true);
 		expect(isProvider("facebook")).toBe(true);
+		expect(isProvider("twitter")).toBe(true);
 		expect(isProvider("myspace")).toBe(false);
 		expect(isProvider("")).toBe(false);
 	});
@@ -271,5 +273,60 @@ describe("buildAuthorizeUrl", () => {
 			"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 		);
 		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+	});
+});
+
+describe("exchangeCodeForToken", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	const stubFetch = () => {
+		const calls: { url: string; init: RequestInit }[] = [];
+		vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+			calls.push({ url, init });
+			return new Response(JSON.stringify({ access_token: "tok-123" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		return calls;
+	};
+
+	it("uses HTTP Basic auth + code_verifier and omits client_secret from the body for token_auth:basic (twitter)", async () => {
+		const calls = stubFetch();
+		const token = await exchangeCodeForToken(
+			"twitter",
+			"the-code",
+			"cid",
+			"csecret",
+			"https://x.test/cb",
+			"the-verifier",
+		);
+		expect(token).toBe("tok-123");
+		expect(calls[0].url).toBe(PROVIDERS.twitter.token_url);
+		const headers = calls[0].init.headers as Record<string, string>;
+		expect(headers.authorization).toBe(`Basic ${btoa("cid:csecret")}`);
+		const body = (calls[0].init.body as URLSearchParams).toString();
+		expect(body).toContain("code_verifier=the-verifier");
+		// The secret must never appear in the body when using Basic auth.
+		expect(body).not.toContain("csecret");
+		expect(body).not.toContain("client_secret");
+	});
+
+	it("puts client_secret in the body and sends no auth header for token_auth:body (github)", async () => {
+		const calls = stubFetch();
+		await exchangeCodeForToken(
+			"github",
+			"the-code",
+			"id",
+			"sec",
+			"https://x.test/cb",
+		);
+		const headers = calls[0].init.headers as Record<string, string>;
+		expect(headers.authorization).toBeUndefined();
+		const body = (calls[0].init.body as URLSearchParams).toString();
+		expect(body).toContain("client_secret=sec");
+		expect(body).not.toContain("code_verifier");
 	});
 });

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -44,6 +44,7 @@ describe("isProvider", () => {
 		expect(isProvider("google")).toBe(true);
 		expect(isProvider("facebook")).toBe(true);
 		expect(isProvider("twitter")).toBe(true);
+		expect(isProvider("discord")).toBe(true);
 		expect(isProvider("myspace")).toBe(false);
 		expect(isProvider("")).toBe(false);
 	});

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -99,6 +99,8 @@ crons = ["*/15 * * * *"]
 #   wrangler secret put FACEBOOK_CLIENT_SECRET
 #   wrangler secret put TWITTER_CLIENT_ID       # optional, X/Twitter OAuth 2.0 from developer.x.com
 #   wrangler secret put TWITTER_CLIENT_SECRET
+#   wrangler secret put DISCORD_CLIENT_ID       # optional, from discord.com/developers → OAuth2
+#   wrangler secret put DISCORD_CLIENT_SECRET
 #   wrangler secret put RESEND_API_KEY
 #   wrangler secret put WEBHOOK_URL           # legacy single-URL webhook; prefer /admin/webhooks endpoints
 #   wrangler secret put CF_API_TOKEN          # optional, Analytics-read token for /admin/usage (with CF_ACCOUNT_ID var)

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -97,6 +97,8 @@ crons = ["*/15 * * * *"]
 #   wrangler secret put GOOGLE_CLIENT_SECRET
 #   wrangler secret put FACEBOOK_CLIENT_ID      # optional, from developers.facebook.com
 #   wrangler secret put FACEBOOK_CLIENT_SECRET
+#   wrangler secret put TWITTER_CLIENT_ID       # optional, X/Twitter OAuth 2.0 from developer.x.com
+#   wrangler secret put TWITTER_CLIENT_SECRET
 #   wrangler secret put RESEND_API_KEY
 #   wrangler secret put WEBHOOK_URL           # legacy single-URL webhook; prefer /admin/webhooks endpoints
 #   wrangler secret put CF_API_TOKEN          # optional, Analytics-read token for /admin/usage (with CF_ACCOUNT_ID var)

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -95,6 +95,8 @@ crons = ["*/15 * * * *"]
 #   wrangler secret put GH_CLIENT_SECRET
 #   wrangler secret put GOOGLE_CLIENT_ID
 #   wrangler secret put GOOGLE_CLIENT_SECRET
+#   wrangler secret put FACEBOOK_CLIENT_ID      # optional, from developers.facebook.com
+#   wrangler secret put FACEBOOK_CLIENT_SECRET
 #   wrangler secret put RESEND_API_KEY
 #   wrangler secret put WEBHOOK_URL           # legacy single-URL webhook; prefer /admin/webhooks endpoints
 #   wrangler secret put CF_API_TOKEN          # optional, Analytics-read token for /admin/usage (with CF_ACCOUNT_ID var)


### PR DESCRIPTION
Closes #28.

Adds three social-login providers — **Facebook, X (Twitter), and Discord** — on top of the existing GitHub + Google flow, and generalizes the shared OAuth2 helpers to support **PKCE** (which X mandates).

## What changed
- **PKCE infrastructure** (`feat(oauth): add PKCE support…`): `genCodeVerifier`/`computeCodeChallenge` (S256, base64url), optional `pkce` + `token_auth` on `ProviderConfig`, verifier carried server-side in the KV `StatePayload` (never sent to the browser), and Basic-auth token exchange. GitHub/Google behavior is unchanged.
- **Facebook** — standard auth-code; email via Graph `/me` (Graph returns only confirmed emails).
- **X / Twitter** — OAuth 2.0 with PKCE + HTTP Basic token auth. The v2 API returns **no email**, so X sign-in carries name + avatar only. Stored provider id is `twitter`; the button label is **X**.
- **Discord** — standard auth-code; email trusted only when Discord flags it `verified` (mirrors GitHub).
- Config templates (`.dev.vars.example`, `wrangler.example.toml`), `Bindings`, `setup.sh` prompts, admin settings rows, and the widget provider list/labels.
- Docs: README/AGENTS provider lists, troubleshooting (per-provider callback paths, the X-has-no-email + `ADMIN_EMAILS` caveat), privacy/TOS templates, and **why Instagram is intentionally excluded** (Meta shut down the Basic Display API in Dec 2024).

## Operator notes
- A provider's button appears only when **both** its `*_CLIENT_ID` and `*_CLIENT_SECRET` are set — no DB migration required (`users` already keys on `(provider, provider_id)` with a nullable email).
- Register each provider's redirect URI as `${OAUTH_CALLBACK_BASE}/api/v1/auth/<provider>/callback` (X = `/twitter`).
- X accounts can't be auto-promoted via `ADMIN_EMAILS` (no email); promote from the admin Users page.

## Testing
- `npm test` — 549 pass, incl. new PKCE (RFC 7636 §B vector) and Basic-auth token-exchange tests (asserts the secret never lands in the body).
- `npm run typecheck` clean; `npm run size` — embed.js 10.45 KB gzipped (≤ 20 KB budget).
- Security review of the diff: no exploitable findings (PKCE correct, CSRF/login-CSRF intact, secrets not logged, avatar set via DOM `.src`/escaped — no XSS sink, fetcher URLs hardcoded).
- Not run: the live popup round-trip against real provider apps (requires registered apps + secrets) — manual operator step.
