### PR TITLE
feat(webhooks): rich Discord embeds + admin/page links

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -109,12 +109,13 @@ red, edited = grey), and a **Links** field with *🔍 Open in admin* and
 with the title and the two links rendered using Slack's `<url|label>`
 syntax.
 
-Both link to `…/admin/comments/<id>` (the moderation detail page) and to
-the post's public URL. These links require **`PUBLIC_BASE_URL`** to be
-set — if it is unset, the notification still sends but the admin link is
-omitted. The page link additionally requires the post to have a stored
-`url` (published by the embed widget's `data-url` on first comment), and
-that URL is scheme-validated (`http`/`https` only) before it is shown.
+The two links point to `…/admin/comments/<id>` (the moderation detail
+page) and to the post's public URL. The **admin** link requires
+**`PUBLIC_BASE_URL`** to be set — if it is unset, the notification still
+sends but that link is omitted. The **page** link is independent of
+`PUBLIC_BASE_URL`: it needs only the post's stored `url` (published by the
+embed widget's `data-url` on first comment). Both URLs are scheme-
+validated (`http`/`https` only) before they are shown.
 
 Safety notes specific to the rich adapters: comment bodies can't ping a
 channel (`@everyone`/role mentions are neutralized), and the Discord embed

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -100,6 +100,27 @@ The default `generic` adapter sends the v1 payload above. `slack` and
 the endpoint when the target URL is a Slack or Discord incoming
 webhook. Adapter changes do not require receiver changes.
 
+The `discord` adapter sends a single rich **embed** (`{"embeds":[…]}`):
+the commenter's name as the embed author, the post title as a link to the
+page, the comment snippet as the (markdown-rendering) description, an
+event-colored accent (new = blurple, approved = green, spam/deleted =
+red, edited = grey), and a **Links** field with *🔍 Open in admin* and
+*🌐 View page*. The `slack` adapter sends the same information as text,
+with the title and the two links rendered using Slack's `<url|label>`
+syntax.
+
+Both link to `…/admin/comments/<id>` (the moderation detail page) and to
+the post's public URL. These links require **`PUBLIC_BASE_URL`** to be
+set — if it is unset, the notification still sends but the admin link is
+omitted. The page link additionally requires the post to have a stored
+`url` (published by the embed widget's `data-url` on first comment), and
+that URL is scheme-validated (`http`/`https` only) before it is shown.
+
+Safety notes specific to the rich adapters: comment bodies can't ping a
+channel (`@everyone`/role mentions are neutralized), and the Discord embed
+description escapes `[`/`]` so a comment body like `[click](https://evil)`
+renders as literal text rather than a clickable masked link.
+
 ## Legacy `WEBHOOK_URL`
 
 Operators upgrading from the original single-`WEBHOOK_URL` setup used one

--- a/src/lib/webhook-adapters.ts
+++ b/src/lib/webhook-adapters.ts
@@ -182,8 +182,15 @@ const escapeDiscordMentions = (s: string): string =>
 // image syntax by backslash-escaping the square brackets so a comment
 // body of "[click me](https://evil)" can't become a clickable link.
 // Basic emphasis is left to render for a nicer look.
+//
+// Backslashes MUST be doubled first: otherwise a body of "\[x](url)"
+// would become "\\[x\](url)" — Discord renders "\\" as a literal
+// backslash, leaving the "[" unescaped and the masked link live again.
+// Escaping "\" → "\\" before the brackets closes that bypass.
 const sanitizeDiscordDescription = (s: string): string =>
-	escapeDiscordMentions(s).replace(/[[\]]/g, "\\$&");
+	escapeDiscordMentions(s)
+		.replace(/\\/g, "\\\\")
+		.replace(/[[\]]/g, "\\$&");
 
 export const renderSlackBody = async (
 	db: WebhookAdapterDb,

--- a/src/lib/webhook-adapters.ts
+++ b/src/lib/webhook-adapters.ts
@@ -4,28 +4,43 @@
  *
  * Architecture note: the generic adapter is a pure JSON.stringify of
  * the v1 payload. Slack/Discord need richer content (author name,
- * comment snippet) than the v1 contract carries, so each adapter does
- * its own DB lookup at render time. Once rendered, the resulting body
- * is stored verbatim on the webhook_deliveries row — retries resend
- * the same body, just with a fresh HMAC timestamp. We do NOT re-render
- * on retry: by the time the 6-hour retry fires, the comment may have
- * been edited or deleted, and we want the Slack/Discord channel to
+ * comment snippet, navigation links) than the v1 contract carries, so
+ * each adapter does its own DB lookup at render time. Once rendered, the
+ * resulting body is stored verbatim on the webhook_deliveries row —
+ * retries resend the same body, just with a fresh HMAC timestamp. We do
+ * NOT re-render on retry: by the time the retry fires, the comment may
+ * have been edited or deleted, and we want the Slack/Discord channel to
  * reflect what *was true at the event time*, not the now-stale state.
+ * The links we embed (admin URL, page URL) are derived from the base URL
+ * + comment id + post URL — all stable — so verbatim retry stays correct.
  *
  * Security posture:
  *   - Snippets are truncated to platform limits BEFORE escaping, so a
  *     long body can't bust the platform's hard 2000/4000-char cap.
  *   - Mentions are neutralized so a comment body of "@everyone come
  *     read this" cannot ping a whole Slack workspace or Discord guild.
- *   - We send only `text` (Slack) / `content` (Discord) — no embeds,
- *     no blocks. Keeps the attack surface small; embeds have their
- *     own injection traps (markdown in titles, URL fields, etc.) we
- *     don't need yet.
+ *   - Discord now renders an *embed* (nicer UI + clickable links). Embeds
+ *     have injection traps the old plain-text path didn't: the embed
+ *     `description` renders markdown, so a comment body of
+ *     "[Win a prize](https://evil)" could become a clickable masked link.
+ *     We defuse this by escaping `[`/`]` in the description (kills masked
+ *     links and images) while leaving basic bold/italic to render. The
+ *     embed `title` / `author.name` positions do NOT render markdown, and
+ *     embeds never fire mentions, but we keep mention-neutralization as
+ *     defense in depth. Every URL we place in a clickable position is
+ *     either server-generated (admin link) or scheme-validated (page /
+ *     avatar), never raw user input.
  */
 import { getComment, getPost, getUser } from "../db/queries";
 import type { WebhookEvent, WebhookPayload } from "./webhook";
 
 type WebhookAdapterDb = Pick<D1Database, "prepare">;
+
+/** Options threaded from the dispatcher into the rich adapters. */
+export type AdapterOpts = {
+	/** Instance base URL (PUBLIC_BASE_URL) for building admin links. */
+	baseUrl?: string | undefined;
+};
 
 const EVENT_VERB: Record<WebhookEvent, string> = {
 	"comment.posted": "New comment",
@@ -35,24 +50,59 @@ const EVENT_VERB: Record<WebhookEvent, string> = {
 	"comment.spam": "Comment marked spam",
 };
 
+// Discord embed accent color per event (decimal RGB).
+const EVENT_COLOR: Record<WebhookEvent, number> = {
+	"comment.posted": 0x5865f2, // blurple
+	"comment.edited": 0x99aab5, // grey
+	"comment.approved": 0x57f287, // green
+	"comment.spam": 0xed4245, // red
+	"comment.deleted": 0x992d22, // dark red
+};
+
 // Cap snippet length pre-escape so the worst-case escaped output still
 // fits inside the platform body limit. 1500 raw chars + escape overhead
-// stays under Discord's 2000 and Slack's 3000.
+// stays under Discord's 4096 embed-description and Slack's 3000.
 const SNIPPET_CAP = 1500;
+// Discord embed title / author.name hard cap is 256.
+const EMBED_NAME_CAP = 256;
 
 type Ctx = {
 	author: string;
 	post_title: string;
 	post_slug: string;
 	snippet: string;
+	/** Admin deep link, or null when PUBLIC_BASE_URL is unset/invalid. */
+	admin_url: string | null;
+	/** Public page URL, or null when the post has no valid url. */
+	page_url: string | null;
+	/** Commenter avatar (provider), or null. https only. */
+	avatar_url: string | null;
 };
 
 const truncate = (s: string, max: number): string =>
 	s.length <= max ? s : `${s.slice(0, max)}…`;
 
+// Parse + scheme-check a stored/derived URL before we place it in a
+// clickable position. Mirrors the guard in src/routes/permalink.ts: the
+// post url came from the embed widget's caller-supplied data-url, so we
+// reject anything that isn't plain http(s) to avoid surfacing
+// javascript:/data:/scheme-relative targets in a chat client.
+const safeHttpUrl = (raw: string | null | undefined): string | null => {
+	if (!raw) return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+	return raw;
+};
+
 const loadContext = async (
 	db: WebhookAdapterDb,
 	payload: WebhookPayload,
+	opts: AdapterOpts,
 ): Promise<Ctx> => {
 	// All three lookups can fail (row deleted, DB hiccup) without
 	// crashing the dispatch — the adapter degrades to ID-only.
@@ -66,7 +116,22 @@ const loadContext = async (
 	const post_title = post?.title ?? post_slug;
 	const raw = comment?.body_md ?? "(no body available)";
 	const snippet = truncate(raw.replace(/\s+/g, " ").trim(), SNIPPET_CAP);
-	return { author, post_slug, post_title, snippet };
+
+	// Admin link only when we have a valid base URL. We link straight to
+	// the post page (not /c/:id) because /c/:id 404s for pending/spam/
+	// deleted comments — and a brand-new comment is exactly the pending
+	// case a moderator gets pinged about.
+	const base = safeHttpUrl(opts.baseUrl);
+	const admin_url = base
+		? `${base.replace(/\/$/, "")}/admin/comments/${encodeURIComponent(payload.comment_id)}`
+		: null;
+	const page_url = safeHttpUrl(post?.url);
+	// Discord/Slack require https for displayed avatars.
+	const avatar = user?.avatar_url ?? null;
+	const avatar_url =
+		avatar && safeHttpUrl(avatar)?.startsWith("https:") ? avatar : null;
+
+	return { author, post_slug, post_title, snippet, admin_url, page_url, avatar_url };
 };
 
 // Slack mentions: @everyone, @here, @channel, <!everyone>, <!here>,
@@ -93,34 +158,89 @@ const escapeSlackText = (s: string): string =>
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;");
 
+// A Slack link label lives inside <url|label>; the `|` would otherwise
+// terminate the label. escapeSlackText already neutralizes <>& — swap the
+// only remaining structural char for a visually identical box-drawing
+// glyph so the label can't break out of the link.
+const slackLinkLabel = (s: string): string =>
+	escapeSlackText(s).replace(/\|/g, "│");
+
+// A url is safe to drop into <url|label> only if it has no chars that
+// would terminate the link span.
+const slackSafeUrl = (url: string): boolean => !/[<>|]/.test(url);
+
 // Discord mentions: @everyone, @here, <@id>, <@!id>, <@&roleId>.
 // Inserting a zero-width space breaks the trigger while keeping the
-// text legible.
+// text legible. (Embeds don't fire mentions, but this is cheap defense
+// in depth and keeps the rendered text tidy.)
 const escapeDiscordMentions = (s: string): string =>
 	s
 		.replace(/@(everyone|here)/gi, "@​$1")
 		.replace(/<@([!&]?\d+)>/g, "<@​$1>");
 
+// The embed `description` renders markdown. Neutralize masked-link and
+// image syntax by backslash-escaping the square brackets so a comment
+// body of "[click me](https://evil)" can't become a clickable link.
+// Basic emphasis is left to render for a nicer look.
+const sanitizeDiscordDescription = (s: string): string =>
+	escapeDiscordMentions(s).replace(/[[\]]/g, "\\$&");
+
 export const renderSlackBody = async (
 	db: WebhookAdapterDb,
 	payload: WebhookPayload,
+	opts: AdapterOpts = {},
 ): Promise<string> => {
-	const ctx = await loadContext(db, payload);
-	const text =
+	const ctx = await loadContext(db, payload, opts);
+
+	// Link the post title to the page when we can.
+	const titleField =
+		ctx.page_url && slackSafeUrl(ctx.page_url)
+			? `<${ctx.page_url}|${slackLinkLabel(ctx.post_title)}>`
+			: `\`${escapeSlackText(ctx.post_title)}\``;
+
+	const links: string[] = [];
+	if (ctx.admin_url && slackSafeUrl(ctx.admin_url)) {
+		links.push(`<${ctx.admin_url}|🔍 Open in admin>`);
+	}
+	if (ctx.page_url && slackSafeUrl(ctx.page_url)) {
+		links.push(`<${ctx.page_url}|🌐 View page>`);
+	}
+
+	let text =
 		`*${EVENT_VERB[payload.event]}* by *${escapeSlackText(ctx.author)}* ` +
-		`on \`${escapeSlackText(ctx.post_title)}\`\n` +
+		`on ${titleField}\n` +
 		`> ${escapeSlackText(ctx.snippet)}`;
+	if (links.length > 0) text += `\n${links.join(" · ")}`;
+
 	return JSON.stringify({ text });
 };
 
 export const renderDiscordBody = async (
 	db: WebhookAdapterDb,
 	payload: WebhookPayload,
+	opts: AdapterOpts = {},
 ): Promise<string> => {
-	const ctx = await loadContext(db, payload);
-	const content =
-		`**${EVENT_VERB[payload.event]}** by **${escapeDiscordMentions(ctx.author)}** ` +
-		`on \`${escapeDiscordMentions(ctx.post_title)}\`\n` +
-		`> ${escapeDiscordMentions(ctx.snippet)}`;
-	return JSON.stringify({ content });
+	const ctx = await loadContext(db, payload, opts);
+
+	const links: string[] = [];
+	if (ctx.admin_url) links.push(`[🔍 Open in admin](${ctx.admin_url})`);
+	if (ctx.page_url) links.push(`[🌐 View page](${ctx.page_url})`);
+
+	const embed: Record<string, unknown> = {
+		author: {
+			name: truncate(escapeDiscordMentions(ctx.author), EMBED_NAME_CAP),
+			...(ctx.avatar_url ? { icon_url: ctx.avatar_url } : {}),
+		},
+		title: truncate(ctx.post_title, EMBED_NAME_CAP),
+		...(ctx.page_url ? { url: ctx.page_url } : {}),
+		description: `> ${sanitizeDiscordDescription(ctx.snippet)}`,
+		color: EVENT_COLOR[payload.event],
+		footer: { text: "Garrul" },
+		timestamp: new Date(payload.ts).toISOString(),
+	};
+	if (links.length > 0) {
+		embed.fields = [{ name: "Links", value: links.join(" · ") }];
+	}
+
+	return JSON.stringify({ embeds: [embed] });
 };

--- a/src/lib/webhook-adapters.ts
+++ b/src/lib/webhook-adapters.ts
@@ -117,14 +117,17 @@ const loadContext = async (
 	const raw = comment?.body_md ?? "(no body available)";
 	const snippet = truncate(raw.replace(/\s+/g, " ").trim(), SNIPPET_CAP);
 
-	// Admin link only when we have a valid base URL. We link straight to
-	// the post page (not /c/:id) because /c/:id 404s for pending/spam/
-	// deleted comments — and a brand-new comment is exactly the pending
-	// case a moderator gets pinged about.
+	// Admin deep link to the moderation detail page — only when we have a
+	// valid base URL. Legacy operators without PUBLIC_BASE_URL simply don't
+	// get this link.
 	const base = safeHttpUrl(opts.baseUrl);
 	const admin_url = base
 		? `${base.replace(/\/$/, "")}/admin/comments/${encodeURIComponent(payload.comment_id)}`
 		: null;
+	// Public page link uses the stored post.url directly rather than the
+	// /c/:id permalink: /c/:id 404s for pending/spam/deleted comments, and a
+	// brand-new (pending) comment is exactly what a moderator gets pinged
+	// about. Independent of PUBLIC_BASE_URL.
 	const page_url = safeHttpUrl(post?.url);
 	// Discord/Slack require https for displayed avatars.
 	const avatar = user?.avatar_url ?? null;
@@ -229,9 +232,13 @@ export const renderDiscordBody = async (
 ): Promise<string> => {
 	const ctx = await loadContext(db, payload, opts);
 
+	// Wrap the destination in <…> so Discord treats it as a literal URL:
+	// a bare URL containing ")" (e.g. a "/wiki/Foo_(bar)" page link) would
+	// otherwise terminate the markdown link early. The URLs are already
+	// scheme-validated; this just hardens the markdown framing.
 	const links: string[] = [];
-	if (ctx.admin_url) links.push(`[🔍 Open in admin](${ctx.admin_url})`);
-	if (ctx.page_url) links.push(`[🌐 View page](${ctx.page_url})`);
+	if (ctx.admin_url) links.push(`[🔍 Open in admin](<${ctx.admin_url}>)`);
+	if (ctx.page_url) links.push(`[🌐 View page](<${ctx.page_url}>)`);
 
 	const embed: Record<string, unknown> = {
 		author: {

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -53,7 +53,11 @@ import {
 } from "../db/queries";
 import { log } from "./log";
 import { checkOutboundUrl } from "./url-safety";
-import { renderDiscordBody, renderSlackBody } from "./webhook-adapters";
+import {
+	type AdapterOpts,
+	renderDiscordBody,
+	renderSlackBody,
+} from "./webhook-adapters";
 import { signWebhookBody } from "./webhook-sig";
 
 export type WebhookEvent =
@@ -75,6 +79,10 @@ type WebhookEnv = {
 	DB: D1Database;
 	WEBHOOK_URL?: string;
 	ENV?: string;
+	// Used by the slack/discord adapters to build "Open in admin" links.
+	// Optional: a legacy operator with no PUBLIC_BASE_URL still gets
+	// deliveries, just without the admin link.
+	PUBLIC_BASE_URL?: string;
 };
 
 const TIMEOUT_MS = 5000;
@@ -111,9 +119,10 @@ const renderBody = async (
 	db: D1Database,
 	adapter: WebhookAdapter,
 	payload: WebhookPayload,
+	opts: AdapterOpts,
 ): Promise<string> => {
-	if (adapter === "slack") return renderSlackBody(db, payload);
-	if (adapter === "discord") return renderDiscordBody(db, payload);
+	if (adapter === "slack") return renderSlackBody(db, payload, opts);
+	if (adapter === "discord") return renderDiscordBody(db, payload, opts);
 	return renderGenericBody(payload);
 };
 
@@ -196,7 +205,9 @@ const dispatchToEndpoint = async (
 	payload: WebhookPayload,
 ): Promise<void> => {
 	if (!matchesEventFilter(endpoint, payload.event)) return;
-	const body = await renderBody(env.DB, endpoint.adapter, payload);
+	const body = await renderBody(env.DB, endpoint.adapter, payload, {
+		baseUrl: env.PUBLIC_BASE_URL,
+	});
 	const result = await postOnce(endpoint, body, allowHttpFor(endpoint, env));
 	if (result.ok) {
 		if (endpoint.id !== "_env" && endpoint.fail_count > 0) {

--- a/tests/webhook-adapters.test.ts
+++ b/tests/webhook-adapters.test.ts
@@ -260,6 +260,23 @@ describe("renderDiscordBody", () => {
 		expect(links).toContain("https://blog.example.com/p");
 	});
 
+	it("angle-wraps markdown link URLs so parens don't break them", async () => {
+		const rows = {
+			...baseRows,
+			posts: {
+				...baseRows.posts,
+				url: "https://en.example.com/wiki/Foo_(bar)",
+			},
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload(), {
+			baseUrl: "https://c.example.com",
+		});
+		const links = JSON.parse(out).embeds[0].fields[0].value;
+		// Destination wrapped in <…>: "[label](<https://…/Foo_(bar)>)".
+		expect(links).toContain("(<https://en.example.com/wiki/Foo_(bar)>)");
+		expect(links).toContain("(<https://c.example.com/admin/comments/");
+	});
+
 	it("omits links when baseUrl is absent and post.url is null", async () => {
 		const out = await renderDiscordBody(makeDb(baseRows), payload());
 		const embed = JSON.parse(out).embeds[0];

--- a/tests/webhook-adapters.test.ts
+++ b/tests/webhook-adapters.test.ts
@@ -297,6 +297,24 @@ describe("renderDiscordBody", () => {
 		expect(desc).not.toContain("[Win a prize](");
 	});
 
+	it("doubles backslashes so they can't cancel the bracket escaping", async () => {
+		// A leading "\" before "[" would, without backslash-doubling, turn
+		// into "\\[" — a literal backslash + a *live* "[", re-enabling the
+		// masked link. CodeQL flagged this incomplete-escaping bypass.
+		const rows = {
+			...baseRows,
+			comments: {
+				...baseRows.comments,
+				body_md: "\\[x](https://evil.example)",
+			},
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload());
+		const desc = JSON.parse(out).embeds[0].description;
+		// The user's "\" is doubled and the bracket stays escaped:
+		// "\\\[x\]" — Discord can't reconstruct a live masked link.
+		expect(desc).toContain("\\\\\\[x\\]");
+	});
+
 	it("neutralizes @everyone and @here in the snippet", async () => {
 		for (const trigger of ["@everyone", "@here"]) {
 			const rows = {

--- a/tests/webhook-adapters.test.ts
+++ b/tests/webhook-adapters.test.ts
@@ -190,32 +190,126 @@ describe("renderSlackBody", () => {
 		const out = await renderSlackBody(makeDb(rows), payload());
 		expect(() => JSON.parse(out)).not.toThrow();
 	});
+
+	it("links the title and appends nav links when configured", async () => {
+		const rows = {
+			...baseRows,
+			posts: { ...baseRows.posts, url: "https://blog.example.com/p" },
+		};
+		const out = await renderSlackBody(makeDb(rows), payload(), {
+			baseUrl: "https://c.example.com",
+		});
+		const text = JSON.parse(out).text;
+		expect(text).toContain("<https://blog.example.com/p|Hello, world!>");
+		expect(text).toContain(
+			"<https://c.example.com/admin/comments/01HC000000000000000000|🔍 Open in admin>",
+		);
+		expect(text).toContain("<https://blog.example.com/p|🌐 View page>");
+	});
+
+	it("falls back to plain title and no links when unconfigured", async () => {
+		const out = await renderSlackBody(makeDb(baseRows), payload());
+		const text = JSON.parse(out).text;
+		expect(text).toContain("`Hello, world!`");
+		expect(text).not.toContain("Open in admin");
+		expect(text).not.toContain("View page");
+	});
 });
 
 describe("renderDiscordBody", () => {
-	it("returns JSON with a content field", async () => {
+	it("returns JSON with an embeds array", async () => {
 		const out = await renderDiscordBody(makeDb(baseRows), payload());
 		const parsed = JSON.parse(out);
-		expect(typeof parsed.content).toBe("string");
-		expect(parsed.content).toContain("New comment");
-		expect(parsed.content).toContain("Alice");
+		expect(Array.isArray(parsed.embeds)).toBe(true);
+		const embed = parsed.embeds[0];
+		expect(embed.author.name).toBe("Alice");
+		expect(embed.title).toBe("Hello, world!");
+		expect(embed.description).toContain("Hello");
+		expect(typeof embed.color).toBe("number");
+		expect(embed.footer.text).toBe("Garrul");
+		expect(typeof embed.timestamp).toBe("string");
 	});
 
-	it("neutralizes @everyone and @here", async () => {
+	it("uses a distinct accent color per event", async () => {
+		const colors = new Set<number>();
+		for (const event of [
+			"comment.posted",
+			"comment.approved",
+			"comment.spam",
+		] as const) {
+			const out = await renderDiscordBody(makeDb(baseRows), payload({ event }));
+			colors.add(JSON.parse(out).embeds[0].color);
+		}
+		expect(colors.size).toBe(3);
+	});
+
+	it("includes admin + page links when baseUrl and post.url are set", async () => {
+		const rows = {
+			...baseRows,
+			posts: { ...baseRows.posts, url: "https://blog.example.com/p" },
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload(), {
+			baseUrl: "https://comments.example.com",
+		});
+		const embed = JSON.parse(out).embeds[0];
+		expect(embed.url).toBe("https://blog.example.com/p");
+		const links = embed.fields[0].value;
+		expect(links).toContain(
+			"https://comments.example.com/admin/comments/01HC000000000000000000",
+		);
+		expect(links).toContain("https://blog.example.com/p");
+	});
+
+	it("omits links when baseUrl is absent and post.url is null", async () => {
+		const out = await renderDiscordBody(makeDb(baseRows), payload());
+		const embed = JSON.parse(out).embeds[0];
+		expect(embed.url).toBeUndefined();
+		expect(embed.fields).toBeUndefined();
+	});
+
+	it("rejects non-http(s) post urls but keeps the admin link", async () => {
+		const rows = {
+			...baseRows,
+			posts: { ...baseRows.posts, url: "javascript:alert(1)" },
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload(), {
+			baseUrl: "https://c.example.com",
+		});
+		const embed = JSON.parse(out).embeds[0];
+		expect(embed.url).toBeUndefined();
+		const links = embed.fields[0].value;
+		expect(links).not.toContain("javascript:");
+		expect(links).toContain("/admin/comments/");
+	});
+
+	it("defuses masked-link injection in the snippet", async () => {
+		const rows = {
+			...baseRows,
+			comments: {
+				...baseRows.comments,
+				body_md: "[Win a prize](https://evil.example)",
+			},
+		};
+		const out = await renderDiscordBody(makeDb(rows), payload());
+		const desc = JSON.parse(out).embeds[0].description;
+		// Brackets are escaped → Discord renders literal text, not a link.
+		expect(desc).toContain("\\[Win a prize\\]");
+		expect(desc).not.toContain("[Win a prize](");
+	});
+
+	it("neutralizes @everyone and @here in the snippet", async () => {
 		for (const trigger of ["@everyone", "@here"]) {
 			const rows = {
 				...baseRows,
 				comments: { ...baseRows.comments, body_md: `Hey ${trigger} woo` },
 			};
 			const out = await renderDiscordBody(makeDb(rows), payload());
-			const content = JSON.parse(out).content;
-			expect(content).not.toMatch(
-				new RegExp(`(?<![​])${trigger}(?!​)`),
-			);
+			const desc = JSON.parse(out).embeds[0].description;
+			expect(desc).not.toMatch(new RegExp(`(?<![​])${trigger}(?!​)`));
 		}
 	});
 
-	it("neutralizes role and user mentions <@…>", async () => {
+	it("neutralizes role and user mentions <@…> in the snippet", async () => {
 		const rows = {
 			...baseRows,
 			comments: {
@@ -224,19 +318,35 @@ describe("renderDiscordBody", () => {
 			},
 		};
 		const out = await renderDiscordBody(makeDb(rows), payload());
-		const content = JSON.parse(out).content;
-		expect(content).not.toContain("<@123456789012345678>");
-		expect(content).not.toContain("<@&987654321>");
+		const desc = JSON.parse(out).embeds[0].description;
+		expect(desc).not.toContain("<@123456789012345678>");
+		expect(desc).not.toContain("<@&987654321>");
 	});
 
-	it("stays under Discord's 2000-char content cap", async () => {
+	it("only sets an avatar when the user has an https avatar", async () => {
+		const https = {
+			...baseRows,
+			users: { ...baseRows.users, avatar_url: "https://cdn.example/a.png" },
+		};
+		const out = await renderDiscordBody(makeDb(https), payload());
+		expect(JSON.parse(out).embeds[0].author.icon_url).toBe(
+			"https://cdn.example/a.png",
+		);
+		const insecure = {
+			...baseRows,
+			users: { ...baseRows.users, avatar_url: "http://cdn.example/a.png" },
+		};
+		const out2 = await renderDiscordBody(makeDb(insecure), payload());
+		expect(JSON.parse(out2).embeds[0].author.icon_url).toBeUndefined();
+	});
+
+	it("keeps the description under Discord's 4096-char cap", async () => {
 		const rows = {
 			...baseRows,
 			comments: { ...baseRows.comments, body_md: "x".repeat(8000) },
 		};
 		const out = await renderDiscordBody(makeDb(rows), payload());
-		const content = JSON.parse(out).content;
-		expect(content.length).toBeLessThan(2000);
+		expect(JSON.parse(out).embeds[0].description.length).toBeLessThan(4096);
 	});
 
 	it("produces valid JSON for newline + quote-laden bodies", async () => {

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -221,3 +221,96 @@ describe("webhook_deliveries body cap (issue #13)", () => {
 		);
 	});
 });
+
+// D1 stub: one enabled *discord* endpoint plus comment/user/post rows so
+// the adapter's loadContext can build links. Proves the PUBLIC_BASE_URL →
+// dispatch → renderBody → adapter threading actually reaches the wire,
+// not just the typechecker.
+const makeDbForDiscord = () => {
+	const endpointRow = {
+		id: "01HE000000000000000000",
+		url: "https://example.com/hook",
+		secret: null,
+		events: null,
+		adapter: "discord",
+		enabled: 1,
+		fail_count: 0,
+		disabled_at: null,
+		created_at: 0,
+		updated_at: 0,
+	};
+	return {
+		prepare(sql: string) {
+			return {
+				bind() {
+					return this;
+				},
+				async first() {
+					if (sql.includes("FROM comments")) {
+						return {
+							id: "01HC000000000000000000",
+							post_slug: "hello-world",
+							body_md: "Nice post!",
+							status: "approved",
+							user_id: "01HU000000000000000000",
+							created_at: 0,
+						};
+					}
+					if (sql.includes("FROM users")) {
+						return { id: "01HU000000000000000000", name: "Alice", avatar_url: null };
+					}
+					if (sql.includes("FROM posts")) {
+						return {
+							slug: "hello-world",
+							title: "Hello, world!",
+							url: "https://blog.example.com/p",
+							created_at: 0,
+						};
+					}
+					return null;
+				},
+				async all() {
+					if (sql.includes("FROM webhook_endpoints")) {
+						return { results: [endpointRow] };
+					}
+					return { results: [] };
+				},
+				async run() {
+					return {};
+				},
+			};
+		},
+	} as unknown as D1Database;
+};
+
+describe("discord adapter dispatch threads PUBLIC_BASE_URL to the wire", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("POSTs an embed body carrying the admin + page links", async () => {
+		await dispatchWebhook(
+			{
+				DB: makeDbForDiscord(),
+				ENV: "production",
+				PUBLIC_BASE_URL: "https://comments.example.com",
+			},
+			payload,
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(Array.isArray(body.embeds)).toBe(true);
+		const links = body.embeds[0].fields[0].value;
+		expect(links).toContain(
+			"https://comments.example.com/admin/comments/01HC000000000000000000",
+		);
+		expect(links).toContain("https://blog.example.com/p");
+	});
+});


### PR DESCRIPTION
## What & why

Discord comment notifications were plain text with **no links** — a moderator couldn't jump to the comment in the admin panel or open the page it was posted on. This makes the notifications nicer and actionable (navigation only — no moderation-from-Discord, by design).

## Changes

- **Discord → embed.** Replaces the plain `content` string with a single rich embed: commenter as author (+ avatar when an https one exists), post title linked to the page, snippet as the description, an event-colored accent (new = blurple, approved = green, spam/deleted = red, edited = grey), a **Links** field, and a Garrul footer + timestamp.
- **Links on both adapters.** Discord and Slack now carry *🔍 Open in admin* (`/admin/comments/<id>`) and *🌐 View page*. Slack uses `<url|label>` syntax.
- **`PUBLIC_BASE_URL` threaded** into the adapters (via `renderBody` → `dispatchToEndpoint`) to build the admin link.
- **Graceful degradation.** No `PUBLIC_BASE_URL` → admin link omitted, notification still sends. Post with no/invalid `url` → page link omitted.

## Security

The code previously avoided embeds specifically because of markdown/URL injection traps. This PR addresses them head-on:

- The embed **description** escapes `[`/`]` so a comment body like `[click](https://evil)` renders as literal text, not a clickable masked link.
- Existing `@everyone`/role-mention neutralization is retained.
- Every clickable URL is server-generated (admin link) or scheme-validated `http`/`https` only (page/avatar), reusing the `permalink.ts` guard. Slack link labels/URLs are checked for span-breaking chars.

## Tests

- `tests/webhook-adapters.test.ts`: embed shape, per-event color, link presence/omission, non-http(s) URL rejection, masked-link & mention injection, https-only avatar, length caps. Slack link rendering + plain-fallback.
- `tests/webhook.test.ts`: a dispatch-level test proving `PUBLIC_BASE_URL → adapter → wire` (the POSTed body is an embed carrying the admin + page links).
- Full suite: **590 tests pass**; `tsc` clean on both tsconfigs.

## Docs

`docs/webhooks.md` documents the new embed/Slack shapes, the `PUBLIC_BASE_URL` requirement, and the safety notes.

## Out of scope

Moderating from Discord (action links / interactive bot) and anonymous-identicon avatars — possible follow-ups.