### PR TITLE
feat(comments): moderation-queue feedback + deleted-comment placeholders

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -115,6 +115,7 @@ Three configuration surfaces:
 | `DOWNVOTES_ENABLED` | var | Downvote button. Same defaults-on semantics. Applies to **both** comment votes and page votes (a brigading-mitigation switch); independent of `VOTING_ENABLED`. | `true` | `wrangler.toml` |
 | `PAGE_REACTIONS_ENABLED` | var | Article-level emoji reaction bar (react to the page itself, no comment). Defaults **off** so an upgrade never surfaces new UI unasked. Enables `POST /api/v1/page-engagement/reactions` and the widget bar. | `false` | `wrangler.toml` |
 | `PAGE_VOTES_ENABLED` | var | Article-level "was this helpful?" up/down vote tally. Defaults **off**. Enables `POST /api/v1/page-engagement/votes`; downvotes here still honor `DOWNVOTES_ENABLED`. | `false` | `wrangler.toml` |
+| `SHOW_DELETED_PLACEHOLDERS` | var | Keep deleted comments in the public tree as a placeholder (`[deleted]` / `[removed by a moderator]`) instead of pruning leaf deletions. Defaults **off** (current behavior: a deleted comment with live replies is still kept for thread continuity; a deleted leaf is dropped). Added v1.15.0. | `false` | `wrangler.toml` |
 | `COMMENTS_PER_PAGE` | var | Top-level comments shown per initial load and per "Load older comments" click (server-side slice in `api.comments.ts`). Defaults **25**; clamped to `[1, 200]`. **Behavior change in v1.11.0:** older installs rendered up to 100 at once — set this to `100` to restore that. | `25` | `wrangler.toml` |
 | `REPLIES_PER_THREAD` | var | Replies shown under each comment before a "Show N more replies" button (widget). `0` = show all. Defaults **3**; clamped to `[0, 100]`. | `3` | `wrangler.toml` |
 | `AUTO_COLLAPSE_DEPTH` | var | Replies nested at this depth or deeper start collapsed in the widget. `0` = never auto-collapse. Defaults **3**; clamped to `[0, 4]` (the tree depth cap). | `3` | `wrangler.toml` |
@@ -127,9 +128,9 @@ hand once a deploy has used them.
 
 ### Feature flags: runtime overrides (since v1.10.0)
 
-The six feature flags — `COMMENTS_ENABLED`, `REACTIONS_ENABLED`,
+The seven feature flags — `COMMENTS_ENABLED`, `REACTIONS_ENABLED`,
 `VOTING_ENABLED`, `DOWNVOTES_ENABLED`, `PAGE_REACTIONS_ENABLED`,
-`PAGE_VOTES_ENABLED` — are **hybrid config**. The env vars above are only
+`PAGE_VOTES_ENABLED`, `SHOW_DELETED_PLACEHOLDERS` — are **hybrid config**. The env vars above are only
 the *defaults*. Each flag is resolved with the precedence:
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,10 +440,12 @@ is on by default. From the end-user perspective:
 4. If the operator has enabled any **optional anti-spam layers**
    (timing honeypot, link-count threshold, first-comment moderation,
    Akismet, or Cloudflare Workers AI), a flagged comment is created
-   with `status='pending'` instead of `approved`. The widget surfaces
-   an "awaiting moderation" notice and the comment is hidden from the
-   public tree until an admin approves it from `/admin/queue`. None of
-   these layers are on by default; see `docs/ANTISPAM.md`.
+   with `status='pending'` instead of `approved`. A signed-in author
+   still sees their own pending comment inline with a **"Pending
+   approval"** badge (the list endpoint returns the viewer's own pending
+   rows, scoped to their session); it stays hidden from everyone else
+   until an admin approves it from `/admin/queue`. None of these layers
+   are on by default; see `docs/ANTISPAM.md`.
 
 Anonymous authors have **no email**, so they're never accidentally
 notified on reply threads. They also have no provider avatar; instead

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "1.14.3",
+      "version": "1.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.3",
+  "version": "1.15.0",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 1,
@@ -162,6 +162,11 @@
       "addedIn": "1.10.0"
     },
     {
+      "name": "SHOW_DELETED_PLACEHOLDERS",
+      "required": false,
+      "addedIn": "1.15.0"
+    },
+    {
       "name": "COMMENTS_PER_PAGE",
       "required": false,
       "addedIn": "1.10.0"
@@ -226,7 +231,8 @@
     "0008_saved_replies.sql",
     "0009_import_tracking.sql",
     "0010_settings.sql",
-    "0011_page_engagement.sql"
+    "0011_page_engagement.sql",
+    "0012_deleted_by.sql"
   ],
   "breakingChanges": []
 }

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -50,6 +50,11 @@ const FLAG_META: { key: FlagKey; label: string; help: string }[] = [
 		label: "Page vote",
 		help: "A simple helpful/up vote tally on the article itself.",
 	},
+	{
+		key: "show_deleted_placeholders",
+		label: "Show deleted-comment placeholders",
+		help: "Keep removed comments in the thread as a placeholder (\"[deleted]\" / \"[removed by a moderator]\") instead of dropping them. Replies are preserved either way.",
+	},
 ];
 
 // Operator-facing labels + help for each numeric display setting. Bounds are

--- a/src/db/migrations/0012_deleted_by.sql
+++ b/src/db/migrations/0012_deleted_by.sql
@@ -7,7 +7,10 @@
 -- or 'moderator' (the moderation queue action). Restoring a comment clears
 -- it back to NULL alongside deleted_at. Values are 'author' | 'moderator'.
 --
