### PR TITLE
fix(auth): revoke KV session record on signout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,8 +420,8 @@ to work in Chrome's 3PC phase-out and Safari ITP — don't strip it.
 
 **Endpoints integrators may call client-side**: `GET /api/v1/auth/me`
 returns the current session user (or `{user:null}`); `POST
-/api/v1/auth/signout` clears the cookie. Both go through the same
-session middleware as the comment routes.
+/api/v1/auth/signout` revokes the KV session and clears the cookie. Both
+go through the same session middleware as the comment routes.
 
 ## 8. Anonymous comments
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,9 +172,12 @@ so plain HTTP works.
 
 ### Sign-out doesn't actually sign me out
 
-`POST /api/v1/auth/signout` clears the cookie. If the session row in
-KV still exists (you cleared the cookie out-of-band, by editing
-DevTools), the KV row will TTL out in 30 days.
+`POST /api/v1/auth/signout` revokes the session server-side — it deletes
+the `sess:<id>` row from KV and then expires the cookie — so a retained
+copy of the cookie is inert immediately. If you instead clear the cookie
+out-of-band (e.g. via DevTools) without hitting `/signout`, the KV row
+lingers until its TTL expires (≤30 days); call `/signout` to revoke it
+now.
 
 ## Email digests
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -7,8 +7,8 @@
  *    Safari ITP / Chrome 3PC-deprecation don't evict it)
  * - Dev fallback (ENV=dev): SameSite=Lax + no Secure, so plain HTTP
  *   wrangler dev works without HTTPS
- * - 30-day TTL in KV; refreshed on every use so an active user keeps
- *   their session forever
+ * - 30-day TTL in KV; slid forward (at most once a day) while the user is
+ *   active so an active user keeps their session forever
  *
  * The cookie value IS the session id. The KV value is the user_id +
  * expiry. To revoke a session, delete the KV entry; the cookie becomes
@@ -29,6 +29,17 @@ type SessionCtx = {
 
 const COOKIE_NAME = "garrul_sess";
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+// Slide the TTL at most once a day rather than on every read: a KV write per
+// authenticated request would burn the (account-wide) write quota, and the
+// rarer the refresh the smaller the window in which a concurrent refresh could
+// resurrect a session that signout just deleted.
+const SESSION_REFRESH_SECONDS = 24 * 60 * 60;
+// Session ids are exactly 64 lowercase hex chars (32 random bytes). Reject
+// anything else before it reaches a KV op — an oversized cookie would blow the
+// 512-byte KV key limit and throw, turning every request (and signout) into a
+// 500 the user can't recover from.
+const SESSION_ID_RE = /^[0-9a-f]{64}$/;
+const sessionKey = (sid: string): string => `sess:${sid}`;
 
 type SessionRecord = {
 	user_id: string;
@@ -55,13 +66,18 @@ export const parseCookie = (
 		const eq = part.indexOf("=");
 		if (eq < 0) continue;
 		if (part.slice(0, eq).trim() === name) {
+			const raw = part.slice(eq + 1).trim();
+			// An empty value can't be a real session; keep scanning so a later
+			// same-name cookie (e.g. one tossed in at a broader scope) can't
+			// shadow the valid one and make us skip revocation.
+			if (!raw) continue;
 			// Malformed percent-encoding (e.g. `%E0%A4%A`) makes
-			// decodeURIComponent throw; treat it as "no cookie" rather than
-			// letting a garbage Cookie header 500 every request.
+			// decodeURIComponent throw; treat it as a non-match and keep
+			// scanning rather than letting a garbage cookie 500 the request.
 			try {
-				return decodeURIComponent(part.slice(eq + 1).trim());
+				return decodeURIComponent(raw);
 			} catch {
-				return null;
+				continue;
 			}
 		}
 	}
@@ -129,7 +145,7 @@ export const issueSession = async (
 		user_id: userId,
 		expires_at: Date.now() + SESSION_TTL_SECONDS * 1000,
 	};
-	await c.env.SESSIONS.put(`sess:${sid}`, JSON.stringify(record), {
+	await c.env.SESSIONS.put(sessionKey(sid), JSON.stringify(record), {
 		expirationTtl: SESSION_TTL_SECONDS,
 	});
 	c.header("Set-Cookie", buildSetCookie(sid, SESSION_TTL_SECONDS, c.env), {
@@ -138,9 +154,21 @@ export const issueSession = async (
 	return sid;
 };
 
-export const destroySession = async (c: SessionCtx): Promise<void> => {
+/**
+ * Delete the KV record for the session named by the request cookie, if any,
+ * without touching the cookie itself. Used both by signout (which then expires
+ * the cookie) and by re-login (which is about to overwrite it) so a fresh
+ * session never orphans a still-replayable record.
+ */
+export const revokeSession = async (c: SessionCtx): Promise<void> => {
 	const sid = parseCookie(c.req.header("cookie"), COOKIE_NAME);
-	if (sid) await c.env.SESSIONS.delete(`sess:${sid}`);
+	if (sid && SESSION_ID_RE.test(sid)) {
+		await c.env.SESSIONS.delete(sessionKey(sid));
+	}
+};
+
+export const destroySession = async (c: SessionCtx): Promise<void> => {
+	await revokeSession(c);
 	c.header("Set-Cookie", buildSetCookie("", 0, c.env), { append: true });
 };
 
@@ -148,25 +176,30 @@ export const readSession = async (
 	c: SessionCtx,
 ): Promise<{ sid: string; user_id: string } | null> => {
 	const sid = parseCookie(c.req.header("cookie"), COOKIE_NAME);
-	if (!sid) return null;
-	const raw = await c.env.SESSIONS.get(`sess:${sid}`);
+	if (!sid || !SESSION_ID_RE.test(sid)) return null;
+	const raw = await c.env.SESSIONS.get(sessionKey(sid));
 	if (!raw) return null;
 	let record: SessionRecord;
 	try {
 		record = JSON.parse(raw) as SessionRecord;
 	} catch {
-		await c.env.SESSIONS.delete(`sess:${sid}`);
+		await c.env.SESSIONS.delete(sessionKey(sid));
 		return null;
 	}
-	if (record.expires_at < Date.now()) {
-		await c.env.SESSIONS.delete(`sess:${sid}`);
+	const now = Date.now();
+	if (record.expires_at < now) {
+		await c.env.SESSIONS.delete(sessionKey(sid));
 		return null;
 	}
-	// Sliding TTL: extend on every use.
-	record.expires_at = Date.now() + SESSION_TTL_SECONDS * 1000;
-	await c.env.SESSIONS.put(`sess:${sid}`, JSON.stringify(record), {
-		expirationTtl: SESSION_TTL_SECONDS,
-	});
+	// Sliding TTL, but only re-write once the record has aged past the refresh
+	// interval — avoids a KV write on every authenticated request.
+	const ageSeconds = SESSION_TTL_SECONDS - (record.expires_at - now) / 1000;
+	if (ageSeconds >= SESSION_REFRESH_SECONDS) {
+		record.expires_at = now + SESSION_TTL_SECONDS * 1000;
+		await c.env.SESSIONS.put(sessionKey(sid), JSON.stringify(record), {
+			expirationTtl: SESSION_TTL_SECONDS,
+		});
+	}
 	return { sid, user_id: record.user_id };
 };
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -12,7 +12,9 @@
  *
  * The cookie value IS the session id. The KV value is the user_id +
  * expiry. To revoke a session, delete the KV entry; the cookie becomes
- * inert immediately.
+ * inert immediately. Signout goes through destroySession, which does
+ * exactly that before expiring the cookie — clearing the cookie alone
+ * would leave the server-side record replayable for its full TTL.
  */
 import type { MiddlewareHandler } from "hono";
 
@@ -129,7 +131,9 @@ export const issueSession = async (
 	return sid;
 };
 
-export const clearSession = (c: SessionCtx): void => {
+export const destroySession = async (c: SessionCtx): Promise<void> => {
+	const sid = parseCookie(c.req.header("cookie"), COOKIE_NAME);
+	if (sid) await c.env.SESSIONS.delete(`sess:${sid}`);
 	c.header("Set-Cookie", buildSetCookie("", 0, c.env), { append: true });
 };
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -55,7 +55,14 @@ export const parseCookie = (
 		const eq = part.indexOf("=");
 		if (eq < 0) continue;
 		if (part.slice(0, eq).trim() === name) {
-			return decodeURIComponent(part.slice(eq + 1).trim());
+			// Malformed percent-encoding (e.g. `%E0%A4%A`) makes
+			// decodeURIComponent throw; treat it as "no cookie" rather than
+			// letting a garbage Cookie header 500 every request.
+			try {
+				return decodeURIComponent(part.slice(eq + 1).trim());
+			} catch {
+				return null;
+			}
 		}
 	}
 	return null;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,7 +1,7 @@
 /**
  * /api/v1/auth/:provider/start    302 → provider authorize URL
  * /api/v1/auth/:provider/callback exchange code, upsert user, issue session
- * POST /api/v1/auth/signout       clear session cookie
+ * POST /api/v1/auth/signout       revoke KV session + clear cookie
  * GET  /api/v1/auth/me            current session user (or null)
  *
  * The callback returns a tiny self-closing HTML page that postMessages
@@ -30,8 +30,8 @@ import {
 import { upsertOauthUser } from "../db/queries";
 import {
 	buildShortCookie,
-	clearSession,
 	clearShortCookie,
+	destroySession,
 	issueSession,
 	parseCookie,
 	readSession,
@@ -304,7 +304,7 @@ auth.get("/:provider/callback", async (c) => {
 });
 
 auth.post("/signout", async (c) => {
-	clearSession(c);
+	await destroySession(c);
 	return c.json({ ok: true });
 });
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -35,6 +35,7 @@ import {
 	issueSession,
 	parseCookie,
 	readSession,
+	revokeSession,
 } from "../lib/session";
 import { writeEvent } from "../lib/analytics";
 import { log } from "../lib/log";
@@ -291,6 +292,10 @@ auth.get("/:provider/callback", async (c) => {
 		return c.html(finishHtml(payload.return_origin, false, "banned"));
 	}
 
+	// Revoke any session the browser already holds before minting a new one,
+	// so re-login (a common "I might be compromised" remediation) doesn't leave
+	// the previous sid live and replayable in KV for its full TTL.
+	await revokeSession(c);
 	await issueSession(c, user.id);
 	// Same user_id is also reachable via the handoff token below. The popup
 	// Set-Cookie above is what works on same-eTLD+1 embeds; the handoff is

--- a/tests/admin-settings.test.ts
+++ b/tests/admin-settings.test.ts
@@ -24,7 +24,9 @@ import { Hono } from "hono";
 import { admin } from "../src/routes/admin";
 import type { Bindings } from "../src/index";
 
-const SID = "testsessionid";
+// Real session ids are 64 lowercase hex chars (see newSessionId); readSession
+// rejects anything else before the KV lookup, so the fixture must match.
+const SID = "a".repeat(64);
 const ADMIN_ID = "01HADMIN0000000000000000AB";
 
 // D1 double: serves the admin user for the auth gate and captures every

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -98,6 +98,19 @@ describe("session cookie roundtrip", () => {
 		expect(await readSession(ctx)).toBeNull();
 	});
 
+	it("malformed percent-encoding in the cookie is treated as no session", async () => {
+		const { ctx } = makeCtx({
+			cookieHeader: "garrul_sess=%E0%A4%A",
+		});
+		expect(await readSession(ctx)).toBeNull();
+		// destroySession must not throw either — it still expires the cookie.
+		const { ctx: destroyCtx, setCookies } = makeCtx({
+			cookieHeader: "garrul_sess=%E0%A4%A",
+		});
+		await destroySession(destroyCtx);
+		expect(setCookies[0]).toMatch(/Max-Age=0/);
+	});
+
 	it("readSession returns null for an unknown cookie value", async () => {
 		const { ctx } = makeCtx({
 			cookieHeader: "garrul_sess=deadbeef".padEnd(72, "0"),

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -12,6 +12,7 @@ import {
 	destroySession,
 	issueSession,
 	readSession,
+	revokeSession,
 } from "../src/lib/session";
 
 class StubKV {
@@ -99,15 +100,35 @@ describe("session cookie roundtrip", () => {
 	});
 
 	it("malformed percent-encoding in the cookie is treated as no session", async () => {
-		const { ctx } = makeCtx({
+		const { ctx, setCookies } = makeCtx({
 			cookieHeader: "garrul_sess=%E0%A4%A",
 		});
 		expect(await readSession(ctx)).toBeNull();
 		// destroySession must not throw either — it still expires the cookie.
-		const { ctx: destroyCtx, setCookies } = makeCtx({
-			cookieHeader: "garrul_sess=%E0%A4%A",
+		await destroySession(ctx);
+		expect(setCookies[0]).toMatch(/Max-Age=0/);
+	});
+
+	it("a malformed cookie cannot shadow a valid same-name cookie", async () => {
+		const { ctx: issueCtx, kv, setCookies } = makeCtx({});
+		await issueSession(issueCtx, userId);
+		const sidValue = extractCookieValue(setCookies[0]!);
+
+		// A garbage first occurrence must not stop us reaching the real sid.
+		const { ctx } = makeCtxWithSameKv(kv, {
+			cookieHeader: `garrul_sess=%E0%A4%A; garrul_sess=${sidValue}`,
 		});
-		await destroySession(destroyCtx);
+		await destroySession(ctx);
+		expect(kv.store.has(`sess:${sidValue}`)).toBe(false);
+	});
+
+	it("an oversized cookie value does not throw on signout", async () => {
+		// >512-byte KV keys throw; a too-long sid must be rejected before the
+		// delete so a corrupted cookie can't make signout un-completable.
+		const { ctx, setCookies } = makeCtx({
+			cookieHeader: `garrul_sess=${"a".repeat(600)}`,
+		});
+		await destroySession(ctx);
 		expect(setCookies[0]).toMatch(/Max-Age=0/);
 	});
 
@@ -142,6 +163,63 @@ describe("session cookie roundtrip", () => {
 			cookieHeader: `garrul_sess=${sidValue}`,
 		});
 		expect(await readSession(replayCtx)).toBeNull();
+	});
+
+	it("revokeSession deletes the KV record without touching the cookie", async () => {
+		const { ctx: issueCtx, kv, setCookies } = makeCtx({});
+		await issueSession(issueCtx, userId);
+		const sidValue = extractCookieValue(setCookies[0]!);
+
+		const { ctx, setCookies: revokeCookies } = makeCtxWithSameKv(kv, {
+			cookieHeader: `garrul_sess=${sidValue}`,
+		});
+		await revokeSession(ctx);
+		expect(kv.store.has(`sess:${sidValue}`)).toBe(false);
+		// Unlike destroySession, revoke leaves the cookie alone — re-login
+		// overwrites it with a fresh Set-Cookie immediately after.
+		expect(revokeCookies).toHaveLength(0);
+	});
+
+	it("does not re-write the KV record on an immediate re-read", async () => {
+		const { ctx: issueCtx, kv, setCookies } = makeCtx({});
+		await issueSession(issueCtx, userId);
+		const sidValue = extractCookieValue(setCookies[0]!);
+		const before = kv.store.get(`sess:${sidValue}`)!.value;
+
+		const { ctx } = makeCtxWithSameKv(kv, {
+			cookieHeader: `garrul_sess=${sidValue}`,
+		});
+		expect((await readSession(ctx))?.user_id).toBe(userId);
+		// Fresh record is well within the refresh interval → no wasted KV write.
+		expect(kv.store.get(`sess:${sidValue}`)!.value).toBe(before);
+	});
+
+	it("slides the TTL once the record has aged past the refresh interval", async () => {
+		const { ctx: issueCtx, kv, setCookies } = makeCtx({});
+		await issueSession(issueCtx, userId);
+		const sidValue = extractCookieValue(setCookies[0]!);
+		const key = `sess:${sidValue}`;
+		const row = kv.store.get(key)!;
+		// Age the record two days (expires_at two days closer than a fresh one).
+		kv.store.set(key, {
+			value: JSON.stringify({
+				user_id: userId,
+				expires_at: Date.now() + (30 - 2) * 24 * 60 * 60 * 1000,
+			}),
+			expiresAt: row.expiresAt,
+		});
+
+		const { ctx } = makeCtxWithSameKv(kv, {
+			cookieHeader: `garrul_sess=${sidValue}`,
+		});
+		expect((await readSession(ctx))?.user_id).toBe(userId);
+		const refreshed = JSON.parse(kv.store.get(key)!.value) as {
+			expires_at: number;
+		};
+		// Aged record → refreshed back toward a full 30-day expiry.
+		expect(refreshed.expires_at).toBeGreaterThan(
+			Date.now() + (30 - 1) * 24 * 60 * 60 * 1000,
+		);
 	});
 
 	it("expired session record is purged on read", async () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import {
-	clearSession,
+	destroySession,
 	issueSession,
 	readSession,
 } from "../src/lib/session";
@@ -105,11 +105,30 @@ describe("session cookie roundtrip", () => {
 		expect(await readSession(ctx)).toBeNull();
 	});
 
-	it("clearSession emits an expiring Set-Cookie", async () => {
+	it("destroySession emits an expiring Set-Cookie", async () => {
 		const { ctx, setCookies } = makeCtx({});
-		clearSession(ctx);
+		await destroySession(ctx);
 		expect(setCookies).toHaveLength(1);
 		expect(setCookies[0]).toMatch(/Max-Age=0/);
+	});
+
+	it("destroySession deletes the KV record so the sid cannot be replayed", async () => {
+		const { ctx: issueCtx, kv, setCookies } = makeCtx({});
+		await issueSession(issueCtx, userId);
+		const sidValue = extractCookieValue(setCookies[0]!);
+		expect(kv.store.has(`sess:${sidValue}`)).toBe(true);
+
+		const { ctx: signoutCtx } = makeCtxWithSameKv(kv, {
+			cookieHeader: `garrul_sess=${sidValue}`,
+		});
+		await destroySession(signoutCtx);
+		expect(kv.store.has(`sess:${sidValue}`)).toBe(false);
+
+		// A retained copy of the cookie is now inert server-side.
+		const { ctx: replayCtx } = makeCtxWithSameKv(kv, {
+			cookieHeader: `garrul_sess=${sidValue}`,
+		});
+		expect(await readSession(replayCtx)).toBeNull();
 	});
 
 	it("expired session record is purged on read", async () => {


### PR DESCRIPTION
## Summary

Security fix from a full-codebase audit (CWE-613, session termination failure — Medium).

`POST /api/v1/auth/signout` called `clearSession`, which only emitted an expiring `Set-Cookie` and never touched KV. The `sess:<sid>` record stayed valid — and the sliding 30-day TTL in `readSession` means an actively replayed session ID stayed valid **indefinitely**. Anyone retaining the cookie value (shared machine, prior capture) remained authenticated after the user signed out, and the user had no way to kill a leaked session. The module's own doc comment named KV deletion as the revocation mechanism, but no code path performed it.

## Changes

- `src/lib/session.ts`: replace `clearSession` with async `destroySession` — parses the sid from the request cookie, deletes `sess:<sid>` from KV, then expires the cookie. (Only one call site existed.)
- `src/routes/auth.ts`: signout handler now `await destroySession(c)`.
- `tests/session.test.ts`: new test covering issue → signout → KV record gone → replayed cookie reads as no session.

## Security notes

`destroySession` can only delete `sess:<value-the-caller-already-holds>` under the `sess:` prefix, so there is no cross-session deletion or KV key-injection surface.

## Testing

- `npm test` — 558/558 pass
- `npm run typecheck` — clean (worker + widget tsconfigs)