--- Rendering of the placeholder is gated by the show_deleted_placeholders
--- flag (see src/lib/settings.ts); this column only supplies the attribution.
+-- This column only supplies the attribution text. Whether a deleted comment
+-- appears as a placeholder at all depends on the tree: a deleted comment with
+-- live descendants is always kept (for thread continuity), while a deleted
+-- leaf is pruned unless the show_deleted_placeholders flag is on
+-- (see src/lib/settings.ts and keepableSet in src/lib/tree.ts).
 
 ALTER TABLE comments ADD COLUMN deleted_by TEXT;

--- a/src/db/migrations/0012_deleted_by.sql
+++ b/src/db/migrations/0012_deleted_by.sql
@@ -1,0 +1,13 @@
+-- Record WHO removed a deleted comment, so the public placeholder can
+-- distinguish a self-delete from a moderator removal.
+--
+-- Nullable, no default: NULL means "not deleted" (or a pre-existing
+-- deletion from before this migration). On transition to status='deleted'
+-- the query layer sets 'author' (self/own-thread delete via the public API)
+-- or 'moderator' (the moderation queue action). Restoring a comment clears
+-- it back to NULL alongside deleted_at. Values are 'author' | 'moderator'.
+--
+-- Rendering of the placeholder is gated by the show_deleted_placeholders
+-- flag (see src/lib/settings.ts); this column only supplies the attribution.
+
+ALTER TABLE comments ADD COLUMN deleted_by TEXT;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -283,7 +283,7 @@ export const insertComment = async (
 			   id, post_slug, parent_id, user_id, body_md, body_html,
 			   renderer_version, status, edited_at, deleted_at, deleted_by,
 			   ip_hash, user_agent, created_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)`,
 		)
 		.bind(
 			id,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -59,6 +59,9 @@ export type Comment = {
 	status: CommentStatus;
 	edited_at: number | null;
 	deleted_at: number | null;
+	/** Who removed a deleted comment: 'author' (self/own-thread delete) or
+	 *  'moderator' (moderation queue). NULL when not deleted. */
+	deleted_by: "author" | "moderator" | null;
 	ip_hash: string | null;
 	user_agent: string | null;
 	created_at: number;
@@ -278,7 +281,7 @@ export const insertComment = async (
 		.prepare(
 			`INSERT INTO comments (
 			   id, post_slug, parent_id, user_id, body_md, body_html,
-			   renderer_version, status, edited_at, deleted_at,
+			   renderer_version, status, edited_at, deleted_at, deleted_by,
 			   ip_hash, user_agent, created_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
 		)
@@ -307,6 +310,7 @@ export const insertComment = async (
 		status,
 		edited_at: null,
 		deleted_at: null,
+		deleted_by: null,
 		ip_hash: input.ip_hash,
 		user_agent: input.user_agent,
 		created_at: now,
@@ -322,7 +326,7 @@ export const getComment = async (
 	return await db
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
-			        renderer_version, status, edited_at, deleted_at,
+			        renderer_version, status, edited_at, deleted_at, deleted_by,
 			        ip_hash, user_agent, created_at, score_up, score_down
 			 FROM comments WHERE id = ?`,
 		)
@@ -343,7 +347,7 @@ export const getCommentsByIds = async (
 	const result = await db
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
-			        renderer_version, status, edited_at, deleted_at,
+			        renderer_version, status, edited_at, deleted_at, deleted_by,
 			        ip_hash, user_agent, created_at, score_up, score_down
 			   FROM comments WHERE id IN (${placeholders})`,
 		)
@@ -390,7 +394,7 @@ export const listCommentsForPost = async (
 	const result = await db
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
-			        renderer_version, status, edited_at, deleted_at,
+			        renderer_version, status, edited_at, deleted_at, deleted_by,
 			        ip_hash, user_agent, created_at, score_up, score_down
 			 FROM comments
 			 WHERE post_slug = ? AND status NOT IN ('spam', 'pending')
@@ -416,7 +420,7 @@ export const listOwnPendingForPost = async (
 	const result = await db
 		.prepare(
 			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
-			        renderer_version, status, edited_at, deleted_at,
+			        renderer_version, status, edited_at, deleted_at, deleted_by,
 			        ip_hash, user_agent, created_at, score_up, score_down
 			 FROM comments
 			 WHERE post_slug = ? AND user_id = ? AND status = 'pending'
@@ -439,7 +443,7 @@ export const listLatestApprovedComments = async (
 	const result = await db
 		.prepare(
 			`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-			        c.renderer_version, c.status, c.edited_at, c.deleted_at,
+			        c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 			        c.ip_hash, c.user_agent, c.created_at, c.score_up, c.score_down,
 			        u.name AS author_name
 			   FROM comments c
@@ -936,7 +940,7 @@ export const adminListComments = async (
 
 	const sql = `
 		SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-		       c.renderer_version, c.status, c.edited_at, c.deleted_at,
+		       c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 		       c.ip_hash, c.user_agent, c.created_at, c.score_up, c.score_down,
 		       u.name       AS author_name,
 		       u.email      AS author_email,
@@ -978,15 +982,18 @@ export const updateCommentStatus = async (
 	status: CommentStatus,
 ): Promise<void> => {
 	const now = Date.now();
-	// deleted_at is set when transitioning to 'deleted', cleared otherwise.
+	// deleted_at / deleted_by are set when transitioning to 'deleted',
+	// cleared otherwise. This path is the moderation queue, so attribute the
+	// removal to a moderator.
 	const deletedAt = status === "deleted" ? now : null;
+	const deletedBy = status === "deleted" ? "moderator" : null;
 	await db
 		.prepare(
 			`UPDATE comments
-			    SET status = ?, deleted_at = ?
+			    SET status = ?, deleted_at = ?, deleted_by = ?
 			  WHERE id = ?`,
 		)
-		.bind(status, deletedAt, id)
+		.bind(status, deletedAt, deletedBy, id)
 		.run();
 };
 
@@ -1102,10 +1109,13 @@ export const softDeleteComment = async (
 	id: string,
 ): Promise<void> => {
 	const now = Date.now();
+	// The public delete route: the author removing their own comment (or an
+	// admin acting on the author's behalf via the same endpoint). Attributed
+	// to 'author' to distinguish from a moderation-queue removal.
 	await db
 		.prepare(
 			`UPDATE comments
-			    SET status = 'deleted', deleted_at = ?
+			    SET status = 'deleted', deleted_at = ?, deleted_by = 'author'
 			  WHERE id = ?`,
 		)
 		.bind(now, id)
@@ -1925,7 +1935,7 @@ export const adminGetCommentDetail = async (
 	const commentRow = await db
 		.prepare(
 			`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-			        c.renderer_version, c.status, c.edited_at, c.deleted_at,
+			        c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 			        c.ip_hash, c.user_agent, c.created_at,
 			        u.name       AS author_name,
 			        u.email      AS author_email,
@@ -1948,7 +1958,7 @@ export const adminGetCommentDetail = async (
 		? await db
 				.prepare(
 					`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-					        c.renderer_version, c.status, c.edited_at, c.deleted_at,
+					        c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 					        c.ip_hash, c.user_agent, c.created_at,
 					        u.name       AS author_name,
 					        u.email      AS author_email,
@@ -1968,7 +1978,7 @@ export const adminGetCommentDetail = async (
 	const repliesResult = await db
 		.prepare(
 			`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-			        c.renderer_version, c.status, c.edited_at, c.deleted_at,
+			        c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 			        c.ip_hash, c.user_agent, c.created_at,
 			        u.name       AS author_name,
 			        u.email      AS author_email,
@@ -1992,7 +2002,7 @@ export const adminGetCommentDetail = async (
 		? await db
 				.prepare(
 					`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-					        c.renderer_version, c.status, c.edited_at, c.deleted_at,
+					        c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 					        c.ip_hash, c.user_agent, c.created_at,
 					        u.name       AS author_name,
 					        u.email      AS author_email,
@@ -2014,7 +2024,7 @@ export const adminGetCommentDetail = async (
 	const userRecent = await db
 		.prepare(
 			`SELECT c.id, c.post_slug, c.parent_id, c.user_id, c.body_md, c.body_html,
-			        c.renderer_version, c.status, c.edited_at, c.deleted_at,
+			        c.renderer_version, c.status, c.edited_at, c.deleted_at, c.deleted_by,
 			        c.ip_hash, c.user_agent, c.created_at,
 			        u.name       AS author_name,
 			        u.email      AS author_email,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -402,6 +402,32 @@ export const listCommentsForPost = async (
 };
 
 /**
+ * Fetch a single viewer's own `pending` comments for a post. Merged into
+ * the public tree only for the authenticated author so they can see their
+ * comment is queued for moderation — never exposed to other viewers (the
+ * caller scopes this to `session.user_id`). Signed-in list responses bypass
+ * the edge cache, so these rows never leak into the anonymous cached copy.
+ */
+export const listOwnPendingForPost = async (
+	db: D1Database,
+	post_slug: string,
+	user_id: string,
+): Promise<Comment[]> => {
+	const result = await db
+		.prepare(
+			`SELECT id, post_slug, parent_id, user_id, body_md, body_html,
+			        renderer_version, status, edited_at, deleted_at,
+			        ip_hash, user_agent, created_at, score_up, score_down
+			 FROM comments
+			 WHERE post_slug = ? AND user_id = ? AND status = 'pending'
+			 ORDER BY created_at ASC, id ASC`,
+		)
+		.bind(post_slug, user_id)
+		.all<Comment>();
+	return result.results ?? [];
+};
+
+/**
  * Latest N approved comments for a post, joined with author name, for
  * the per-post RSS feed.
  */

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -35,6 +35,7 @@ export const en = {
 	"ui.subscribe": "Notify me of replies",
 	"ui.posted_just_now": "just now",
 	"ui.deleted": "[deleted]",
+	"ui.pending": "Pending approval",
 	"ui.edited_suffix": "(edited)",
 	"ui.verified": "verified",
 	"ui.subscribe.pending": "Check your inbox to confirm your subscription.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -35,6 +35,7 @@ export const en = {
 	"ui.subscribe": "Notify me of replies",
 	"ui.posted_just_now": "just now",
 	"ui.deleted": "[deleted]",
+	"ui.deleted_by_mod": "[removed by a moderator]",
 	"ui.pending": "Pending approval",
 	"ui.edited_suffix": "(edited)",
 	"ui.verified": "verified",

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,9 @@ export type Bindings = {
 	REACTIONS_ENABLED?: string;
 	PAGE_REACTIONS_ENABLED?: string;
 	PAGE_VOTES_ENABLED?: string;
+	// Keep deleted comments in the public tree as a placeholder instead of
+	// pruning leaf deletions. Default OFF (see src/lib/settings.ts).
+	SHOW_DELETED_PLACEHOLDERS?: string;
 	// Numeric display settings. Env-var *defaults*; a row in the `settings`
 	// table overrides the matching one at runtime (see src/lib/settings.ts).
 	//   COMMENTS_PER_PAGE   — top-level threads per initial load + Load-more.

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -30,7 +30,8 @@ export type FlagKey =
 	| "votes_enabled"
 	| "downvotes_enabled"
 	| "page_reactions_enabled"
-	| "page_votes_enabled";
+	| "page_votes_enabled"
+	| "show_deleted_placeholders";
 
 export type ResolvedFlags = Record<FlagKey, boolean>;
 
@@ -51,6 +52,14 @@ const FLAGS: Record<FlagKey, { env: keyof Bindings; default: boolean }> = {
 	downvotes_enabled: { env: "DOWNVOTES_ENABLED", default: true },
 	page_reactions_enabled: { env: "PAGE_REACTIONS_ENABLED", default: false },
 	page_votes_enabled: { env: "PAGE_VOTES_ENABLED", default: false },
+	// When OFF (default) a deleted comment with no surviving replies is pruned
+	// from the public tree — current behavior. When ON, every deleted comment
+	// is kept and rendered as a placeholder ("[deleted]" / "[removed by a
+	// moderator]"), so threads never silently lose entries.
+	show_deleted_placeholders: {
+		env: "SHOW_DELETED_PLACEHOLDERS",
+		default: false,
+	},
 };
 
 export const FLAG_KEYS = Object.keys(FLAGS) as FlagKey[];

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -44,6 +44,9 @@ export type TreeNode = {
 	status: Comment["status"];
 	edited_at: number | null;
 	deleted_at: number | null;
+	/** Who removed a deleted comment ('author' | 'moderator'), for the
+	 *  placeholder wording. NULL when not deleted. */
+	deleted_by: Comment["deleted_by"];
 	created_at: number;
 	author: TreeAuthor;
 	depth: number;
@@ -146,6 +149,7 @@ const toNode = (
 	status: row.status,
 	edited_at: row.edited_at,
 	deleted_at: row.deleted_at,
+	deleted_by: row.status === "deleted" ? row.deleted_by : null,
 	created_at: row.created_at,
 	author: buildAuthor(usersById, row.user_id),
 	depth,

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -82,9 +82,15 @@ const indexByParent = (rows: Comment[]): ChildIndex => {
 /**
  * Returns the set of comment IDs that should remain visible — every non-
  * deleted comment, plus every deleted ancestor that has a non-deleted
- * descendant.
+ * descendant. When `keepAllDeleted` is set (the show_deleted_placeholders
+ * flag), every deleted comment is kept too, so leaf deletions surface as a
+ * placeholder rather than being pruned.
  */
-const keepableSet = (rows: Comment[], children: ChildIndex): Set<string> => {
+const keepableSet = (
+	rows: Comment[],
+	children: ChildIndex,
+	keepAllDeleted: boolean,
+): Set<string> => {
 	const byId = new Map<string, Comment>();
 	for (const r of rows) byId.set(r.id, r);
 
@@ -106,7 +112,7 @@ const keepableSet = (rows: Comment[], children: ChildIndex): Set<string> => {
 	for (const r of rows) {
 		if (r.status !== "deleted") {
 			keep.add(r.id);
-		} else if (visit(r.id)) {
+		} else if (keepAllDeleted || visit(r.id)) {
 			keep.add(r.id);
 		}
 	}
@@ -229,11 +235,12 @@ export const buildTree = (
 	usersById: Map<string, TreeAuthor>,
 	reactionsById: Map<string, ReactionCount[]> = new Map(),
 	myVotes: Map<string, -1 | 1> = new Map(),
+	opts: { keepAllDeleted?: boolean } = {},
 ): BuildResult => {
 	const byId = new Map<string, Comment>();
 	for (const r of rows) byId.set(r.id, r);
 	const children = indexByParent(rows);
-	const keep = keepableSet(rows, children);
+	const keep = keepableSet(rows, children, opts.keepAllDeleted ?? false);
 
 	const tops = (children.get(null) ?? []).filter((t) => keep.has(t.id));
 	const threads: TreeNode[] = [];

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -139,6 +139,7 @@ const serializeComment = (c: Comment, author: User) => {
 		status: c.status,
 		edited_at: c.edited_at,
 		deleted_at: c.deleted_at,
+		deleted_by: visible ? c.deleted_by : null,
 		created_at: c.created_at,
 		author: {
 			id: author.id,

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -31,6 +31,7 @@ import {
 	isUserRole,
 	listActiveSubscriptionsForPost,
 	listCommentsForPost,
+	listOwnPendingForPost,
 	listReactionsForPost,
 	listUserReactionsOnPost,
 	softDeleteComment,
@@ -619,6 +620,18 @@ comments.get("/", async (c) => {
 
 	const post = await getPost(c.env.DB, slug);
 	const rows = await listCommentsForPost(c.env.DB, slug);
+	// Signed-in authors also see their own queued comments so they get a
+	// visible confirmation that the post landed in moderation. Scoped to the
+	// session user; never exposed to other viewers. Safe to merge here because
+	// signed-in responses bypass the anonymous edge cache (see `cacheable`).
+	if (session) {
+		const ownPending = await listOwnPendingForPost(
+			c.env.DB,
+			slug,
+			session.user_id,
+		);
+		if (ownPending.length > 0) rows.push(...ownPending);
+	}
 	const authors = await loadAuthors(c.env.DB, rows);
 
 	const reactionRows = await listReactionsForPost(c.env.DB, slug);

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -654,7 +654,14 @@ comments.get("/", async (c) => {
 		? await getUserVotesOnPost(c.env.DB, slug, session.user_id)
 		: new Map<string, -1 | 1>();
 
-	const { threads: allThreads } = buildTree(rows, authors, reactionsById, myVotes);
+	// When the operator opts in, keep every deleted comment as a placeholder
+	// (leaf deletions included) rather than pruning them. A toggle change is
+	// reflected for anonymous viewers within the tree-cache TTL.
+	const keepAllDeleted = (await loadFlags(c.env)).show_deleted_placeholders;
+
+	const { threads: allThreads } = buildTree(rows, authors, reactionsById, myVotes, {
+		keepAllDeleted,
+	});
 
 	if (sort === "top") {
 		// Top-level only — replies stay in created_at ASC so threaded

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -130,16 +130,16 @@ const validName = (raw: string | undefined): { ok: true; name: string } | { ok: 
 };
 
 const serializeComment = (c: Comment, author: User) => {
-	const visible = c.status === "deleted";
+	const isDeleted = c.status === "deleted";
 	return {
 		id: c.id,
 		post_slug: c.post_slug,
 		parent_id: c.parent_id,
-		body_html: visible ? "" : c.body_html,
+		body_html: isDeleted ? "" : c.body_html,
 		status: c.status,
 		edited_at: c.edited_at,
 		deleted_at: c.deleted_at,
-		deleted_by: visible ? c.deleted_by : null,
+		deleted_by: isDeleted ? c.deleted_by : null,
 		created_at: c.created_at,
 		author: {
 			id: author.id,

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -48,6 +48,7 @@ type TreeNode = {
 	status: "approved" | "pending" | "spam" | "deleted";
 	edited_at: number | null;
 	deleted_at: number | null;
+	deleted_by: "author" | "moderator" | null;
 	created_at: number;
 	author: TreeAuthor;
 	depth: number;
@@ -1414,7 +1415,11 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 
 	const body = el("div", "gr-body");
 	if (n.status === "deleted") {
-		const p = el("p", "gr-deleted", "[deleted]");
+		const label =
+			n.deleted_by === "moderator"
+				? "[removed by a moderator]"
+				: "[deleted]";
+		const p = el("p", "gr-deleted", label);
 		body.appendChild(p);
 	} else {
 		if (n.flatten_from) {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -316,6 +316,13 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 }
 .gr-time { color: var(--gr-muted); font-size: 0.85em; }
 .gr-edited { color: var(--gr-muted); font-size: 0.85em; font-style: italic; }
+.gr-pending {
+	color: var(--gr-notice);
+	border: 1px solid var(--gr-notice);
+	font-size: 0.75em;
+	padding: 0.05em 0.4em;
+	border-radius: 999px;
+}
 .gr-body { margin: 0.25rem 0 0; }
 .gr-body p { margin: 0.3em 0; }
 .gr-body a { color: var(--gr-link); }
@@ -1369,15 +1376,9 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 				tsHandle?.reset();
 				return;
 			}
-			if (json.comment?.status === "pending") {
-				errBox.textContent = "Comment submitted — awaiting moderation.";
-				errBox.classList.add("is-notice");
-				errBox.hidden = false;
-				ta.value = "";
-				submit.disabled = false;
-				tsHandle?.reset();
-				return;
-			}
+			// Pending replies reload like approved ones: the author's own
+			// queued comment comes back from the list endpoint and renders
+			// inline with a "Pending approval" badge.
 			ctx.reload();
 		} catch (err) {
 			errBox.textContent = String(err);
@@ -1405,6 +1406,11 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	}
 	meta.appendChild(el("span", "gr-time", fmtTime(n.created_at)));
 	if (n.edited_at) meta.appendChild(el("span", "gr-edited", "· edited"));
+	// Author-only signal: the list endpoint returns the viewer's own queued
+	// comments, so this badge is only ever seen by the author themselves.
+	if (n.status === "pending") {
+		meta.appendChild(el("span", "gr-pending", "Pending approval"));
+	}
 
 	const body = el("div", "gr-body");
 	if (n.status === "deleted") {
@@ -1422,7 +1428,9 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 
 	main.append(meta, body);
 
-	if (n.status !== "deleted") {
+	// Votes/reactions only on public (approved) comments — a pending comment
+	// isn't visible to anyone but its author, so engagement is meaningless.
+	if (n.status === "approved") {
 		if (ctx.votingEnabled) main.appendChild(buildVotes(n, ctx));
 		if (ctx.reactionsEnabled) main.appendChild(buildReactions(n, ctx));
 	}
@@ -2133,20 +2141,10 @@ const submit = async (
 			return;
 		}
 
-		if (json.comment?.status === "pending") {
-			if (errEl) {
-				errEl.textContent = "Comment submitted — awaiting moderation.";
-				errEl.classList.add("is-notice");
-				errEl.hidden = false;
-			}
-			const bodyInput = form.querySelector(
-				".gr-body-input",
-			) as HTMLTextAreaElement | null;
-			if (bodyInput) bodyInput.value = "";
-			if (submitBtn) submitBtn.disabled = false;
-			turnstileHandles.get(form)?.reset();
-			return;
-		}
+		// Pending comments fall through to the same reload path as approved
+		// ones: the list endpoint returns the author's own queued comment, so
+		// `load()` re-renders it inline with a "Pending approval" badge — a
+		// visible, persistent confirmation rather than a transient notice.
 
 		// Fire-and-forget subscription — failure here doesn't roll back
 		// the comment. The widget already has both inputs handy.

--- a/tests/comments-pending.test.ts
+++ b/tests/comments-pending.test.ts
@@ -1,0 +1,222 @@
+/**
+ * GET /api/v1/comments — own-pending visibility.
+ *
+ * A logged-in author sees their own `pending` (in-moderation) comments merged
+ * into the thread so they get a visible confirmation; nobody else does. This
+ * is an authZ contract: pending content must never leak to other users or to
+ * anonymous viewers.
+ *
+ * No Miniflare: a hand-rolled D1 stub routes by SQL substring and scopes the
+ * own-pending query by its bound user_id, an in-memory KV double backs
+ * settings, and a mock `caches.default` covers the anonymous first-page edge
+ * cache. Sessions are simulated via a SESSIONS KV double + cookie.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { comments } from "../src/routes/api.comments";
+import {
+	installMockCaches,
+	uninstallMockCaches,
+	type MockCache,
+} from "./helpers/mock-caches";
+import type { Bindings } from "../src/index";
+
+let mockCache: MockCache;
+beforeEach(() => {
+	mockCache = installMockCaches();
+});
+afterEach(() => uninstallMockCaches());
+
+const AUTHOR = "01HU000000000000000000";
+const OTHER = "01HU000000000000000001";
+// 64-hex session ids (SESSION_ID_RE) for each user.
+const SID_AUTHOR = "a".repeat(64);
+const SID_OTHER = "b".repeat(64);
+
+type Row = {
+	id: string;
+	post_slug: string;
+	parent_id: string | null;
+	user_id: string;
+	body_md: string;
+	body_html: string;
+	renderer_version: number;
+	status: string;
+	edited_at: number | null;
+	deleted_at: number | null;
+	deleted_by: string | null;
+	ip_hash: string | null;
+	user_agent: string | null;
+	created_at: number;
+	score_up: number;
+	score_down: number;
+};
+
+const mkRow = (id: string, user_id: string, status: string, at: number): Row => ({
+	id,
+	post_slug: "hello",
+	parent_id: null,
+	user_id,
+	body_md: id,
+	body_html: `<p>${id}</p>`,
+	renderer_version: 1,
+	status,
+	edited_at: null,
+	deleted_at: null,
+	deleted_by: null,
+	ip_hash: null,
+	user_agent: null,
+	created_at: at,
+	score_up: 0,
+	score_down: 0,
+});
+
+const userRow = (id: string) => ({
+	id,
+	provider: "anon",
+	provider_id: null,
+	name: id,
+	email: null,
+	avatar_url: null,
+	is_admin: 0,
+	is_banned: 0,
+	role: "user",
+	created_at: 1_700_000_000_000,
+});
+
+// D1 double. `approved` feeds the public list query; `pending` feeds the
+// own-pending query but is filtered by the bound user_id so the stub enforces
+// the same scoping the real SQL does.
+const makeDb = (approved: Row[], pending: Row[]) => {
+	const chain = (sql: string) => {
+		let boundArgs: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				boundArgs = args;
+				return this;
+			},
+			all: async () => {
+				if (sql.includes("key, value FROM settings")) return { results: [] };
+				if (
+					sql.includes("FROM comments") &&
+					sql.includes("status = 'pending'")
+				) {
+					const uid = boundArgs[1];
+					return { results: pending.filter((r) => r.user_id === uid) };
+				}
+				if (sql.includes("FROM comments") && sql.includes("status NOT IN")) {
+					// Fresh array per call: the handler mutates `rows` via push().
+					return { results: [...approved] };
+				}
+				if (sql.includes("FROM users WHERE id IN")) {
+					const ids = new Set([...approved, ...pending].map((r) => r.user_id));
+					return { results: [...ids].map(userRow) };
+				}
+				return { results: [] };
+			},
+			first: async () => {
+				if (sql.includes("FROM posts WHERE slug")) {
+					return { slug: "hello", title: "Hello", url: null, created_at: 1 };
+				}
+				return null;
+			},
+		};
+	};
+	return { prepare: (sql: string) => chain(sql) };
+};
+
+const makeKv = () => {
+	const store = new Map<string, string>();
+	return {
+		store,
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+// SESSIONS double mapping each session id to its user. Far-future expiry so
+// readSession's sliding-TTL refresh never rewrites.
+const makeSessions = () => {
+	const map: Record<string, string> = {
+		[`sess:${SID_AUTHOR}`]: AUTHOR,
+		[`sess:${SID_OTHER}`]: OTHER,
+	};
+	return {
+		async get(key: string) {
+			const uid = map[key];
+			if (!uid) return null;
+			return JSON.stringify({
+				user_id: uid,
+				expires_at: 4_102_444_800_000, // year 2100
+			});
+		},
+		async put() {},
+		async delete() {},
+	};
+};
+
+const mkEnv = (approved: Row[], pending: Row[]) =>
+	({
+		DB: makeDb(approved, pending),
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+	}) as unknown as Bindings;
+
+type ListResp = { threads: { id: string; status: string }[] };
+
+const get = async (env: Bindings, cookie?: string): Promise<ListResp> => {
+	const app = new Hono<{ Bindings: Bindings }>().route("/", comments);
+	const headers = cookie ? { cookie } : undefined;
+	const res = await app.request(
+		"/?slug=hello",
+		headers ? { headers } : {},
+		env as unknown as Record<string, unknown>,
+	);
+	expect(res.status).toBe(200);
+	return (await res.json()) as ListResp;
+};
+
+describe("GET /comments — own pending visibility", () => {
+	const approved = [mkRow("01HUAPPROVED0000000000", OTHER, "approved", 1000)];
+	const pending = [mkRow("01HUPENDING00000000000", AUTHOR, "pending", 2000)];
+
+	it("shows the author their own pending comment", async () => {
+		const env = mkEnv(approved, pending);
+		const page = await get(env, `garrul_sess=${SID_AUTHOR}`);
+		const ids = page.threads.map((t) => t.id);
+		expect(ids).toContain("01HUPENDING00000000000");
+		const node = page.threads.find((t) => t.id === "01HUPENDING00000000000");
+		expect(node!.status).toBe("pending");
+	});
+
+	it("does NOT show a pending comment to a different signed-in user", async () => {
+		const env = mkEnv(approved, pending);
+		const page = await get(env, `garrul_sess=${SID_OTHER}`);
+		const ids = page.threads.map((t) => t.id);
+		expect(ids).not.toContain("01HUPENDING00000000000");
+	});
+
+	it("does NOT show a pending comment to anonymous viewers", async () => {
+		const env = mkEnv(approved, pending);
+		const page = await get(env);
+		const ids = page.threads.map((t) => t.id);
+		expect(ids).not.toContain("01HUPENDING00000000000");
+		expect(ids).toContain("01HUAPPROVED0000000000");
+	});
+});

--- a/tests/queries-comments-realdb.test.ts
+++ b/tests/queries-comments-realdb.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Real-SQLite regression coverage for the comment write paths.
+ *
+ * The rest of the comment suite uses hand-rolled D1 stubs that route by SQL
+ * substring — fast, but they never parse SQL, so a column/value-count mismatch
+ * in an INSERT/UPDATE sails straight through (it did: the `deleted_by` column
+ * was added to insertComment's column list without a matching VALUES entry,
+ * breaking *all* comment creation, and no stub test caught it).
+ *
+ * These tests run the genuine queries against Node's built-in `node:sqlite`
+ * (no new dependency, no network) with every migration applied, so the SQL is
+ * executed for real and column drift fails loudly.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+	insertComment,
+	getComment,
+	softDeleteComment,
+	updateCommentStatus,
+} from "../src/db/queries";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+// Minimal D1Database adapter over node:sqlite. Covers the surface the comment
+// write/read queries use: prepare().bind().run()/first()/all().
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith(".sql")).sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	return makeD1(sqlite);
+};
+
+const baseInput = {
+	post_slug: "hello",
+	parent_id: null,
+	user_id: "u1",
+	body_md: "hi",
+	body_html: "<p>hi</p>",
+	renderer_version: 1,
+	ip_hash: "iphash",
+	user_agent: "ua",
+};
+
+describe("comment write paths (real SQLite)", () => {
+	let db: any;
+	beforeEach(async () => {
+		db = freshDb();
+		// comments has real FKs on post_slug → posts and user_id → users, and
+		// node:sqlite enforces them — seed both parents first.
+		await db
+			.prepare("INSERT INTO posts (slug, title, url, created_at) VALUES (?, ?, ?, ?)")
+			.bind("hello", "Hello", null, 1_700_000_000_000)
+			.run();
+		await db
+			.prepare(
+				"INSERT INTO users (id, provider, provider_id, name, created_at) VALUES (?, ?, ?, ?, ?)",
+			)
+			.bind("u1", "anon", null, "u1", 1_700_000_000_000)
+			.run();
+	});
+
+	it("insertComment persists a row with fields in the right columns", async () => {
+		const c = await insertComment(db, baseInput);
+		const row = await getComment(db, c.id);
+		expect(row).not.toBeNull();
+		// The bug this guards: a column/value shift would land ip_hash in
+		// deleted_by, etc. Assert each field landed in its own column.
+		expect(row!.status).toBe("approved");
+		expect(row!.deleted_by).toBeNull();
+		expect(row!.deleted_at).toBeNull();
+		expect(row!.ip_hash).toBe("iphash");
+		expect(row!.user_agent).toBe("ua");
+		expect(row!.body_html).toBe("<p>hi</p>");
+		expect(typeof row!.created_at).toBe("number");
+	});
+
+	it("insertComment honors a forced 'pending' status", async () => {
+		const c = await insertComment(db, { ...baseInput, status: "pending" });
+		const row = await getComment(db, c.id);
+		expect(row!.status).toBe("pending");
+		expect(row!.deleted_by).toBeNull();
+	});
+
+	it("softDeleteComment attributes the removal to the author", async () => {
+		const c = await insertComment(db, baseInput);
+		await softDeleteComment(db, c.id);
+		const row = await getComment(db, c.id);
+		expect(row!.status).toBe("deleted");
+		expect(row!.deleted_by).toBe("author");
+		expect(typeof row!.deleted_at).toBe("number");
+	});
+
+	it("updateCommentStatus to 'deleted' attributes the removal to a moderator", async () => {
+		const c = await insertComment(db, baseInput);
+		await updateCommentStatus(db, c.id, "deleted");
+		const row = await getComment(db, c.id);
+		expect(row!.status).toBe("deleted");
+		expect(row!.deleted_by).toBe("moderator");
+		expect(typeof row!.deleted_at).toBe("number");
+	});
+
+	it("updateCommentStatus away from 'deleted' clears deleted_at/deleted_by", async () => {
+		const c = await insertComment(db, baseInput);
+		await updateCommentStatus(db, c.id, "deleted");
+		await updateCommentStatus(db, c.id, "approved");
+		const row = await getComment(db, c.id);
+		expect(row!.status).toBe("approved");
+		expect(row!.deleted_by).toBeNull();
+		expect(row!.deleted_at).toBeNull();
+	});
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -101,6 +101,7 @@ describe("loadFlags — defaults", () => {
 			downvotes_enabled: true,
 			page_reactions_enabled: false,
 			page_votes_enabled: false,
+			show_deleted_placeholders: false,
 		});
 	});
 

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -28,6 +28,7 @@ const mk = (
 	created_at: number,
 	user_id = "u1",
 	status: Comment["status"] = "approved",
+	deleted_by: Comment["deleted_by"] = status === "deleted" ? "author" : null,
 ): Comment => ({
 	id,
 	post_slug: "p",
@@ -39,6 +40,7 @@ const mk = (
 	status,
 	edited_at: null,
 	deleted_at: status === "deleted" ? created_at + 1 : null,
+	deleted_by,
 	ip_hash: null,
 	user_agent: null,
 	created_at,
@@ -175,5 +177,53 @@ describe("buildTree — deleted-parent semantics", () => {
 		];
 		const { threads } = buildTree(rows, usersById(author("u1")));
 		expect(threads[0]!.replies).toEqual([]);
+	});
+});
+
+describe("buildTree — keepAllDeleted (show_deleted_placeholders)", () => {
+	it("keeps a deleted leaf reply as a placeholder when set", () => {
+		const rows = [
+			mk("root", null, 100),
+			mk("dead", "root", 200, "u1", "deleted"),
+		];
+		const { threads } = buildTree(
+			rows,
+			usersById(author("u1")),
+			undefined,
+			undefined,
+			{ keepAllDeleted: true },
+		);
+		expect(threads[0]!.replies.map((r) => r.id)).toEqual(["dead"]);
+		expect(threads[0]!.replies[0]!.status).toBe("deleted");
+	});
+
+	it("keeps a deleted top-level thread with no live descendants when set", () => {
+		const rows = [mk("solo", null, 100, "u1", "deleted")];
+		const { threads } = buildTree(
+			rows,
+			usersById(author("u1")),
+			undefined,
+			undefined,
+			{ keepAllDeleted: true },
+		);
+		expect(threads.map((t) => t.id)).toEqual(["solo"]);
+	});
+
+	it("propagates deleted_by onto the node for placeholder wording", () => {
+		const rows = [
+			mk("root", null, 100),
+			mk("byMod", "root", 200, "u1", "deleted", "moderator"),
+			mk("byAuthor", "root", 300, "u1", "deleted", "author"),
+		];
+		const { threads } = buildTree(
+			rows,
+			usersById(author("u1")),
+			undefined,
+			undefined,
+			{ keepAllDeleted: true },
+		);
+		const byId = new Map(threads[0]!.replies.map((r) => [r.id, r]));
+		expect(byId.get("byMod")!.deleted_by).toBe("moderator");
+		expect(byId.get("byAuthor")!.deleted_by).toBe("author");
 	});
 });

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -53,6 +53,9 @@ OAUTH_CALLBACK_BASE = "https://comments.example.com"
 # Page-level engagement — react / vote on the article itself (default off):
 # PAGE_REACTIONS_ENABLED = "false"
 # PAGE_VOTES_ENABLED = "false"
+# Keep deleted comments in the thread as a placeholder ("[deleted]" /
+# "[removed by a moderator]") instead of pruning leaf deletions (default off):
+# SHOW_DELETED_PLACEHOLDERS = "false"
 # Display & pagination (all optional; clamped server-side). Also editable at
 # runtime from the admin Settings page. Top-level comments per initial load /
 # "Load older" click (default 25, range 1-200 — set 100 for pre-v1.10 behavior):


### PR DESCRIPTION
## Moderation-queue feedback + deleted-comment placeholders

Two related comment-visibility improvements, plus the `deleted_by` plumbing that backs them. Ships as **v1.15.0**.

### Feature 1 — Authors see their own pending comments
When a signed-in user's comment is held for moderation (`status='pending'`), the list endpoint now merges that author's *own* pending comments into the thread, and the widget renders a persistent **"Pending approval"** badge on them. Previously the comment vanished after a one-line transient notice, leaving the author unsure it worked.

- Scoped strictly to `user_id = session.user_id` — pending content never leaks to other signed-in users or anonymous viewers.
- Safe against the edge cache: the pending merge only runs when a session is present, and the edge cache is already anonymous-only, so no cache poisoning.
- The transient "awaiting moderation" notice is replaced by the inline badge (survives reload).

### Feature 2 — Deleted comments record *who* removed them
New nullable `deleted_by` column (`'author'` | `'moderator'` | NULL):
- Author/self-delete → `'author'`
- Moderation-queue removal → `'moderator'`

The widget picks placeholder wording accordingly: `[deleted]` vs `[removed by a moderator]`.

### New setting — `show_deleted_placeholders` (default OFF)
Admin-toggleable flag (env `SHOW_DELETED_PLACEHOLDERS`, or the Settings page). **Default off preserves today's behavior** (deleted leaf comments are pruned; deleted nodes with live replies are still kept for ancestry). When **on**, every deleted comment is kept as a placeholder.

## Operator notes
- **New env var:** `SHOW_DELETED_PLACEHOLDERS` (optional, default `false`). Documented in `wrangler.example.toml`; editable at runtime from admin Settings.
- **New migration:** `0012_deleted_by.sql` — `ALTER TABLE comments ADD COLUMN deleted_by TEXT` (nullable, forward-only, idempotent via `npm run migrate`).
- No breaking changes.

## Verification
- 576 tests pass (+6 new: own-pending authZ scoping, `keepAllDeleted` tree behavior, `deleted_by` propagation).
- Typecheck clean, `manifest:check` OK, `embed.js` **10.5 KB gzipped** (≤20KB budget).
- Migration applies cleanly in sequence (`npm run migrate -- --local`).

**Known gap:** widget visual DOM (badge element, placeholder text) verified via typecheck + build, not a live browser render. The API contract feeding the widget is covered by route-level tests.
