### PR TITLE
feat: reader reporting, thread lifecycle, ban-author, draft autosave & community collapse (v1.17.0)

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -169,6 +169,36 @@ out-of-range values clamp, non-numeric values fall back to the default.
 will see **25** initial comments instead of the previous ~100. Set it to `100`
 (env var or Settings page) to restore the old behavior.
 
+### Thread lifecycle & community settings (since v1.17.0)
+
+Four more integers, same hybrid precedence (DB settings row > env var > default)
+and the same server-side clamping. All default to **off**, so an install that
+ignores them behaves exactly as before.
+
+- **Auto-close** — `AUTO_CLOSE_DAYS` (close a thread this many days after its
+  anchor date; `0` = never) and `AUTO_CLOSE_AT` (an epoch-ms sunset that closes
+  **every** thread at/after that instant; `0` = never). Closure is evaluated
+  **lazily** at read/write time — there is no cron and nothing is persisted, so a
+  thread "becomes" closed the moment a request observes the rule. The age anchor
+  is the host page's real publish time when the embed supplies `data-published`
+  (stored as `posts.published_at`); without it Garrul falls back to first-comment
+  time, which is later than real publish, so set `data-published` if you rely on
+  `AUTO_CLOSE_DAYS`. A closed thread hides the composer (the widget shows a
+  reason-specific notice) and the POST endpoint rejects new comments **and
+  replies** with `403 err.thread_closed` — existing comments, reactions, and
+  votes stay live. Per-post manual close (below) overrides nothing here; it's a
+  separate, higher-precedence input to the same resolver.
+- **Community auto-collapse** — `COMMUNITY_COLLAPSE_RATIO` (percent of downvotes,
+  `down/(up+down)`, that folds a comment; `0` = off) gated by
+  `COMMUNITY_MIN_VOTES` (minimum total votes before the ratio applies; default
+  `5`). The floor is the **brigading guard** — without it a single downvote would
+  read as 100% and fold every fresh comment. Collapse is **client-side and
+  cosmetic**: the widget folds the body behind a "show" toggle, the content stays
+  in the payload, and votes stay live so a comment re-expands once its score
+  recovers (on the next render). It's derived in the browser because votes
+  deliberately don't bust the tree cache, so a server flag would be stale against
+  the score the widget already shows. Requires `DOWNVOTES_ENABLED`.
+
 ## 6. `ALLOWED_ORIGINS` deep-dive
 
 The single most common foot-gun. Symptom: the widget mounts but every
@@ -344,6 +374,10 @@ tracked by the `_migrations` table. Current set:
 - `0007_votes.sql` — vote storage + denormalized score counters
 - `0008_saved_replies.sql` — moderator saved replies
 - `0009_import_tracking.sql` — Disqus import idempotency
+- `0010_settings.sql` — DB-backed runtime settings overrides
+- `0011_page_engagement.sql` — page-level reactions + votes
+- `0012_deleted_by.sql` — records who deleted a comment
+- `0013_thread_lifecycle_reports.sql` — per-post close/`published_at` + reader `reports` table
 
 Run with `npm run migrate` (local Miniflare) or
 `npm run migrate -- --remote` (production D1). Idempotent. Never edit a
@@ -373,7 +407,7 @@ Pages (top nav):
 | Path | Purpose |
 | --- | --- |
 | `/admin` | Dashboard: counts, 30-day comments-per-day sparkline, oldest pending, spam-rate, top posts/commenters. |
-| `/admin/queue` | Moderation queue. Status tabs + filter bar (body search, post slug, date range, scoped-by-user). Per-row + bulk actions (Approve/Spam/Delete/Restore). Each row shows author identity (avatar + provider + admin/banned pills) and the latest audit footer. |
+| `/admin/queue` | Moderation queue. Status tabs (incl. a **Reported** tab — comments with open reader reports, with a count badge) + filter bar (body search, post slug, date range, scoped-by-user). Per-row + bulk actions (Approve/Spam/Delete/Restore). When filtered to a single post slug, a **Close / Open comments for this post** toggle appears. Rows also offer one-click **Ban author**. Each row shows author identity (avatar + provider + admin/banned pills) and the latest audit footer. |
 | `/admin/comments/:id` | Single-comment view: parent + replies, raw markdown, spam-verdicts per source, full audit history for that comment, author block with their last 5 comments. |
 | `/admin/users` | User search + ban toggle. |
 | `/admin/users/:id` | User detail: all their comments paginated, reactions received, audit history affecting them, Ban/Unban. |
@@ -391,17 +425,43 @@ responding):
 
 - `POST /admin/api/comments/:id` — `{action: approve|spam|delete|restore, reason?}`
 - `POST /admin/api/comments/bulk` — `{ids: string[], action}` (cap 100)
-- `POST /admin/api/users/:id` — `{banned: boolean, reason?}`
+- `POST /admin/api/comments/:id/reports/resolve` — clears open reader reports on a comment (audited `report.resolve`)
+- `POST /admin/api/posts/close` — `{slug, closed: boolean}` (per-post close/open; audited `post.close` / `post.open`; busts the cached first page)
+- `POST /admin/api/users/:id` — `{banned: boolean, reason?, from_comment?}` (one-click ban-author records the originating comment in audit meta; admin-only)
 - `POST /admin/api/subscriptions/:id` — `{action: unsubscribe|resend, reason?}`
 - `POST /admin/api/ops/rerender` — `{batch?: number, cursor?}` → `{processed, next_cursor}`
 - `POST /admin/api/ops/seed-demo` — disabled when `ENV=production`
+
+**Reader reporting & thread moderation.** Readers can flag a comment
+from the widget (anonymous allowed, no Turnstile — rate-limited by
+network and deduped one-per-network-per-comment, storing only an
+`ip_hash`, never a raw IP). Each new report fires a `comment.reported`
+webhook so operators get a Slack/Discord ping, and the comment surfaces
+in the queue's **Reported** tab with a count badge; the comment detail
+page lists the reasons. Dismiss the flags with **resolve** (the comment
+itself is still actioned with the normal approve/spam/delete buttons).
+Report counts are operator-only — they're never in the public payload,
+so they can't be used as a brigading signal.
+
+Per-post **close** freezes one thread: existing comments, reactions and
+votes stay live, but new comments and replies are rejected server-side
+(`403 err.thread_closed`) regardless of what the widget shows. Closure
+is also driven globally without touching individual posts via
+`AUTO_CLOSE_DAYS` / `AUTO_CLOSE_AT` (see §5) — all evaluated lazily at
+read/write time, no cron, no row migration.
+
+One-click **Ban author** reuses the user-ban mechanism. For an
+anonymous (ghost) author this is a *network-egress* ban keyed on the
+author's `ip_hash`, so behind CGNAT or a shared IP it can catch
+bystanders — the action confirms before banning. The originating
+comment id is recorded in the audit row's `meta.from_comment`.
 
 **Outbound webhooks.** Configured on `/admin/webhooks` (table-backed;
 the legacy `WEBHOOK_URL` env var still works only while no endpoint
 rows exist). Per endpoint: target URL (validated against an SSRF
 blocklist — private IPs, localhost, internal TLDs are rejected),
 optional HMAC secret, event filter (`comment.posted` / `edited` /
-`deleted` / `approved` / `spam`; empty = all), and an adapter that
+`deleted` / `approved` / `spam` / `reported`; empty = all), and an adapter that
 shapes the body (`generic` JSON, `slack`, or `discord` — the chat
 adapters neutralize `@everyone`-style mentions and truncate long
 bodies). Secured endpoints sign every request Stripe-style:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ Every attribute the widget reads from the `#garrul` host element
 | `data-api`   | no       | Worker origin override. Defaults to the origin of the script tag (`<script src>`). Set this explicitly when loading `embed.js` via a bundler or async import (anywhere `document.currentScript` may be null at execution time). |
 | `data-title` | no       | Post title; sent on first comment create, surfaces in admin and notification emails.        |
 | `data-url`   | no       | Canonical permalink; sent on first comment create, used in RSS and notification emails.     |
+| `data-published` | no   | Article publish time (epoch ms or ISO 8601); sent on first comment create. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit and Garrul falls back to the first-comment time, which closes the thread a bit later than intended. Only relevant if the operator enabled `AUTO_CLOSE_DAYS`. |
 
 The host element MUST have `id="garrul"`; the widget looks it up by ID
 and mounts a Shadow DOM on it. One widget per page — multi-thread
@@ -564,8 +565,8 @@ both `data-api` and the `<script src>`.
   the Worker origin so the script's `currentScript.src` correctly
   infers the API base when `data-api` is absent.
 - Don't strip `data-*` attributes in build-step HTML minifiers. The
-  widget reads `data-slug`, `data-api`, `data-title`, and `data-url`
-  off the host element at runtime.
+  widget reads `data-slug`, `data-api`, `data-title`, `data-url`, and
+  `data-published` off the host element at runtime.
 - Don't set `data-api` to a value without `https://`. The widget passes
   it through `new URL(...)` and uses the origin verbatim for CORS-cred
   requests; mixed-content or scheme-relative values will fail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Self-hosted comment system on Cloudflare Workers + D1 + KV + Turnstile. This fil
 - **Database**: Cloudflare D1 (SQLite).
 - **KV**: rate-limits, OAuth state, sessions, tree cache.
 - **Anti-spam**: Cloudflare Turnstile.
-- **Email**: pluggable adapter (Resend default; MailChannels/Postmark adapters available).
+- **Email**: Resend only (`src/lib/email.ts`). The `EMAIL_PROVIDER` env var leaves room for more adapters, but Resend is the sole implementation today (MailChannels dropped its free Workers plan). Additional adapters are future work.
 - **Widget**: vanilla TypeScript, no framework. Built with esbuild. Bundle budget: `embed.js` ≤ 20KB gzipped.
 - **Admin UI**: server-rendered HTML (Hono JSX) + Alpine.js for interactivity.
 - **Tests**: Vitest + Miniflare for in-memory D1/KV.
@@ -21,8 +21,8 @@ src/
   index.ts              # Hono app entry, route mounting
   routes/               # one file per logical surface (api.comments, auth, admin, embed, rss, health)
   db/                   # migrations + typed query wrappers
-  lib/                  # session, markdown, turnstile, ratelimit, oauth, ulid, identicon, ip-hash, webhook, cors, log
-  email/                # adapter interface + per-provider impls
+  lib/                  # session, markdown, turnstile, ratelimit, oauth, ulid, identicon, ip-hash,
+                        #   webhook, webhook-sig, cors, log, settings, thread, email (Resend), disqus-import
   i18n/                 # en.ts string table; t(key) shim
   widget/               # embed.ts (script), iframe.ts, iframe-resizer.ts, styles.css, templates.ts
   admin-ui/             # layout + per-page renderers (server-rendered HTML + Alpine attrs)
@@ -93,7 +93,7 @@ All user-facing strings go through `t(key)` from `src/i18n`. English is the only
 
 ## Out of scope (v2 backlog)
 
-Multi-site/multi-tenant per Worker, real-time updates, image uploads, Disqus/WordPress importers, self-serve account-delete, @mentions, in-comment search, generic OIDC, webhook signing.
+Multi-site/multi-tenant per Worker, real-time updates, image uploads, WordPress importer (Disqus import shipped), self-serve account-delete, @mentions, in-comment search, generic OIDC, per-post custom auto-close schedules (global rule + per-post manual override only), community hide-and-hold (auto-suppress on a downvote threshold — reader reporting + auto-collapse cover the moderation value without auto-suppressing legit content).
 
 ## Domain layout (maintainer's instance)
 

--- a/docs/privacy-policy.template.md
+++ b/docs/privacy-policy.template.md
@@ -68,6 +68,13 @@ We set one cookie, `garrul_sess`, on the comments subdomain
 
 No advertising, analytics, or tracking cookies are set.
 
+## Local browser storage
+
+While you are typing, an unsent comment draft is saved in your own
+browser's `localStorage` so it survives an accidental reload. It never
+leaves your device — it is not sent to us — and it is cleared as soon as
+you submit or cancel the comment.
+
 ## Who sees your data
 
 - **Site moderators** at `[YOUR DOMAIN]` (whose emails are in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.1",
+  "version": "1.17.0",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 1,
@@ -180,6 +180,26 @@
       "name": "AUTO_COLLAPSE_DEPTH",
       "required": false,
       "addedIn": "1.10.0"
+    },
+    {
+      "name": "AUTO_CLOSE_DAYS",
+      "required": false,
+      "addedIn": "1.17.0"
+    },
+    {
+      "name": "AUTO_CLOSE_AT",
+      "required": false,
+      "addedIn": "1.17.0"
+    },
+    {
+      "name": "COMMUNITY_MIN_VOTES",
+      "required": false,
+      "addedIn": "1.17.0"
+    },
+    {
+      "name": "COMMUNITY_COLLAPSE_RATIO",
+      "required": false,
+      "addedIn": "1.17.0"
     }
   ],
   "kvNamespaces": [
@@ -232,7 +252,8 @@
     "0009_import_tracking.sql",
     "0010_settings.sql",
     "0011_page_engagement.sql",
-    "0012_deleted_by.sql"
+    "0012_deleted_by.sql",
+    "0013_thread_lifecycle_reports.sql"
   ],
   "breakingChanges": []
 }

--- a/src/admin-ui/escape.ts
+++ b/src/admin-ui/escape.ts
@@ -7,3 +7,21 @@ export const escapeHtml = (s: string | null | undefined): string => {
 		.replace(/"/g, "&quot;")
 		.replace(/'/g, "&#39;");
 };
+
+// Embed values as code-safe, HTML-escaped JS string literals so the resulting
+// Alpine expression is well-formed and injection-proof regardless of the
+// underlying string content (defense in depth: ULIDs are safe today, but the
+// typing is just `string`).
+//
+// JSON.stringify alone is not enough: it leaves `<`, `>`, `/` and the line
+// separators U+2028/U+2029 raw, which are unsafe once the literal is embedded
+// as executable JS (markup-context breakout / older-JS line terminators). We
+// re-encode those as `\uXXXX` escapes — valid inside a JS string and inert —
+// then escapeHtml for the surrounding double-quoted attribute.
+export const jsLiteral = (s: string): string =>
+	escapeHtml(
+		JSON.stringify(s).replace(
+			/[<>\/\u2028\u2029]/g,
+			(c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`,
+		),
+	);

--- a/src/admin-ui/pages/comment-detail.ts
+++ b/src/admin-ui/pages/comment-detail.ts
@@ -3,11 +3,12 @@ import type {
 	AdminCommentDetail,
 	AuditRowWithAdmin,
 	CommentStatus,
+	Report,
 	SpamVerdictRow,
 } from "../../db/queries";
 import { identiconSvg } from "../../lib/identicon";
 import { sanitizeForEmail as resanitizeBodyHtml } from "../../lib/markdown";
-import { escapeHtml } from "../escape";
+import { escapeHtml, jsLiteral } from "../escape";
 
 const formatTs = (ts: number): string =>
 	new Date(ts).toISOString().slice(0, 16).replace("T", " ");
@@ -77,6 +78,60 @@ const verdictsSection = (verdicts: SpamVerdictRow[]): string => {
 </div>`;
 };
 
+/**
+ * Reader reports for the selected comment. Reasons are free-text from
+ * (possibly anonymous) reporters, so they're escaped here. Reporter identity
+ * (ip_hash / user_id) is intentionally NOT shown — operators act on the
+ * content, not the reporter, and exposing the hash adds no moderation value.
+ * "Dismiss reports" resolves every OPEN report on the comment in one click.
+ */
+const reportsSection = (commentId: string, reports: Report[]): string => {
+	if (reports.length === 0) return "";
+	const open = reports.filter((r) => r.status === "open");
+	const rows = reports
+		.map(
+			(r) => `
+<tr>
+  <td><span class="pill ${r.status === "open" ? "pending" : "approved"}">${r.status}</span></td>
+  <td class="muted">${formatTs(r.created_at)}</td>
+  <td class="row-body">${r.reason ? escapeHtml(r.reason) : '<span class="muted">(no reason given)</span>'}</td>
+</tr>`,
+		)
+		.join("");
+	const dismiss =
+		open.length > 0
+			? `
+  <div class="actions" style="margin-top:0.5rem"
+       x-data="{ busy: false,
+         resolve() {
+           this.busy = true;
+           return fetch('/admin/api/comments/${escapeHtml(commentId)}/reports/resolve', {
+             method: 'POST',
+             headers: { 'content-type': 'application/json' },
+             body: '{}',
+           }).then(r => {
+             if (!r.ok) throw new Error('action failed: ' + r.status);
+             this.$dispatch('toast', { text: 'Reports dismissed' });
+             setTimeout(() => location.reload(), 600);
+           }).catch(e => {
+             this.$dispatch('toast', { text: e.message, kind: 'bad' });
+           }).finally(() => { this.busy = false; });
+         }
+       }">
+    <button :disabled="busy" @click="resolve()">Dismiss reports</button>
+  </div>`
+			: "";
+	return `
+<div class="card">
+  <h3>Reader reports (${open.length} open / ${reports.length} total)</h3>
+  <table>
+    <thead><tr><th>Status</th><th>When</th><th>Reason</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+  ${dismiss}
+</div>`;
+};
+
 const auditSection = (rows: AuditRowWithAdmin[], title: string): string => {
 	if (rows.length === 0) return "";
 	const trs = rows
@@ -100,6 +155,44 @@ const auditSection = (rows: AuditRowWithAdmin[], title: string): string => {
 </div>`;
 };
 
+/**
+ * One-click "Ban author" — reuses POST /admin/api/users/:id { banned } with the
+ * comment's author and records the originating comment in the audit meta.
+ * Admin-only (the ban route is admin-gated). For anonymous (ghost) authors a
+ * ban blocks the hashed IP, i.e. the whole network egress — behind CGNAT or a
+ * shared IP that can catch bystanders, so the confirm copy spells that out.
+ */
+const banAuthorAction = (c: AdminComment, isAdmin: boolean): string => {
+	if (!isAdmin) return "";
+	if (c.author_is_banned) {
+		return `<div class="muted" style="margin-top:0.5rem">Author is already banned.</div>`;
+	}
+	const isAnon = (c.author_provider ?? "anon") === "anon";
+	const warning = isAnon
+		? "Ban this anonymous author? This blocks their hashed IP (the whole network egress) — behind shared IPs/CGNAT it can also block bystanders. Continue?"
+		: "Ban this author? They will no longer be able to comment. Continue?";
+	return `
+<div class="actions" style="margin-top:0.5rem" x-data="{ busy: false,
+  ban() {
+    if (!confirm(${jsLiteral(warning)})) return;
+    this.busy = true;
+    return fetch('/admin/api/users/${escapeHtml(c.user_id)}', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ banned: true, from_comment: ${jsLiteral(c.id)} }),
+    }).then(r => {
+      if (!r.ok) throw new Error('ban failed: ' + r.status);
+      this.$dispatch('toast', { text: 'Author banned' });
+      setTimeout(() => location.reload(), 600);
+    }).catch(e => {
+      this.$dispatch('toast', { text: e.message, kind: 'bad' });
+    }).finally(() => { this.busy = false; });
+  }
+}">
+  <button class="bad" :disabled="busy" @click="ban()">Ban author</button>
+</div>`;
+};
+
 const actionsFor = (status: CommentStatus): string => {
 	const parts: string[] = [];
 	if (status !== "approved")
@@ -117,8 +210,11 @@ const actionsFor = (status: CommentStatus): string => {
 	return parts.join("");
 };
 
-export const renderCommentDetail = (d: AdminCommentDetail): string => {
-	const { comment, parent, replies, ip_siblings, user_recent, verdicts, audit } = d;
+export const renderCommentDetail = (
+	d: AdminCommentDetail,
+	isAdmin = false,
+): string => {
+	const { comment, parent, replies, ip_siblings, user_recent, verdicts, reports, audit } = d;
 	const parentSection = parent
 		? `<div class="card">${commentCard(parent, "Parent")}</div>`
 		: "";
@@ -168,6 +264,7 @@ export const renderCommentDetail = (d: AdminCommentDetail): string => {
   <h2>Comment</h2>
   ${commentCard(comment, "Selected")}
   <div class="actions" style="margin-top:0.5rem">${actionsFor(comment.status)}</div>
+  ${banAuthorAction(comment, isAdmin)}
 </div>
 
 <div class="card">
@@ -175,6 +272,7 @@ export const renderCommentDetail = (d: AdminCommentDetail): string => {
   <pre style="white-space:pre-wrap;font-size:0.85rem">${escapeHtml(comment.body_md)}</pre>
 </div>
 
+${reportsSection(comment.id, reports)}
 ${verdictsSection(verdicts)}
 ${parentSection}
 ${repliesSection}

--- a/src/admin-ui/pages/queue.ts
+++ b/src/admin-ui/pages/queue.ts
@@ -197,9 +197,19 @@ export const renderQueue = (
 		filters.to ||
 		filters.host ||
 		filters.reported;
+	// Submitting the filter form (or clearing) must keep the active tab. The
+	// reported view is its own dimension, so carry it through as a hidden field
+	// and point "clear" back at it; otherwise the form would silently drop the
+	// user out of the reported tab and into the status view.
+	const tabHidden = filters.reported
+		? `<input type="hidden" name="reported" value="1">`
+		: `<input type="hidden" name="status" value="${escapeHtml(filters.status)}">`;
+	const clearHref = filters.reported
+		? "/admin/queue?reported=1"
+		: `/admin/queue?status=${escapeHtml(filters.status)}`;
 	const filterBar = `
 <form class="filter-bar queue-filter" method="get" action="/admin/queue">
-  <input type="hidden" name="status" value="${escapeHtml(filters.status)}">
+  ${tabHidden}
   <input type="text" name="q" placeholder="search body" value="${escapeHtml(filters.q)}">
   <input type="text" name="post_slug" placeholder="post slug" value="${escapeHtml(filters.post_slug)}">
   ${renderHostFilter({ hosts, selected: filters.host })}
@@ -207,7 +217,7 @@ export const renderQueue = (
   <input type="date" name="to" value="${escapeHtml(filters.to)}" title="to (UTC, inclusive)">
   ${filters.user_id ? `<input type="hidden" name="user_id" value="${escapeHtml(filters.user_id)}"><span class="muted">user: <code>${escapeHtml(filters.user_id)}</code></span>` : ""}
   <button type="submit">Filter</button>
-  ${hasFilters ? `<a href="/admin/queue?status=${escapeHtml(filters.status)}" class="muted">clear</a>` : ""}
+  ${hasFilters ? `<a href="${clearHref}" class="muted">clear</a>` : ""}
 </form>`;
 
 	// Per-post freeze toggle. Only meaningful when the queue is scoped to one

--- a/src/admin-ui/pages/queue.ts
+++ b/src/admin-ui/pages/queue.ts
@@ -6,7 +6,7 @@ import type {
 import { identiconSvg } from "../../lib/identicon";
 import { sanitizeForEmail as resanitizeBodyHtml } from "../../lib/markdown";
 import { renderHostFilter } from "../components/host-filter";
-import { escapeHtml } from "../escape";
+import { escapeHtml, jsLiteral } from "../escape";
 
 const relTime = (ts: number, now: number = Date.now()): string => {
 	const diff = Math.max(0, now - ts);
@@ -25,6 +25,12 @@ const auditStrip = (a: AuditRowWithAdmin | undefined): string => {
 	return `<div class="muted audit-strip">${escapeHtml(a.action)} by ${escapeHtml(who)} · ${relTime(a.created_at)}</div>`;
 };
 
+/** Open-report count badge for a queue row. Empty string when zero. */
+const reportBadge = (n: number): string =>
+	n > 0
+		? ` <span class="pill spam" title="${n} open report${n === 1 ? "" : "s"}">⚑ ${n}</span>`
+		: "";
+
 export type QueueFilters = {
 	status: CommentStatus | "all";
 	q: string;
@@ -33,11 +39,14 @@ export type QueueFilters = {
 	from: string;
 	to: string;
 	host: string;
+	/** The cross-status "reported" view (comments with open reader reports). */
+	reported: boolean;
 };
 
 const queryString = (f: QueueFilters): string => {
 	const params = new URLSearchParams();
-	if (f.status !== "pending") params.set("status", f.status);
+	if (f.reported) params.set("reported", "1");
+	else if (f.status !== "pending") params.set("status", f.status);
 	if (f.q) params.set("q", f.q);
 	if (f.post_slug) params.set("post_slug", f.post_slug);
 	if (f.user_id) params.set("user_id", f.user_id);
@@ -111,24 +120,6 @@ const metaCell = (c: AdminComment): string => {
           @click="navigator.clipboard.writeText(${jsLiteral(c.id)}); $dispatch('toast',{text:'ID copied'})">${escapeHtml(c.id)}</span>`;
 };
 
-// Embed values as code-safe, HTML-escaped JS string literals so the resulting
-// Alpine expression is well-formed and injection-proof regardless of the
-// underlying string content (defense in depth: ULIDs are safe today, but the
-// typing is just `string`).
-//
-// JSON.stringify alone is not enough: it leaves `<`, `>`, `/` and the line
-// separators U+2028/U+2029 raw, which are unsafe once the literal is embedded
-// as executable JS (markup-context breakout / older-JS line terminators). We
-// re-encode those as `\uXXXX` escapes — valid inside a JS string and inert —
-// then escapeHtml for the surrounding double-quoted attribute.
-const jsLiteral = (s: string): string =>
-	escapeHtml(
-		JSON.stringify(s).replace(
-			/[<>\/\u2028\u2029]/g,
-			(c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`,
-		),
-	);
-
 const rowAct = (
 	id: string,
 	action: "approve" | "spam" | "delete",
@@ -164,22 +155,39 @@ const actionButtons = (id: string, status: CommentStatus): string => {
 	return parts.join("");
 };
 
+/**
+ * Per-post comment-lifecycle state, surfaced only when the queue is filtered
+ * down to a single post_slug. Drives the "Close / Open comments" toggle.
+ */
+export type PostLifecycle = { slug: string; closed: boolean };
+
 export const renderQueue = (
 	rows: AdminComment[],
 	filters: QueueFilters,
 	nextCursor: string | null,
 	latestAudit: Map<string, AuditRowWithAdmin> = new Map(),
 	hosts: string[] = [],
+	post: PostLifecycle | null = null,
+	reportCounts: Record<string, number> = {},
 ): string => {
-	const tabs = ["all", "approved", "pending", "spam", "deleted"]
+	const statusTabs = ["all", "approved", "pending", "spam", "deleted"]
 		.map((s) => {
 			// Status tabs preserve every other active filter — clicking
 			// "spam" while a search is active should keep the search.
-			const tabFilters = { ...filters, status: s as QueueFilters["status"] };
+			const tabFilters = {
+				...filters,
+				reported: false,
+				status: s as QueueFilters["status"],
+			};
 			const href = `/admin/queue${queryString(tabFilters)}`;
-			return `<a href="${href}" ${s === filters.status ? 'style="font-weight:600"' : ""}>${s}</a>`;
+			const active = !filters.reported && s === filters.status;
+			return `<a href="${href}" ${active ? 'style="font-weight:600"' : ""}>${s}</a>`;
 		})
 		.join(" · ");
+	// Cross-status "reported" tab — its own filter dimension, not a status.
+	const reportedHref = `/admin/queue${queryString({ ...filters, reported: true })}`;
+	const reportedTab = `<a href="${reportedHref}" ${filters.reported ? 'style="font-weight:600"' : ""}>reported</a>`;
+	const tabs = `${statusTabs} · ${reportedTab}`;
 
 	const hasFilters =
 		filters.q ||
@@ -187,7 +195,8 @@ export const renderQueue = (
 		filters.user_id ||
 		filters.from ||
 		filters.to ||
-		filters.host;
+		filters.host ||
+		filters.reported;
 	const filterBar = `
 <form class="filter-bar queue-filter" method="get" action="/admin/queue">
   <input type="hidden" name="status" value="${escapeHtml(filters.status)}">
@@ -201,6 +210,35 @@ export const renderQueue = (
   ${hasFilters ? `<a href="/admin/queue?status=${escapeHtml(filters.status)}" class="muted">clear</a>` : ""}
 </form>`;
 
+	// Per-post freeze toggle. Only meaningful when the queue is scoped to one
+	// post (a global flag/auto-close still applies on top of this; this controls
+	// only the manual per-post `closed` column). Mod-gated server-side.
+	const lifecycleBar = post
+		? `
+<div class="filter-bar post-lifecycle" x-data="{ closed: ${post.closed ? "true" : "false"}, busy: false,
+  async toggle() {
+    this.busy = true;
+    try {
+      const r = await fetch('/admin/api/posts/close', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ slug: ${jsLiteral(post.slug)}, closed: !this.closed }),
+      });
+      if (!r.ok) { const j = await r.json().catch(() => ({})); throw new Error(j.error || ('Failed: ' + r.status)); }
+      const j = await r.json();
+      this.closed = !!j.closed;
+      this.$dispatch('toast', { text: this.closed ? 'Comments closed for this thread' : 'Comments reopened for this thread' });
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Action failed', kind: 'bad' });
+    } finally { this.busy = false; }
+  }
+}">
+  <span class="muted">thread <code>${escapeHtml(post.slug)}</code>:</span>
+  <span class="pill" :class="closed ? 'spam' : 'approved'" x-text="closed ? 'closed' : 'open'"></span>
+  <button :disabled="busy" @click="toggle()" x-text="closed ? 'Open comments' : 'Close comments'"></button>
+</div>`
+		: "";
+
 	const rowsHtml = rows.length
 		? rows
 				.map(
@@ -209,7 +247,7 @@ export const renderQueue = (
     x-show="!gone" x-transition.opacity
     @bulk-done.window="if ($event.detail.ids.includes(${jsLiteral(c.id)})) gone = true">
   <td class="bulk-cell"><input type="checkbox" :value="${jsLiteral(c.id)}" x-model="selected" :disabled="busy"></td>
-  <td><span class="pill ${c.status}">${c.status}</span></td>
+  <td><span class="pill ${c.status}">${c.status}</span>${reportBadge(reportCounts[c.id] ?? 0)}</td>
   <td>${authorCell(c)}</td>
   <td class="score-cell" title="up / down">${scoreCell(c)}</td>
   <td class="meta-cell">${metaCell(c)}</td>
@@ -236,6 +274,7 @@ export const renderQueue = (
 	return `
 <div class="filter-bar"><span class="muted">filter:</span> ${tabs}</div>
 ${filterBar}
+${lifecycleBar}
 <div x-data="{
   open: false,
   commentId: null,

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -14,6 +14,7 @@ import { escapeHtml } from "../escape";
 const TABS = [
 	{ id: "features", label: "Features" },
 	{ id: "display", label: "Display" },
+	{ id: "moderation", label: "Moderation" },
 	{ id: "config", label: "Configuration" },
 ];
 
@@ -78,6 +79,27 @@ const NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
 	},
 ];
 
+// Moderation-tab steppers. auto_close_at is NOT here — it's an epoch instant
+// rendered with a date picker (raw epoch ms is unusable in a stepper); see the
+// auto-close card below.
+const MOD_NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
+	{
+		key: "auto_close_days",
+		label: "Auto-close after (days)",
+		help: "Close a thread to new comments this many days after the article's publish date (or, if the host page doesn't send one, the first comment's date). 0 = never auto-close by age. Existing comments stay visible.",
+	},
+	{
+		key: "community_min_votes",
+		label: "Auto-collapse: minimum votes",
+		help: "A comment needs at least this many total votes before the downvote ratio can collapse it. Guards new comments from being folded by a single downvote. Ignored when the ratio below is 0.",
+	},
+	{
+		key: "community_collapse_ratio",
+		label: "Auto-collapse: downvote %",
+		help: "Fold a comment (readers can still expand it) once this percent of its votes are downvotes and it has met the minimum above. 0 = never auto-collapse. Needs downvotes enabled.",
+	},
+];
+
 export const renderSettings = (
 	env: Bindings,
 	flags: ResolvedFlags,
@@ -129,7 +151,7 @@ export const renderSettings = (
 
 	// Numeric display settings. Each stepper reflects the resolved effective
 	// value; min/max mirror the server-side clamp (numberBounds).
-	const numberInputs = NUMBER_META.map((f) => {
+	const stepper = (f: { key: NumberKey; label: string; help: string }) => {
 		const b = numberBounds(f.key);
 		return renderStepper({
 			name: f.key,
@@ -139,14 +161,16 @@ export const renderSettings = (
 			label: f.label,
 			help: f.help,
 		});
-	}).join("");
+	};
+	const numberInputs = NUMBER_META.map(stepper).join("");
+	const modNumberInputs = MOD_NUMBER_META.map(stepper).join("");
 
 	const initial = JSON.stringify(
 		Object.fromEntries(FLAG_META.map((f) => [f.key, flags[f.key]])),
 	);
-	const numInitial = JSON.stringify(
-		Object.fromEntries(NUMBER_META.map((f) => [f.key, numbers[f.key]])),
-	);
+	// Seed the whole resolved numbers object so keys surfaced as non-stepper
+	// controls (auto_close_at, via the date picker) round-trip on save too.
+	const numInitial = JSON.stringify(numbers);
 
 	return `
 <div x-data="{
@@ -154,6 +178,18 @@ export const renderSettings = (
   busy: false,
   flags: ${escapeHtml(initial)},
   nums: ${escapeHtml(numInitial)},
+  // Friendly proxy over the epoch-ms auto_close_at: the date picker reads/writes
+  // a YYYY-MM-DD string; the canonical value stays the number in nums. Empty
+  // string clears it to 0 (disabled). End-of-day UTC so the chosen date is fully
+  // included before the sunset trips.
+  get autoCloseDate() {
+    return this.nums.auto_close_at
+      ? new Date(this.nums.auto_close_at).toISOString().slice(0, 10)
+      : '';
+  },
+  set autoCloseDate(v) {
+    this.nums.auto_close_at = v ? Date.parse(v + 'T23:59:59Z') : 0;
+  },
   async save() {
     this.busy = true;
     try {
@@ -212,6 +248,34 @@ export const renderSettings = (
       replies collapse. Smaller values keep a busy thread from pushing the rest
       of the page down.</p>
       ${numberInputs}
+    </div>
+
+    <div class="card" x-show="tab === 'moderation'" x-cloak>
+      <h2>Moderation</h2>
+      <p class="muted">Thread auto-close and community auto-collapse. All off by
+      default. Closing a thread only blocks <em>new</em> comments — existing ones
+      stay visible and votes/reactions stay live. Auto-collapse just folds
+      heavily-downvoted comments; readers can still expand them.</p>
+      ${modNumberInputs}
+      <div class="field-row">
+        <span class="field-control">
+          <input type="date" x-model="autoCloseDate">
+          <button type="button" class="secondary" @click="autoCloseDate = ''"
+                  x-show="nums.auto_close_at">Clear</button>
+        </span>
+        <span class="field-text">
+          <strong>Close all threads on</strong>
+          <span class="muted">Instance-wide sunset: once this date passes, no
+          thread accepts new comments. Leave empty to disable. Takes effect
+          within a few minutes of the date passing.</span>
+        </span>
+      </div>
+      <!-- Canonical epoch-ms value for auto_close_at; the date picker above is a
+           proxy over it. Kept as the named number input so it saves like every
+           other numeric setting. -->
+      <input type="hidden" name="auto_close_at" x-model.number="nums.auto_close_at"
+             min="${numberBounds("auto_close_at").min}"
+             max="${numberBounds("auto_close_at").max}">
     </div>
 
     <p class="settings-actions" x-show="tab !== 'config'">

--- a/src/admin-ui/pages/webhooks.ts
+++ b/src/admin-ui/pages/webhooks.ts
@@ -10,6 +10,7 @@ const ALL_EVENTS = [
 	"comment.deleted",
 	"comment.approved",
 	"comment.spam",
+	"comment.reported",
 ] as const;
 
 const ADAPTERS: Array<{ value: string; label: string }> = [

--- a/src/db/migrations/0013_thread_lifecycle_reports.sql
+++ b/src/db/migrations/0013_thread_lifecycle_reports.sql
@@ -1,0 +1,37 @@
+-- Thread lifecycle + reader reporting.
+--
+-- 1) Per-post comment closing. `closed` is an operator-set freeze for a single
+--    thread; `published_at` is the host page's real publish time (epoch ms),
+--    supplied via the widget's data-published attribute. The auto-close rule
+--    (see src/lib/settings.ts / src/lib/thread.ts) anchors relative age on
+--    published_at, falling back to posts.created_at — note that created_at is
+--    "when the first comment arrived" (posts are created lazily on first
+--    comment in upsertPost), NOT when the article was published, so the
+--    published_at anchor is what makes age-based closing accurate.
+--
+--    Both are evaluated LAZILY at read/write time (no cron, no status flips,
+--    no KV writes). Closing blocks new comments/replies only; existing
+--    comments stay visible and reactions/votes stay live.
+--
+-- 2) Reader reporting. A `reports` row is one reader flagging one comment.
+--    reporter_ip_hash is the HMAC hash (never a raw IP, per the IP-handling
+--    convention) used for both rate-limit dedup and the UNIQUE guard so a
+--    single network can't report-bomb the same comment. status is
+--    'open' | 'resolved'; a moderator dismissing the reports flips them to
+--    'resolved' without necessarily acting on the comment itself.
+
+ALTER TABLE posts ADD COLUMN closed INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE posts ADD COLUMN published_at INTEGER;
+
+CREATE TABLE IF NOT EXISTS reports (
+	id               TEXT PRIMARY KEY,
+	comment_id       TEXT NOT NULL REFERENCES comments(id),
+	reporter_user_id TEXT REFERENCES users(id),
+	reporter_ip_hash TEXT,
+	reason           TEXT,
+	status           TEXT NOT NULL DEFAULT 'open',
+	created_at       INTEGER NOT NULL,
+	UNIQUE (comment_id, reporter_ip_hash)
+);
+CREATE INDEX IF NOT EXISTS reports_comment_idx ON reports(comment_id, status);
+CREATE INDEX IF NOT EXISTS reports_status_idx  ON reports(status, created_at);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -186,9 +186,14 @@ export const insertReport = async (
 ): Promise<boolean> => {
 	const res = await db
 		.prepare(
-			`INSERT OR IGNORE INTO reports
+			// Scope the silent ignore to the intended dedup conflict only.
+			// A bare INSERT OR IGNORE would also swallow e.g. a foreign-key
+			// violation as a benign 0-change "duplicate"; ON CONFLICT on the
+			// unique pair lets any other error throw instead.
+			`INSERT INTO reports
 			   (id, comment_id, reporter_user_id, reporter_ip_hash, reason, status, created_at)
-			 VALUES (?, ?, ?, ?, ?, 'open', ?)`,
+			 VALUES (?, ?, ?, ?, ?, 'open', ?)
+			 ON CONFLICT(comment_id, reporter_ip_hash) DO NOTHING`,
 		)
 		.bind(
 			ulid(),
@@ -199,8 +204,8 @@ export const insertReport = async (
 			Date.now(),
 		)
 		.run();
-	// D1 surfaces the affected-row count on meta.changes; INSERT OR IGNORE that
-	// hits the UNIQUE constraint reports 0.
+	// D1 surfaces the affected-row count on meta.changes; the ON CONFLICT
+	// DO NOTHING path (this reporter already flagged this comment) reports 0.
 	return (res.meta?.changes ?? 0) > 0;
 };
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -106,8 +106,12 @@ export const upsertPost = async (
 	publishedAt: number | null = null,
 ): Promise<Post> => {
 	const now = Date.now();
-	// COALESCE so a later comment that omits these can't clobber an existing
-	// title/url/published_at; closed is operator-controlled and never set here.
+	// title/url: COALESCE(excluded, existing) so the host can refresh them on a
+	// later comment, but an omitted value never clobbers what's stored.
+	// published_at: COALESCE(existing, excluded) — write-once / first-writer-wins.
+	// It anchors age-based auto-close, so once set it must be immutable; otherwise
+	// an untrusted client could overwrite an established thread's close-anchor with
+	// a bogus date to force it closed. closed is operator-controlled, never set here.
 	await db
 		.prepare(
 			`INSERT INTO posts (slug, title, url, created_at, published_at)
@@ -115,7 +119,7 @@ export const upsertPost = async (
 			 ON CONFLICT(slug) DO UPDATE SET
 			   title        = COALESCE(excluded.title, posts.title),
 			   url          = COALESCE(excluded.url,   posts.url),
-			   published_at = COALESCE(excluded.published_at, posts.published_at)`,
+			   published_at = COALESCE(posts.published_at, excluded.published_at)`,
 		)
 		.bind(slug, title, url, now, publishedAt)
 		.run();

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -24,7 +24,23 @@ export type Post = {
 	title: string | null;
 	url: string | null;
 	created_at: number;
+	/** Operator freeze for this one thread: blocks new comments/replies. */
+	closed: boolean;
+	/** Host page's real publish time (epoch ms), from data-published. The
+	 *  anchor for age-based auto-close; NULL falls back to created_at. */
+	published_at: number | null;
 };
+
+type PostRow = Omit<Post, "closed"> & { closed: number };
+
+const toPost = (row: PostRow): Post => ({
+	...row,
+	closed: row.closed === 1,
+});
+
+// Every posts SELECT goes through this list so the new lifecycle columns stay
+// in one place.
+const POST_COLS = "slug, title, url, created_at, closed, published_at";
 
 export type UserRole = "user" | "mod" | "admin";
 
@@ -87,34 +103,153 @@ export const upsertPost = async (
 	slug: string,
 	title: string | null,
 	url: string | null,
+	publishedAt: number | null = null,
 ): Promise<Post> => {
 	const now = Date.now();
+	// COALESCE so a later comment that omits these can't clobber an existing
+	// title/url/published_at; closed is operator-controlled and never set here.
 	await db
 		.prepare(
-			`INSERT INTO posts (slug, title, url, created_at)
-			 VALUES (?, ?, ?, ?)
+			`INSERT INTO posts (slug, title, url, created_at, published_at)
+			 VALUES (?, ?, ?, ?, ?)
 			 ON CONFLICT(slug) DO UPDATE SET
-			   title = COALESCE(excluded.title, posts.title),
-			   url   = COALESCE(excluded.url,   posts.url)`,
+			   title        = COALESCE(excluded.title, posts.title),
+			   url          = COALESCE(excluded.url,   posts.url),
+			   published_at = COALESCE(excluded.published_at, posts.published_at)`,
 		)
-		.bind(slug, title, url, now)
+		.bind(slug, title, url, now, publishedAt)
 		.run();
 	const row = await db
-		.prepare(`SELECT slug, title, url, created_at FROM posts WHERE slug = ?`)
+		.prepare(`SELECT ${POST_COLS} FROM posts WHERE slug = ?`)
 		.bind(slug)
-		.first<Post>();
+		.first<PostRow>();
 	if (!row) throw new Error("upsertPost: post not found after insert");
-	return row;
+	return toPost(row);
 };
 
 export const getPost = async (
 	db: D1Database,
 	slug: string,
 ): Promise<Post | null> => {
-	return await db
-		.prepare(`SELECT slug, title, url, created_at FROM posts WHERE slug = ?`)
+	const row = await db
+		.prepare(`SELECT ${POST_COLS} FROM posts WHERE slug = ?`)
 		.bind(slug)
-		.first<Post>();
+		.first<PostRow>();
+	return row ? toPost(row) : null;
+};
+
+/** Operator freeze/unfreeze of a single thread. */
+export const setPostClosed = async (
+	db: D1Database,
+	slug: string,
+	closed: boolean,
+): Promise<void> => {
+	await db
+		.prepare(`UPDATE posts SET closed = ? WHERE slug = ?`)
+		.bind(closed ? 1 : 0, slug)
+		.run();
+};
+
+// ---------------------------------------------------------------------------
+// Reader reports
+// ---------------------------------------------------------------------------
+
+export type Report = {
+	id: string;
+	comment_id: string;
+	reporter_user_id: string | null;
+	reporter_ip_hash: string | null;
+	reason: string | null;
+	status: "open" | "resolved";
+	created_at: number;
+};
+
+/**
+ * Record a reader's report of a comment. Returns true if a new report row was
+ * created, false if this reporter (by ip_hash) had already reported this
+ * comment — the UNIQUE(comment_id, reporter_ip_hash) makes the second attempt a
+ * silent no-op so the caller can return the same {ok:true} either way without
+ * leaking prior-report state.
+ */
+export const insertReport = async (
+	db: D1Database,
+	args: {
+		comment_id: string;
+		reporter_user_id?: string | null;
+		reporter_ip_hash?: string | null;
+		reason?: string | null;
+	},
+): Promise<boolean> => {
+	const res = await db
+		.prepare(
+			`INSERT OR IGNORE INTO reports
+			   (id, comment_id, reporter_user_id, reporter_ip_hash, reason, status, created_at)
+			 VALUES (?, ?, ?, ?, ?, 'open', ?)`,
+		)
+		.bind(
+			ulid(),
+			args.comment_id,
+			args.reporter_user_id ?? null,
+			args.reporter_ip_hash ?? null,
+			args.reason ?? null,
+			Date.now(),
+		)
+		.run();
+	// D1 surfaces the affected-row count on meta.changes; INSERT OR IGNORE that
+	// hits the UNIQUE constraint reports 0.
+	return (res.meta?.changes ?? 0) > 0;
+};
+
+/** Open-report counts for a set of comment IDs (queue badges). Empty → {}. */
+export const countOpenReportsByComment = async (
+	db: D1Database,
+	commentIds: string[],
+): Promise<Record<string, number>> => {
+	if (commentIds.length === 0) return {};
+	const placeholders = commentIds.map(() => "?").join(",");
+	const rows = await db
+		.prepare(
+			`SELECT comment_id, COUNT(*) AS n
+			   FROM reports
+			  WHERE status = 'open' AND comment_id IN (${placeholders})
+			  GROUP BY comment_id`,
+		)
+		.bind(...commentIds)
+		.all<{ comment_id: string; n: number }>();
+	const out: Record<string, number> = {};
+	for (const r of rows.results ?? []) out[r.comment_id] = r.n;
+	return out;
+};
+
+/** Full report list for one comment (comment-detail page). */
+export const listReportsForComment = async (
+	db: D1Database,
+	commentId: string,
+): Promise<Report[]> => {
+	const rows = await db
+		.prepare(
+			`SELECT id, comment_id, reporter_user_id, reporter_ip_hash, reason,
+			        status, created_at
+			   FROM reports WHERE comment_id = ? ORDER BY created_at DESC`,
+		)
+		.bind(commentId)
+		.all<Report>();
+	return rows.results ?? [];
+};
+
+/** Resolve (dismiss) all open reports on a comment. Returns rows affected. */
+export const resolveReportsForComment = async (
+	db: D1Database,
+	commentId: string,
+): Promise<number> => {
+	const res = await db
+		.prepare(
+			`UPDATE reports SET status = 'resolved'
+			  WHERE comment_id = ? AND status = 'open'`,
+		)
+		.bind(commentId)
+		.run();
+	return res.meta?.changes ?? 0;
 };
 
 /**
@@ -892,6 +1027,8 @@ export type AdminCommentFilter = {
 	from?: number;
 	to?: number;
 	host?: string;
+	/** Restrict to comments that have at least one OPEN reader report. */
+	reported?: boolean;
 };
 
 export const adminListComments = async (
@@ -936,6 +1073,11 @@ export const adminListComments = async (
 	if (filter.host) {
 		where.push(`${hostExpr("p.url")} = ?`);
 		binds.push(filter.host);
+	}
+	if (filter.reported) {
+		where.push(
+			"EXISTS (SELECT 1 FROM reports r WHERE r.comment_id = c.id AND r.status = 'open')",
+		);
 	}
 
 	const sql = `
@@ -1459,6 +1601,7 @@ export type AuditTargetKind =
 	| "subscription"
 	| "webhook"
 	| "saved_reply"
+	| "post"
 	| "system";
 
 export const ADMIN_ACTIONS = [
@@ -1490,6 +1633,9 @@ export const ADMIN_ACTIONS = [
 	"saved_reply.post",
 	"import.disqus",
 	"settings.update",
+	"post.close",
+	"post.open",
+	"report.resolve",
 ] as const;
 export type AdminAction = (typeof ADMIN_ACTIONS)[number];
 
@@ -1925,6 +2071,7 @@ export type AdminCommentDetail = {
 	ip_siblings: AdminComment[];
 	user_recent: AdminComment[];
 	verdicts: SpamVerdictRow[];
+	reports: Report[];
 	audit: AuditRowWithAdmin[];
 };
 
@@ -2045,6 +2192,7 @@ export const adminGetCommentDetail = async (
 		.then((r) => (r.results ?? []).map(toAdminComment));
 
 	const verdicts = await adminListSpamVerdicts(db, id);
+	const reports = await listReportsForComment(db, id);
 	const audit = await adminAuditForTarget(db, "comment", id, 50);
 
 	return {
@@ -2054,6 +2202,7 @@ export const adminGetCommentDetail = async (
 		ip_siblings: ipSiblings,
 		user_recent: userRecent,
 		verdicts,
+		reports,
 		audit,
 	};
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -21,6 +21,7 @@ export const en = {
 	"err.delete.not_author": "You can only delete your own comments.",
 	"err.not_found": "Not found.",
 	"err.banned": "Your account is banned.",
+	"err.thread_closed": "Comments are closed on this post.",
 	"err.internal": "Something went wrong. Try again.",
 
 	// UI strings (used later by widget templates)

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,21 @@ export type Bindings = {
 	COMMENTS_PER_PAGE?: string;
 	REPLIES_PER_THREAD?: string;
 	AUTO_COLLAPSE_DEPTH?: string;
+	// Thread auto-close. Env-var *defaults*; a `settings` row overrides at
+	// runtime (see src/lib/settings.ts). Evaluated lazily at read/write time
+	// (no cron). 0 = disabled.
+	//   AUTO_CLOSE_DAYS — close a thread this many days after its publish date
+	//                     (posts.published_at, else created_at).
+	//   AUTO_CLOSE_AT   — close ALL threads at/after this epoch-ms sunset date.
+	AUTO_CLOSE_DAYS?: string;
+	AUTO_CLOSE_AT?: string;
+	// Community auto-collapse (cosmetic, client-side). 0 = disabled.
+	//   COMMUNITY_MIN_VOTES      — min total votes before the ratio applies
+	//                              (brigading floor).
+	//   COMMUNITY_COLLAPSE_RATIO — percent downvotes that folds a comment
+	//                              (expandable). Gated on DOWNVOTES_ENABLED.
+	COMMUNITY_MIN_VOTES?: string;
+	COMMUNITY_COLLAPSE_RATIO?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { health } from "./routes/health";
 import { comments } from "./routes/api.comments";
+import { reports } from "./routes/api.reports";
 import { config } from "./routes/api.config";
 import { preview } from "./routes/api.preview";
 import { pageEngagement } from "./routes/api.page-engagement";
@@ -190,6 +191,7 @@ app.use("/api/*", sessionMiddleware());
 
 app.route("/api/v1/health", health);
 app.route("/api/v1/comments", comments);
+app.route("/api/v1/comments", reports);
 app.route("/api/v1/reactions", reactions);
 app.route("/api/v1/page-engagement", pageEngagement);
 app.route("/api/v1/votes", votes);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -19,6 +19,7 @@ export type EventName =
 	| "comment.posted"
 	| "comment.deleted"
 	| "comment.edited"
+	| "comment.reported"
 	| "ratelimit.hit"
 	| "oauth.start"
 	| "oauth.complete"

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -38,7 +38,11 @@ export type ResolvedFlags = Record<FlagKey, boolean>;
 export type NumberKey =
 	| "comments_per_page"
 	| "replies_per_thread"
-	| "auto_collapse_depth";
+	| "auto_collapse_depth"
+	| "auto_close_days"
+	| "auto_close_at"
+	| "community_min_votes"
+	| "community_collapse_ratio";
 
 export type ResolvedNumbers = Record<NumberKey, number>;
 
@@ -86,6 +90,42 @@ const NUMBERS: Record<
 		default: 3,
 		min: 0,
 		max: MAX_DEPTH,
+	},
+	// Thread auto-close: close a thread this many days after its publish anchor
+	// (posts.published_at, else posts.created_at). 0 = disabled. Evaluated lazily
+	// at read/write time (src/lib/thread.ts) — no cron, no status flips.
+	auto_close_days: {
+		env: "AUTO_CLOSE_DAYS",
+		default: 0,
+		min: 0,
+		max: 3650,
+	},
+	// Instance-wide sunset: close ALL threads at/after this epoch-ms instant.
+	// 0 = disabled. The admin UI exposes a date picker that writes the epoch.
+	// Max ~ year 2100 so a fat-fingered value can't overflow the clamp.
+	auto_close_at: {
+		env: "AUTO_CLOSE_AT",
+		default: 0,
+		min: 0,
+		max: 4102444800000,
+	},
+	// Community auto-collapse floor: minimum total votes (up+down) on a comment
+	// before the collapse ratio is allowed to apply. Mandatory brigading guard —
+	// without it a single downvote is 100% and would fold every new comment.
+	community_min_votes: {
+		env: "COMMUNITY_MIN_VOTES",
+		default: 5,
+		min: 0,
+		max: 1000,
+	},
+	// Community auto-collapse ratio: percent of downvotes/total that folds a
+	// comment (client-side, reversible, expandable). 0 = disabled. Gated on
+	// downvotes_enabled. Applied only once community_min_votes is met.
+	community_collapse_ratio: {
+		env: "COMMUNITY_COLLAPSE_RATIO",
+		default: 0,
+		min: 0,
+		max: 100,
 	},
 };
 

--- a/src/lib/thread.ts
+++ b/src/lib/thread.ts
@@ -1,0 +1,76 @@
+/**
+ * Thread acceptance resolver.
+ *
+ * "Is this thread accepting new comments right now?" has four inputs that
+ * stack in precedence order. Manual per-post close and the two auto-close
+ * rules are not separate features — they're inputs to this one pure function,
+ * which the POST handler consults before inserting a comment or reply and the
+ * GET handler consults to tell the widget whether to show the form.
+ *
+ * Precedence (first match wins):
+ *   1. global `comments_enabled` flag OFF      → closed everywhere
+ *   2. per-post `posts.closed` set             → this thread frozen
+ *   3. `auto_close_at` epoch reached           → instance-wide sunset passed
+ *   4. `auto_close_days` elapsed since anchor  → thread aged out
+ * Otherwise: open.
+ *
+ * Evaluated LAZILY at read/write time — there is no cron, no status flip, no
+ * KV write. A thread "becomes" closed the moment a request observes the rule
+ * crossing its threshold; nothing is persisted.
+ *
+ * Anchor for the age rule is `published_at` (the host page's real publish
+ * time, supplied via data-published) falling back to `created_at`. Note that
+ * `created_at` is when the FIRST COMMENT arrived (posts are created lazily on
+ * first comment), not when the article was published — so the published_at
+ * anchor is what makes day-based closing accurate. With neither a meaningful
+ * anchor nor published_at, day-based close still works off created_at, just
+ * measured from first-comment time.
+ */
+import type { Post } from "../db/queries";
+import type { ResolvedFlags, ResolvedNumbers } from "./settings";
+
+const DAY_MS = 86_400_000;
+
+export type ThreadState = {
+	/** Whether new comments/replies are accepted right now. */
+	open: boolean;
+	/** Why it's closed (for the widget's closed-state copy); undefined if open. */
+	reason?: "comments_disabled" | "post_closed" | "sunset" | "aged_out";
+};
+
+/**
+ * Pure resolver — no I/O, no clock of its own (caller passes `now`), so it's
+ * trivially unit-testable. `now` is epoch ms.
+ */
+export const resolveThreadOpen = (
+	post: Pick<Post, "closed" | "published_at" | "created_at">,
+	flags: Pick<ResolvedFlags, "comments_enabled">,
+	numbers: Pick<ResolvedNumbers, "auto_close_days" | "auto_close_at">,
+	now: number,
+): ThreadState => {
+	// 1. Global kill switch.
+	if (!flags.comments_enabled) {
+		return { open: false, reason: "comments_disabled" };
+	}
+
+	// 2. Operator froze this one thread.
+	if (post.closed) {
+		return { open: false, reason: "post_closed" };
+	}
+
+	// 3. Instance-wide sunset date. 0 = disabled.
+	if (numbers.auto_close_at > 0 && now >= numbers.auto_close_at) {
+		return { open: false, reason: "sunset" };
+	}
+
+	// 4. Age-based close. 0 = disabled. Anchor on the host's real publish time,
+	//    falling back to first-comment time.
+	if (numbers.auto_close_days > 0) {
+		const anchor = post.published_at ?? post.created_at;
+		if (now >= anchor + numbers.auto_close_days * DAY_MS) {
+			return { open: false, reason: "aged_out" };
+		}
+	}
+
+	return { open: true };
+};

--- a/src/lib/webhook-adapters.ts
+++ b/src/lib/webhook-adapters.ts
@@ -48,6 +48,7 @@ const EVENT_VERB: Record<WebhookEvent, string> = {
 	"comment.deleted": "Comment deleted",
 	"comment.approved": "Comment approved",
 	"comment.spam": "Comment marked spam",
+	"comment.reported": "Comment reported",
 };
 
 // Discord embed accent color per event (decimal RGB).
@@ -57,6 +58,7 @@ const EVENT_COLOR: Record<WebhookEvent, number> = {
 	"comment.approved": 0x57f287, // green
 	"comment.spam": 0xed4245, // red
 	"comment.deleted": 0x992d22, // dark red
+	"comment.reported": 0xfaa61a, // amber
 };
 
 // Cap snippet length pre-escape so the worst-case escaped output still

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -65,7 +65,8 @@ export type WebhookEvent =
 	| "comment.edited"
 	| "comment.deleted"
 	| "comment.approved"
-	| "comment.spam";
+	| "comment.spam"
+	| "comment.reported";
 
 export type WebhookPayload = {
 	event: WebhookEvent;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -41,6 +41,7 @@ import {
 	adminTopCommenters,
 	adminTopPosts,
 	countAdmins,
+	countOpenReportsByComment,
 	createWebhookEndpoint,
 	deleteSettings,
 	deleteWebhookEndpoint,
@@ -58,6 +59,8 @@ import {
 	listSavedRepliesForUser,
 	listWebhookEndpoints,
 	markSubscriptionUnsubscribed,
+	resolveReportsForComment,
+	setPostClosed,
 	setSetting,
 	setUserBanned,
 	setUserRole,
@@ -65,6 +68,7 @@ import {
 	updateSavedReply,
 	deleteSavedReply,
 	updateWebhookEndpoint,
+	upsertPost,
 	type AdminAction,
 	type AuditTargetKind,
 	type CommentStatus,
@@ -290,6 +294,11 @@ admin.get("/queue", async (c) => {
 	const hostRaw = (c.req.query("host") ?? "").trim();
 	const host = hostRaw.length > 0 && hostRaw.length <= 253 ? hostRaw : "";
 
+	// The "reported" view cuts across statuses (a reported comment may be
+	// approved, pending, etc.), so it ignores the status tab.
+	const reportedRaw = (c.req.query("reported") ?? "").trim();
+	const reported = reportedRaw === "1" || reportedRaw === "true";
+
 	const before = c.req.query("before");
 	let cursorTs: number | null = null;
 	let cursorId: string | null = null;
@@ -306,13 +315,18 @@ admin.get("/queue", async (c) => {
 		}
 	}
 
-	const filter: import("../db/queries").AdminCommentFilter = { status };
+	// When the reported view is active, drop the status constraint so reported
+	// comments of any status show up together.
+	const filter: import("../db/queries").AdminCommentFilter = {
+		status: reported ? "all" : status,
+	};
 	if (q) filter.q = q;
 	if (postSlug) filter.post_slug = postSlug;
 	if (userId) filter.user_id = userId;
 	if (fromMs != null) filter.from = fromMs;
 	if (toExclusive != null) filter.to = toExclusive;
 	if (host) filter.host = host;
+	if (reported) filter.reported = true;
 
 	const rows = await adminListComments(c.env.DB, filter, 51, cursorTs, cursorId);
 	const trimmed = rows.slice(0, 50);
@@ -323,6 +337,13 @@ admin.get("/queue", async (c) => {
 	const latestAudit = await adminLatestAuditByTarget(
 		c.env.DB,
 		"comment",
+		trimmed.map((r) => r.id),
+	);
+
+	// Open-report counts for the visible rows → queue badges. Operator-only;
+	// never surfaced in the public payload (avoids a brigading signal).
+	const reportCounts = await countOpenReportsByComment(
+		c.env.DB,
 		trimmed.map((r) => r.id),
 	);
 
@@ -337,11 +358,29 @@ admin.get("/queue", async (c) => {
 		from: fromRaw ?? "",
 		to: toRaw ?? "",
 		host,
+		reported,
 	};
+	// Surface the per-post close toggle only when the queue is scoped to a
+	// single post. A post row may not exist yet (no comments) — treat absent
+	// as open so the operator can still pre-close it.
+	const postState = postSlug
+		? await getPost(c.env.DB, postSlug).then((p) => ({
+				slug: postSlug,
+				closed: p?.closed ?? false,
+			}))
+		: null;
 	return c.html(
 		renderPage(c,
 			"Queue",
-			renderQueue(trimmed, filters, nextCursor, latestAudit, hosts),
+			renderQueue(
+				trimmed,
+				filters,
+				nextCursor,
+				latestAudit,
+				hosts,
+				postState,
+				reportCounts,
+			),
 			user,
 			updateInfo,
 		),
@@ -358,7 +397,13 @@ admin.get("/comments/:id", async (c) => {
 	}
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		renderPage(c, `Comment ${id.slice(0, 8)}`, renderCommentDetail(detail), user, updateInfo),
+		renderPage(
+			c,
+			`Comment ${id.slice(0, 8)}`,
+			renderCommentDetail(detail, user.role === "admin"),
+			user,
+			updateInfo,
+		),
 	);
 });
 
@@ -1343,6 +1388,63 @@ admin.post("/api/comments/:id", async (c) => {
 	return c.json({ ok: true, id, status: newStatus });
 });
 
+// Per-post comment freeze/unfreeze. Flips posts.closed; the lazy thread
+// resolver (src/lib/thread.ts) enforces it on the next POST. Mod-gated; the
+// admin middleware already applies the same-origin CSRF check.
+const POST_SLUG_RE = /^[a-zA-Z0-9_\-./]{1,200}$/;
+
+admin.post("/api/posts/close", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const body = await c.req
+		.json<{ slug?: unknown; closed?: unknown }>()
+		.catch(() => null);
+	if (!body || typeof body.slug !== "string" || typeof body.closed !== "boolean") {
+		return c.json({ error: "invalid_body" }, 400);
+	}
+	const slug = body.slug.trim();
+	if (!slug || !POST_SLUG_RE.test(slug)) {
+		return c.json({ error: "invalid_slug" }, 400);
+	}
+	const closed = body.closed;
+	// Ensure a post row exists before flipping — a thread can be pre-closed
+	// before its first comment arrives. upsertPost never touches `closed`, so
+	// it's safe to create-or-noop here.
+	await upsertPost(c.env.DB, slug, null, null);
+	await setPostClosed(c.env.DB, slug, closed);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: closed ? "post.close" : "post.open",
+		target_kind: "post",
+		target_id: slug,
+		meta: { post_slug: slug },
+	});
+	// Bust the cached first page so the closed-state banner reflects immediately
+	// for anonymous viewers (the GET payload carries accepting_comments).
+	await bustTreeCache(c.env, c.req.url, slug);
+	return c.json({ ok: true, slug, closed });
+});
+
+// Dismiss (resolve) all open reader reports on a comment. The comment itself
+// is moderated via the existing approve/spam/delete actions; this only clears
+// the report flags so the comment leaves the "reported" queue. Mod-gated.
+admin.post("/api/comments/:id/reports/resolve", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const id = c.req.param("id");
+	const existing = await getComment(c.env.DB, id);
+	if (!existing) return c.json({ error: "not_found" }, 404);
+	const resolved = await resolveReportsForComment(c.env.DB, id);
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "report.resolve",
+		target_kind: "comment",
+		target_id: id,
+		meta: { resolved_count: resolved, post_slug: existing.post_slug },
+	});
+	return c.json({ ok: true, id, resolved });
+});
+
 const BULK_ACTION_LIMIT = 100;
 
 admin.post("/api/comments/bulk", async (c) => {
@@ -1426,7 +1528,7 @@ admin.post("/api/users/:id", async (c) => {
 	if (user instanceof Response) return user;
 	const id = c.req.param("id");
 	const body = await c.req
-		.json<{ banned?: boolean; reason?: string }>()
+		.json<{ banned?: boolean; reason?: string; from_comment?: unknown }>()
 		.catch(() => null);
 	if (!body || typeof body.banned !== "boolean") {
 		return c.json({ error: "invalid_body" }, 400);
@@ -1436,13 +1538,22 @@ admin.post("/api/users/:id", async (c) => {
 	const target = await getUser(c.env.DB, id);
 	if (!target) return c.json({ error: "not_found" }, 404);
 	await setUserBanned(c.env.DB, id, body.banned);
+	// When the ban was triggered from a specific comment (one-click "Ban
+	// author"), record that comment id in the audit trail so the action is
+	// traceable back to its trigger.
+	const fromComment =
+		typeof body.from_comment === "string" && body.from_comment.length > 0
+			? body.from_comment
+			: null;
 	await adminInsertAudit(c.env.DB, {
 		admin_id: user.id,
 		action: body.banned ? "ban" : "unban",
 		target_kind: "user",
 		target_id: id,
 		reason: body.reason ?? null,
-		meta: { target_name: target.name },
+		meta: fromComment
+			? { target_name: target.name, from_comment: fromComment }
+			: { target_name: target.name },
 	});
 	return c.json({ ok: true, id, banned: body.banned });
 });

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -862,6 +862,7 @@ const VALID_EVENTS = [
 	"comment.deleted",
 	"comment.approved",
 	"comment.spam",
+	"comment.reported",
 ] as const;
 
 const isValidEvent = (v: unknown): v is (typeof VALID_EVENTS)[number] =>
@@ -905,7 +906,7 @@ const parseWebhookBody = (
 		if (filtered.length !== body.events.length) {
 			return { ok: false, error: "events_unknown" };
 		}
-		// All five events selected = "no filter"; store NULL so receivers
+		// Every known event selected = "no filter"; store NULL so receivers
 		// see future events too without a re-save.
 		events = filtered.length === VALID_EVENTS.length ? null : filtered;
 	}

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -51,6 +51,7 @@ import { verifyTurnstile } from "../lib/turnstile";
 import { writeEvent } from "../lib/analytics";
 import { fireWebhook } from "../lib/webhook";
 import { loadFlags, loadNumbers } from "../lib/settings";
+import { resolveThreadOpen } from "../lib/thread";
 import { bustTreeCache, TREE_CACHE_TTL, treeCacheKey } from "../lib/tree-cache";
 import {
 	cacheJson,
@@ -113,8 +114,29 @@ type CreateBody = {
 	turnstile_token?: string;
 	post_title?: string | null;
 	post_url?: string | null;
+	/** Host page's real publish time (epoch ms or ISO), from data-published. */
+	post_published?: number | string | null;
 	form_ts?: string;
 	[HONEYPOT_FIELD]?: string;
+};
+
+// Upper bound for a host-supplied publish time (~year 2100), matching the
+// auto_close_at clamp. A bogus far-future value would only ever DELAY that one
+// post's age-based close, but reject out-of-range/garbage so it can't poison
+// the anchor. Accepts epoch ms (number or numeric string) or an ISO date.
+const PUBLISHED_AT_MAX = 4102444800000;
+const parsePublishedAt = (raw: number | string | null | undefined): number | null => {
+	if (raw == null) return null;
+	let ms: number;
+	if (typeof raw === "number") {
+		ms = raw;
+	} else {
+		const s = raw.trim();
+		if (!s) return null;
+		ms = /^\d+$/.test(s) ? Number.parseInt(s, 10) : Date.parse(s);
+	}
+	if (!Number.isFinite(ms) || ms <= 0 || ms > PUBLISHED_AT_MAX) return null;
+	return ms;
 };
 
 const editWindowMs = (env: Bindings): number => {
@@ -410,7 +432,23 @@ comments.post("/", async (c) => {
 			// drop
 		}
 	}
-	await upsertPost(c.env.DB, slug, body.post_title ?? null, postUrl);
+	const post = await upsertPost(
+		c.env.DB,
+		slug,
+		body.post_title ?? null,
+		postUrl,
+		parsePublishedAt(body.post_published),
+	);
+
+	// Thread acceptance gate. The global comments_enabled switch was checked at
+	// the top; this also enforces the per-post manual close and the lazy
+	// auto-close rules (sunset date / age). It runs before the parent lookup and
+	// insert, so it covers replies as well as top-level comments. The widget's
+	// closed-state UI is cosmetic — this is the authoritative gate.
+	const numbers = await loadNumbers(c.env);
+	if (!resolveThreadOpen(post, flags, numbers, Date.now()).open) {
+		return c.json({ error: t("err.thread_closed") }, 403);
+	}
 
 	// Parent must exist and live on the same post.
 	let parent_id: string | null = null;
@@ -545,6 +583,10 @@ type ListPayload = {
 	post: Awaited<ReturnType<typeof getPost>>;
 	threads: TreeNode[];
 	next_cursor: string | null;
+	/** Whether the widget should show the composer (vs. a closed notice). */
+	accepting_comments: boolean;
+	/** Why the thread is closed, for the closed-notice copy; null if open. */
+	closed_reason: string | null;
 };
 
 const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
@@ -599,8 +641,10 @@ comments.get("/", async (c) => {
 	const session = await readSession(c);
 
 	// Top-level threads per page, operator-tunable (DB > env > default 25),
-	// clamped to [1,200] in the settings layer.
-	const pageSize = (await loadNumbers(c.env)).comments_per_page;
+	// clamped to [1,200] in the settings layer. The full numbers object is also
+	// reused below to resolve the thread's accepting-comments state.
+	const numbers = await loadNumbers(c.env);
+	const pageSize = numbers.comments_per_page;
 
 	// Fast path: first page is cached at the edge (Cache API, not KV — see
 	// response-cache.ts) for anonymous viewers only, keyed by sort AND page
@@ -657,7 +701,8 @@ comments.get("/", async (c) => {
 	// When the operator opts in, keep every deleted comment as a placeholder
 	// (leaf deletions included) rather than pruning them. A toggle change is
 	// reflected for anonymous viewers within the tree-cache TTL.
-	const keepAllDeleted = (await loadFlags(c.env)).show_deleted_placeholders;
+	const flags = await loadFlags(c.env);
+	const keepAllDeleted = flags.show_deleted_placeholders;
 
 	const { threads: allThreads } = buildTree(rows, authors, reactionsById, myVotes, {
 		keepAllDeleted,
@@ -703,7 +748,24 @@ comments.get("/", async (c) => {
 			: last.id
 		: null;
 
-	const payload: ListPayload = { post, threads: page, next_cursor };
+	// Whether new comments are accepted, so the widget can show the composer or a
+	// closed notice. A post with no row yet (no comments posted) is open unless a
+	// global/sunset rule says otherwise, so synthesize a default-open post for
+	// the resolver in that case. Anonymous viewers may see this lag a sunset/age
+	// flip by up to the tree-cache TTL — acceptable (the POST gate is exact).
+	const threadState = resolveThreadOpen(
+		post ?? { closed: false, published_at: null, created_at: Date.now() },
+		flags,
+		numbers,
+		Date.now(),
+	);
+	const payload: ListPayload = {
+		post,
+		threads: page,
+		next_cursor,
+		accepting_comments: threadState.open,
+		closed_reason: threadState.reason ?? null,
+	};
 
 	if (cacheable) {
 		// Write-through to the edge cache; the put runs after the response when

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -432,23 +432,39 @@ comments.post("/", async (c) => {
 			// drop
 		}
 	}
-	const post = await upsertPost(
+	// Thread acceptance gate. The global comments_enabled switch was checked at
+	// the top; this also enforces the per-post manual close and the lazy
+	// auto-close rules (sunset date / age). It runs before the parent lookup and
+	// insert, so it covers replies as well as top-level comments. The widget's
+	// closed-state UI is cosmetic — this is the authoritative gate.
+	//
+	// Crucially it runs against the EXISTING stored post BEFORE upsertPost, so a
+	// crafted request that fails the gate can't mutate the post row as a side
+	// effect (e.g. persist a bogus published_at to poison the close-anchor and
+	// then 403). A post with no row yet is open unless a global/sunset rule says
+	// otherwise, so synthesize a default-open post for the resolver in that case.
+	const existing = await getPost(c.env.DB, slug);
+	const numbers = await loadNumbers(c.env);
+	const threadState = resolveThreadOpen(
+		existing ?? { closed: false, published_at: null, created_at: Date.now() },
+		flags,
+		numbers,
+		Date.now(),
+	);
+	if (!threadState.open) {
+		return c.json({ error: t("err.thread_closed") }, 403);
+	}
+
+	// Make sure the post row exists so the FK on comments resolves. published_at
+	// is write-once in upsertPost (first-writer-wins), so this can establish a
+	// fresh thread's anchor but can never overwrite an established one.
+	await upsertPost(
 		c.env.DB,
 		slug,
 		body.post_title ?? null,
 		postUrl,
 		parsePublishedAt(body.post_published),
 	);
-
-	// Thread acceptance gate. The global comments_enabled switch was checked at
-	// the top; this also enforces the per-post manual close and the lazy
-	// auto-close rules (sunset date / age). It runs before the parent lookup and
-	// insert, so it covers replies as well as top-level comments. The widget's
-	// closed-state UI is cosmetic — this is the authoritative gate.
-	const numbers = await loadNumbers(c.env);
-	if (!resolveThreadOpen(post, flags, numbers, Date.now()).open) {
-		return c.json({ error: t("err.thread_closed") }, 403);
-	}
 
 	// Parent must exist and live on the same post.
 	let parent_id: string | null = null;

--- a/src/routes/api.config.ts
+++ b/src/routes/api.config.ts
@@ -18,6 +18,9 @@
  *   - numeric display settings (comments_per_page, replies_per_thread,
  *     auto_collapse_depth): page size and reply-collapse tuning, same
  *     DB-override > env > default precedence (see src/lib/settings.ts).
+ *   - community auto-collapse thresholds (community_min_votes,
+ *     community_collapse_ratio): the widget folds heavily-downvoted comments
+ *     client-side using these (see src/widget). 0 ratio = disabled.
  *
  * The widget calls this once on mount. Missing or empty → widget renders
  * without a Turnstile challenge (and anonymous POSTs will be rejected
@@ -73,6 +76,13 @@ config.get("/", async (c) => {
 		comments_per_page: numbers.comments_per_page,
 		replies_per_thread: numbers.replies_per_thread,
 		auto_collapse_depth: numbers.auto_collapse_depth,
+		// Community auto-collapse thresholds. The widget folds a comment when
+		// down/(up+down) ≥ ratio once total votes ≥ floor (and downvotes are
+		// enabled). Collapse is derived client-side because votes deliberately
+		// don't bust the tree cache (see api.votes.ts) — a server flag would be
+		// stale against the cached score the widget already shows. 0 ratio = off.
+		community_min_votes: numbers.community_min_votes,
+		community_collapse_ratio: numbers.community_collapse_ratio,
 	});
 });
 

--- a/src/routes/api.reports.ts
+++ b/src/routes/api.reports.ts
@@ -1,0 +1,92 @@
+/**
+ * /api/v1/comments/:id/report — reader-facing comment reporting.
+ *
+ *   POST /api/v1/comments/:id/report   { reason? }
+ *
+ * Low-friction by design: anonymous reports are allowed and there is NO
+ * Turnstile challenge (a challenge on a one-tap "report" is overkill and
+ * hurts adoption). Abuse is bounded three ways instead:
+ *   - the shared per-IP-hash rate-limit bucket (same as commenting);
+ *   - a UNIQUE(comment_id, reporter_ip_hash) dedup — a second report from the
+ *     same network is a silent no-op (INSERT OR IGNORE in insertReport);
+ *   - report counts are operator-only (never in the public payload) so there
+ *     is no brigading signal to chase.
+ *
+ * The response is always { ok: true } whether the report is new or a
+ * duplicate, so a caller can't probe whether they (or anyone) already
+ * reported a given comment.
+ *
+ * State change ⇒ this goes through the global Origin/CSRF middleware mounted
+ * on /api/* (see src/index.ts). IP is only ever stored hashed (ip-hash.ts).
+ */
+import { Hono } from "hono";
+import type { Bindings } from "../index";
+import { getComment, insertReport } from "../db/queries";
+import { clientIp, hashIp } from "../lib/ip-hash";
+import { checkRateLimit } from "../lib/ratelimit";
+import { readSession } from "../lib/session";
+import { writeEvent } from "../lib/analytics";
+import { fireWebhook } from "../lib/webhook";
+import { t } from "../i18n";
+
+const reports = new Hono<{ Bindings: Bindings }>();
+
+// Reason is a free-text hint from the reporter. Stored as plain text and
+// escaped on admin render; capped so a report can't be used as a storage
+// amplification vector.
+const REASON_MAX = 300;
+
+reports.post("/:id/report", async (c) => {
+	const id = c.req.param("id");
+
+	// Optional reason. A malformed/absent body is fine — reason just stays null.
+	const body = await c.req.json<{ reason?: unknown }>().catch(() => null);
+	let reason: string | null = null;
+	if (body && typeof body.reason === "string") {
+		const trimmed = body.reason.trim().slice(0, REASON_MAX);
+		reason = trimmed.length > 0 ? trimmed : null;
+	}
+
+	const ipHash = await hashIp(clientIp(c.req.raw), c.env.IP_HASH_SECRET);
+	const rl = await checkRateLimit(c.env, ipHash);
+	if (!rl.ok) {
+		writeEvent(c.env.ANALYTICS, "ratelimit.hit", {
+			outcome: rl.reason ?? null,
+			post_slug: null,
+		});
+		return c.json({ error: t("err.ratelimit") }, 429);
+	}
+
+	// Resolve the target. A missing comment returns the same {ok:true} as a
+	// success so the endpoint can't be used to enumerate comment ids.
+	const target = await getComment(c.env.DB, id);
+	if (!target) return c.json({ ok: true });
+
+	const session = await readSession(c);
+	const isNew = await insertReport(c.env.DB, {
+		comment_id: id,
+		reporter_user_id: session?.user_id ?? null,
+		reporter_ip_hash: ipHash,
+		reason,
+	});
+
+	// Only ping operators / count analytics on a genuinely new report — a
+	// duplicate is a no-op and shouldn't re-fire the webhook.
+	if (isNew) {
+		writeEvent(c.env.ANALYTICS, "comment.reported", {
+			post_slug: target.post_slug,
+			outcome: null,
+		});
+		fireWebhook(c.env, c.executionCtx, {
+			event: "comment.reported",
+			comment_id: id,
+			post_slug: target.post_slug,
+			user_id: target.user_id,
+			ts: Date.now(),
+		});
+	}
+
+	return c.json({ ok: true });
+});
+
+export { reports };

--- a/src/routes/api.reports.ts
+++ b/src/routes/api.reports.ts
@@ -58,9 +58,12 @@ reports.post("/:id/report", async (c) => {
 	}
 
 	// Resolve the target. A missing comment returns the same {ok:true} as a
-	// success so the endpoint can't be used to enumerate comment ids.
+	// success so the endpoint can't be used to enumerate comment ids. An
+	// already-deleted comment is treated the same way: nothing to moderate, so
+	// don't let a crafted POST open a report on a dead comment (the widget
+	// already hides the button for deleted ones — this is the server guard).
 	const target = await getComment(c.env.DB, id);
-	if (!target) return c.json({ ok: true });
+	if (!target || target.status === "deleted") return c.json({ ok: true });
 
 	const session = await readSession(c);
 	const isNew = await insertReport(c.env.DB, {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -74,6 +74,12 @@ type ListResponse = {
 	post: unknown;
 	threads: TreeNode[];
 	next_cursor: string | null;
+	// Per-post thread-lifecycle state (src/lib/thread.ts). The widget shows the
+	// composer only when accepting_comments is true; closed_reason picks the
+	// notice copy. Both optional so an older server (pre-thread-lifecycle) that
+	// omits them degrades to "open".
+	accepting_comments?: boolean;
+	closed_reason?: "comments_disabled" | "post_closed" | "sunset" | "aged_out" | null;
 };
 
 type Me = {
@@ -338,6 +344,25 @@ button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-
 	cursor: pointer;
 }
 .gr-actions button:hover { color: var(--gr-link); }
+/* Post-report confirmation that replaces the Report button in place. */
+.gr-reported { color: var(--gr-muted); font-size: 0.85em; }
+/* Low-score collapse toggle (community auto-collapse). Muted, inline, reads as
+   a stub line rather than a primary action. */
+.gr-low-score {
+	font: inherit;
+	font-size: 0.85em;
+	background: transparent;
+	border: 0;
+	padding: 0;
+	margin: 0.25rem 0;
+	cursor: pointer;
+	color: var(--gr-muted);
+	align-self: flex-start;
+}
+.gr-low-score:hover { color: var(--gr-link); }
+/* Folded body is hidden via the [hidden] attribute; the rule below just
+   guarantees it across the Shadow DOM reset. */
+.gr-body[hidden] { display: none; }
 .gr-page-engage {
 	display: flex;
 	flex-wrap: wrap;
@@ -502,6 +527,59 @@ const el = <K extends keyof HTMLElementTagNameMap>(
 const parseTrustedHtml = (html: string): DocumentFragment => {
 	const range = document.createRange();
 	return range.createContextualFragment(html);
+};
+
+// ── Draft autosave ──────────────────────────────────────────────────────────
+// A long comment shouldn't vanish on an accidental reload or a failed submit.
+// Drafts live ONLY in the visitor's own browser (localStorage), keyed by slug
+// (and parent id for replies). No server state, no PII leaves the device; the
+// value is re-inserted via textarea.value (never as HTML), so no XSS surface.
+const DRAFT_PREFIX = "garrul:draft:";
+// Cap the stored size — localStorage is small and shared across the origin, and
+// the server rejects oversized bodies anyway. Generous vs. the comment limit.
+const DRAFT_MAX = 10_000;
+
+const draftKey = (slug: string, parentId: string | null): string =>
+	`${DRAFT_PREFIX}${slug}${parentId ? `:${parentId}` : ""}`;
+
+const clearDraft = (key: string): void => {
+	try {
+		localStorage.removeItem(key);
+	} catch {
+		// Safari private mode / disabled storage: nothing to clear.
+	}
+};
+
+/**
+ * Wire a textarea to localStorage: restore any saved draft on mount, then
+ * persist (debounced) on input. Returns the storage key so the submit/cancel
+ * paths can clear it. All storage access is wrapped — a throwing localStorage
+ * (Safari private mode, quota, disabled) degrades to no autosave, never breaks
+ * the composer.
+ */
+const attachDraft = (ta: HTMLTextAreaElement, key: string): string => {
+	try {
+		const saved = localStorage.getItem(key);
+		// Only restore into an empty field so we never clobber a server-provided
+		// or already-typed value.
+		if (saved && !ta.value) ta.value = saved;
+	} catch {
+		// Storage unavailable — skip restore.
+	}
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	ta.addEventListener("input", () => {
+		if (timer) clearTimeout(timer);
+		timer = setTimeout(() => {
+			try {
+				const v = ta.value;
+				if (v) localStorage.setItem(key, v.slice(0, DRAFT_MAX));
+				else localStorage.removeItem(key);
+			} catch {
+				// Quota/disabled: drop this save silently.
+			}
+		}, 400);
+	});
+	return key;
 };
 
 type MdFormat = {
@@ -708,6 +786,16 @@ type WidgetCtx = {
 	editWindowMs: number;
 	turnstileSiteKey: string | null;
 	commentsEnabled: boolean;
+	// Per-post acceptance (folds in the global flag, per-post close, and
+	// auto-close). Drives Reply visibility and the composer/closed-notice
+	// swap. closedReason picks the notice copy.
+	acceptingComments: boolean;
+	closedReason:
+		| "comments_disabled"
+		| "post_closed"
+		| "sunset"
+		| "aged_out"
+		| null;
 	reactionsEnabled: boolean;
 	votingEnabled: boolean;
 	downvotesEnabled: boolean;
@@ -718,6 +806,11 @@ type WidgetCtx = {
 	// a comment at depth >= this starts with its replies collapsed (0 = never).
 	repliesPerThread: number;
 	autoCollapseDepth: number;
+	// Community auto-collapse thresholds (src/routes/api.config.ts). A comment
+	// folds client-side when down/(up+down) ≥ ratio% once total votes ≥ floor
+	// (and downvotes are on). ratio 0 = disabled.
+	communityMinVotes: number;
+	communityCollapseRatio: number;
 	reload: () => void;
 };
 
@@ -1158,7 +1251,7 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLElement => {
 	const row = el("div", "gr-actions");
 
-	if (ctx.commentsEnabled && n.depth < 4 && n.status !== "deleted") {
+	if (ctx.acceptingComments && n.depth < 4 && n.status !== "deleted") {
 		const replyBtn = el("button", undefined, "Reply");
 		replyBtn.type = "button";
 		replyBtn.addEventListener("click", () => {
@@ -1202,6 +1295,40 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 			}
 		});
 		row.appendChild(delBtn);
+	}
+
+	// Report: any reader can flag a visible comment they didn't write. It's
+	// independent of whether the thread accepts new comments (you can still
+	// report on a closed thread) and of sign-in (the endpoint allows anon,
+	// rate-limited + deduped server-side). Hidden on deleted comments and on
+	// the viewer's own (reporting yourself is meaningless).
+	const isOwnComment = ctx.me != null && n.author.id === ctx.me.id;
+	if (n.status !== "deleted" && !isOwnComment) {
+		const reportBtn = el("button", "gr-report", "Report");
+		reportBtn.type = "button";
+		reportBtn.addEventListener("click", async () => {
+			reportBtn.disabled = true;
+			try {
+				await fetch(
+					`${ctx.apiBase}/api/v1/comments/${encodeURIComponent(n.id)}/report`,
+					{
+						method: "POST",
+						credentials: "include",
+						headers: { "content-type": "application/json" },
+						body: "{}",
+					},
+				);
+			} catch {
+				// Network failure: still show the thanks state. The endpoint is
+				// fire-and-forget from the reader's view (it returns ok even for
+				// duplicates/unknown ids to avoid leaking state), so there's no
+				// useful error to surface — and a retry would just re-dedupe.
+			}
+			// Replace the button with a non-interactive confirmation regardless
+			// of outcome, so a reader can't report-bomb one comment from the UI.
+			reportBtn.replaceWith(el("span", "gr-reported", "Reported, thanks"));
+		});
+		row.appendChild(reportBtn);
 	}
 
 	return row;
@@ -1261,6 +1388,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	const ta = el("textarea");
 	ta.placeholder = `Reply to @${parent.author.name}…`;
 	ta.required = true;
+	const dkey = attachDraft(ta, draftKey(ctx.slug, parent.id));
 
 	let nameInput: HTMLInputElement | null = null;
 	if (!ctx.me) {
@@ -1334,6 +1462,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	}
 
 	cancel.addEventListener("click", () => {
+		clearDraft(dkey);
 		tsHandle?.destroy();
 		wrap.remove();
 	});
@@ -1377,6 +1506,8 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 				tsHandle?.reset();
 				return;
 			}
+			// Reply landed — drop the saved draft before the list re-renders.
+			clearDraft(dkey);
 			// Pending replies reload like approved ones: the author's own
 			// queued comment comes back from the list endpoint and renders
 			// inline with a "Pending approval" badge.
@@ -1390,6 +1521,22 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	});
 
 	return wrap;
+};
+
+/**
+ * Community auto-collapse (Reddit/HN "below threshold"). Purely cosmetic and
+ * reversible: a heavily-downvoted comment's body is folded behind a toggle, the
+ * content stays in the payload, and votes stay live so it can recover. Derived
+ * client-side because votes deliberately don't bust the tree cache — a server
+ * flag would be stale against the score the widget already shows. The
+ * min-votes floor is the brigading guard (without it, 1 downvote = 100% would
+ * fold every fresh comment).
+ */
+const shouldCollapseLowScore = (n: TreeNode, ctx: WidgetCtx): boolean => {
+	if (!ctx.downvotesEnabled || ctx.communityCollapseRatio <= 0) return false;
+	const total = n.score_up + n.score_down;
+	if (total < ctx.communityMinVotes) return false;
+	return (n.score_down / total) * 100 >= ctx.communityCollapseRatio;
 };
 
 const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
@@ -1432,6 +1579,29 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	}
 
 	main.append(meta, body);
+
+	// Community auto-collapse: fold a heavily-downvoted (approved) comment's
+	// body behind a toggle. Reversible and cosmetic — the content is already in
+	// the DOM, just hidden.
+	if (n.status === "approved" && shouldCollapseLowScore(n, ctx)) {
+		body.hidden = true;
+		const toggle = el("button", "gr-low-score") as HTMLButtonElement;
+		toggle.type = "button";
+		let shown = false;
+		const apply = () => {
+			body.hidden = !shown;
+			toggle.textContent = shown
+				? "Hide comment"
+				: "Comment hidden (low score) — show";
+			toggle.setAttribute("aria-expanded", String(shown));
+		};
+		toggle.addEventListener("click", () => {
+			shown = !shown;
+			apply();
+		});
+		apply();
+		body.insertAdjacentElement("beforebegin", toggle);
+	}
 
 	// Votes/reactions only on public (approved) comments — a pending comment
 	// isn't visible to anyone but its author, so engagement is meaningless.
@@ -1858,6 +2028,21 @@ const setSort = (root: ShadowRoot, sort: SortKey): void => {
 	if (st) st.sort = sort;
 };
 
+// Closed-state notice copy, picked from the server's closed_reason enum so the
+// reader sees *why* the thread is frozen rather than a generic line.
+const closedNotice = (reason: ListResponse["closed_reason"]): string => {
+	switch (reason) {
+		case "post_closed":
+			return "Comments are closed on this post.";
+		case "aged_out":
+			return "This thread has been closed to new comments.";
+		case "sunset":
+			return "Commenting has ended.";
+		default:
+			return "Comments are closed.";
+	}
+};
+
 const loadOnce = async (
 	root: ShadowRoot,
 	slug: string,
@@ -1879,6 +2064,8 @@ const loadOnce = async (
 	// config fetch degrades gracefully to the same behavior.
 	let repliesPerThread = 3;
 	let autoCollapseDepth = 3;
+	let communityMinVotes = 5;
+	let communityCollapseRatio = 0;
 	try {
 		const cfgRes = await fetch(`${apiBase}/api/v1/config`, {
 			credentials: "include",
@@ -1897,6 +2084,8 @@ const loadOnce = async (
 				page_votes_enabled?: boolean;
 				replies_per_thread?: number;
 				auto_collapse_depth?: number;
+				community_min_votes?: number;
+				community_collapse_ratio?: number;
 			};
 			siteKey = cfg.turnstile_site_key ?? null;
 			editWindowMinutes = cfg.edit_window_minutes ?? 5;
@@ -1914,6 +2103,10 @@ const loadOnce = async (
 				repliesPerThread = cfg.replies_per_thread;
 			if (typeof cfg.auto_collapse_depth === "number")
 				autoCollapseDepth = cfg.auto_collapse_depth;
+			if (typeof cfg.community_min_votes === "number")
+				communityMinVotes = cfg.community_min_votes;
+			if (typeof cfg.community_collapse_ratio === "number")
+				communityCollapseRatio = cfg.community_collapse_ratio;
 		}
 	} catch {
 		// /api/v1/config is optional; the widget still renders without Turnstile
@@ -1929,6 +2122,15 @@ const loadOnce = async (
 		return;
 	}
 	const data = dataResult as ListResponse;
+
+	// Per-post acceptance: the server resolves the global flag, per-post close,
+	// and auto-close into one boolean + reason. Fall back to the global flag for
+	// an older server that doesn't send these fields.
+	const acceptingComments =
+		typeof data.accepting_comments === "boolean"
+			? data.accepting_comments
+			: commentsEnabled;
+	const closedReason = data.closed_reason ?? null;
 
 	root.replaceChildren();
 	const style = el("style");
@@ -1947,6 +2149,8 @@ const loadOnce = async (
 		editWindowMs: editWindowMinutes * 60_000,
 		turnstileSiteKey: siteKey,
 		commentsEnabled,
+		acceptingComments,
+		closedReason,
 		reactionsEnabled,
 		votingEnabled,
 		downvotesEnabled,
@@ -1954,6 +2158,8 @@ const loadOnce = async (
 		pageVotesEnabled,
 		repliesPerThread,
 		autoCollapseDepth,
+		communityMinVotes,
+		communityCollapseRatio,
 		reload,
 	};
 	// Article-level engagement bar sits at the very top, above the composer.
@@ -1965,28 +2171,34 @@ const loadOnce = async (
 	// down) but only mounted when comments are enabled. When disabled, existing
 	// comments stay visible (read-only) and we show a "closed" notice instead.
 	const form = buildForm(apiBase, siteKey, me != null);
+	// Restore/persist the top-level composer draft (cleared on successful post
+	// in submit()). Reply-form drafts are wired separately in buildReplyForm.
+	const composer = form.querySelector(
+		".gr-body-input",
+	) as HTMLTextAreaElement | null;
+	if (composer) attachDraft(composer, draftKey(slug, null));
 	const list = el("div", "gr-list");
 	if (data.threads.length === 0) {
 		// Don't invite a comment the reader can't leave: when comments are
-		// closed the "Comments are closed." notice below is the whole story.
+		// closed the closed-state notice below is the whole story.
 		list.appendChild(
 			el(
 				"p",
 				"gr-empty",
-				commentsEnabled ? "Be the first to comment." : "No comments yet.",
+				acceptingComments ? "Be the first to comment." : "No comments yet.",
 			),
 		);
 	} else {
 		appendThreads(list, data.threads, ctx);
 	}
-	if (commentsEnabled) {
+	if (acceptingComments) {
 		if (authBlock) wrap.appendChild(authBlock);
 		// Mint the timing token now so the honeypot-timing heuristic has
 		// real elapsed seconds to measure when the user eventually submits.
 		prefetchFormToken(apiBase);
 		wrap.append(form);
 	} else {
-		wrap.appendChild(el("p", "gr-empty", "Comments are closed."));
+		wrap.appendChild(el("p", "gr-empty", closedNotice(closedReason)));
 	}
 
 	// Sort selector only when voting is on (no scores to rank without it).
@@ -2063,7 +2275,7 @@ const loadOnce = async (
 		}
 	}
 
-	if (siteKey && commentsEnabled) {
+	if (siteKey && acceptingComments) {
 		const tsBox = form.querySelector(".gr-turnstile") as HTMLElement | null;
 		if (tsBox) {
 			const handle = mountTurnstileFrame(tsBox, apiBase, () => {
@@ -2145,6 +2357,10 @@ const submit = async (
 			turnstileHandles.get(form)?.reset();
 			return;
 		}
+
+		// Comment landed — drop the saved composer draft so the reload starts
+		// from a clean field.
+		clearDraft(draftKey(slug, null));
 
 		// Pending comments fall through to the same reload path as approved
 		// ones: the list endpoint returns the author's own queued comment, so

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1308,8 +1308,13 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 		reportBtn.type = "button";
 		reportBtn.addEventListener("click", async () => {
 			reportBtn.disabled = true;
+			let ok = false;
 			try {
-				await fetch(
+				// The endpoint returns 200 for both new and duplicate reports and
+				// never discloses which (anti-enumeration), so a 2xx is the only
+				// success signal we get — and the only one we need. fetch does NOT
+				// reject on a 4xx/5xx, so we must inspect res.ok explicitly.
+				const res = await fetch(
 					`${ctx.apiBase}/api/v1/comments/${encodeURIComponent(n.id)}/report`,
 					{
 						method: "POST",
@@ -1318,15 +1323,20 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 						body: "{}",
 					},
 				);
+				ok = res.ok;
 			} catch {
-				// Network failure: still show the thanks state. The endpoint is
-				// fire-and-forget from the reader's view (it returns ok even for
-				// duplicates/unknown ids to avoid leaking state), so there's no
-				// useful error to surface — and a retry would just re-dedupe.
+				// Network failure — fall through to the retry path below.
 			}
-			// Replace the button with a non-interactive confirmation regardless
-			// of outcome, so a reader can't report-bomb one comment from the UI.
-			reportBtn.replaceWith(el("span", "gr-reported", "Reported, thanks"));
+			if (ok) {
+				// Replace the button with a non-interactive confirmation so a
+				// reader can't report-bomb one comment from the UI. (Server-side
+				// dedup + rate-limit are the real guard; this is just UX.)
+				reportBtn.replaceWith(el("span", "gr-reported", "Reported, thanks"));
+			} else {
+				// A real refusal (429 rate-limit, 4xx/5xx, or a dropped network
+				// call) — don't claim success; re-enable so the reader can retry.
+				reportBtn.disabled = false;
+			}
 		});
 		row.appendChild(reportBtn);
 	}

--- a/tests/admin-ban-author.test.ts
+++ b/tests/admin-ban-author.test.ts
@@ -1,0 +1,204 @@
+/**
+ * One-click "Ban author" — admin route (POST /admin/api/users/:id).
+ *
+ * The ban mechanism itself is pre-existing; this covers the one-click affordance's
+ * contract against REAL SQLite (every migration applied):
+ *
+ *   - an admin can ban a comment's author and the originating comment id is
+ *     recorded in the audit row's meta (from_comment) for traceability;
+ *   - a ban without from_comment still works and omits it from meta;
+ *   - the action is admin-only — a mod session is rejected with 403;
+ *   - banning a non-existent user returns 404 (surfaces stale UI / typos).
+ *
+ * The same-origin CSRF check in the admin middleware is satisfied with an Origin
+ * header matching the request URL.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { admin } from "../src/routes/admin";
+import type { Bindings } from "../src/index";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const ADMIN_SID = "a".repeat(64);
+const MOD_SID = "b".repeat(64);
+const ADMIN_ID = "01HADMIN0000000000000000AB";
+const MOD_ID = "01HMOD00000000000000000MOD";
+const TARGET_ID = "01HTARGET00000000000000TGT";
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	return { sqlite, db: makeD1(sqlite) };
+};
+
+const makeSessions = () => ({
+	async get(key: string) {
+		if (key === `sess:${ADMIN_SID}`)
+			return JSON.stringify({ user_id: ADMIN_ID, expires_at: 4_102_444_800_000 });
+		if (key === `sess:${MOD_SID}`)
+			return JSON.stringify({ user_id: MOD_ID, expires_at: 4_102_444_800_000 });
+		return null;
+	},
+	async put() {},
+	async delete() {},
+});
+
+const makeKv = () => {
+	const store = new Map<string, string>([
+		["meta:latest-release", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+		["meta:recent-releases", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+	]);
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+const execCtx = {
+	waitUntil() {},
+	passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+let sqlite: DatabaseSync;
+let env: Bindings;
+
+beforeEach(() => {
+	const fresh = freshDb();
+	sqlite = fresh.sqlite;
+	const seedUser = sqlite.prepare(
+		`INSERT INTO users (id, provider, provider_id, name, is_admin, role, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	);
+	seedUser.run(ADMIN_ID, "github", "1", "Op", 1, "admin", 1_700_000_000_000);
+	seedUser.run(MOD_ID, "github", "2", "Mod", 0, "mod", 1_700_000_000_000);
+	seedUser.run(TARGET_ID, "anon", null, "Spammer", 0, "user", 1_700_000_000_000);
+	env = {
+		DB: fresh.db,
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+	} as unknown as Bindings;
+});
+
+const app = () => new Hono<{ Bindings: Bindings }>().route("/admin", admin);
+
+const ban = (
+	body: unknown,
+	opts: { sid?: string | null; origin?: string | null } = {},
+) => {
+	const { sid = ADMIN_SID, origin = "http://localhost" } = opts;
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (sid) headers.cookie = `garrul_sess=${sid}`;
+	if (origin) headers.origin = origin;
+	return app().request(
+		`/admin/api/users/${TARGET_ID}`,
+		{ method: "POST", headers, body: JSON.stringify(body) },
+		env as unknown as Record<string, unknown>,
+		execCtx,
+	);
+};
+
+const lastBanAudit = (): { action: string; meta: string | null } | undefined =>
+	sqlite
+		.prepare(
+			"SELECT action, meta FROM audit_log WHERE target_kind = 'user' ORDER BY created_at DESC LIMIT 1",
+		)
+		.get() as { action: string; meta: string | null } | undefined;
+
+const isBanned = (id: string): number =>
+	(sqlite.prepare("SELECT is_banned FROM users WHERE id = ?").get(id) as {
+		is_banned: number;
+	}).is_banned;
+
+describe("POST /admin/api/users/:id (one-click ban author)", () => {
+	it("bans the author and records from_comment in the audit meta", async () => {
+		const res = await ban({ banned: true, from_comment: "01HCOMMENT00000000000000CM" });
+		expect(res.status).toBe(200);
+		expect(isBanned(TARGET_ID)).toBe(1);
+		const audit = lastBanAudit();
+		expect(audit?.action).toBe("ban");
+		const meta = JSON.parse(audit?.meta ?? "{}");
+		expect(meta.from_comment).toBe("01HCOMMENT00000000000000CM");
+		expect(meta.target_name).toBe("Spammer");
+	});
+
+	it("bans without from_comment and omits it from meta", async () => {
+		const res = await ban({ banned: true });
+		expect(res.status).toBe(200);
+		const meta = JSON.parse(lastBanAudit()?.meta ?? "{}");
+		expect(meta.from_comment).toBeUndefined();
+		expect(meta.target_name).toBe("Spammer");
+	});
+
+	it("rejects a mod (admin-only)", async () => {
+		const res = await ban({ banned: true, from_comment: "01HCOMMENT00000000000000CM" }, {
+			sid: MOD_SID,
+		});
+		expect(res.status).toBe(403);
+		expect(isBanned(TARGET_ID)).toBe(0);
+	});
+
+	it("returns 404 for a non-existent target", async () => {
+		const res = await app().request(
+			"/admin/api/users/01HGHOST0000000000000GHOST",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: `garrul_sess=${ADMIN_SID}`,
+					origin: "http://localhost",
+				},
+				body: JSON.stringify({ banned: true }),
+			},
+			env as unknown as Record<string, unknown>,
+			execCtx,
+		);
+		expect(res.status).toBe(404);
+	});
+});

--- a/tests/admin-ban-author.test.ts
+++ b/tests/admin-ban-author.test.ts
@@ -184,6 +184,15 @@ describe("POST /admin/api/users/:id (one-click ban author)", () => {
 		expect(isBanned(TARGET_ID)).toBe(0);
 	});
 
+	it("rejects a cross-origin request (CSRF)", async () => {
+		const res = await ban(
+			{ banned: true, from_comment: "01HCOMMENT00000000000000CM" },
+			{ origin: "https://evil.example" },
+		);
+		expect(res.status).toBe(403);
+		expect(isBanned(TARGET_ID)).toBe(0);
+	});
+
 	it("returns 404 for a non-existent target", async () => {
 		const res = await app().request(
 			"/admin/api/users/01HGHOST0000000000000GHOST",

--- a/tests/admin-post-close.test.ts
+++ b/tests/admin-post-close.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Per-post comment close/open — admin route (POST /admin/api/posts/close).
+ *
+ * Exercises the operator freeze toggle against REAL SQLite (every migration
+ * applied) so upsertPost → setPostClosed → audit runs end-to-end:
+ *
+ *   - a mod can close a thread (posts.closed = 1) and an audit row is written
+ *     with action "post.close";
+ *   - reopening flips it back and audits "post.open";
+ *   - a thread with no comments yet can still be pre-closed (post row created);
+ *   - auth + input guards: no session → 401, bad slug / body → 400.
+ *
+ * The same-origin CSRF check in the admin middleware is satisfied with an
+ * Origin header matching the request URL.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { admin } from "../src/routes/admin";
+import type { Bindings } from "../src/index";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+// node:sqlite → D1 adapter (same shape as thread-closure-api.test.ts).
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const SID = "a".repeat(64);
+const ADMIN_ID = "01HADMIN0000000000000000AB";
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	return { sqlite, db: makeD1(sqlite) };
+};
+
+const makeSessions = () => ({
+	async get(key: string) {
+		if (key !== `sess:${SID}`) return null;
+		return JSON.stringify({ user_id: ADMIN_ID, expires_at: 4_102_444_800_000 });
+	},
+	async put() {},
+	async delete() {},
+});
+
+const makeKv = () => {
+	const store = new Map<string, string>([
+		// Seed the version-check cache so the admin middleware never fetches.
+		["meta:latest-release", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+		["meta:recent-releases", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+	]);
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+const execCtx = {
+	waitUntil() {},
+	passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+let sqlite: DatabaseSync;
+let env: Bindings;
+
+beforeEach(() => {
+	const fresh = freshDb();
+	sqlite = fresh.sqlite;
+	sqlite
+		.prepare(
+			`INSERT INTO users (id, provider, provider_id, name, is_admin, role, created_at)
+			 VALUES (?, ?, ?, ?, 1, 'admin', ?)`,
+		)
+		.run(ADMIN_ID, "github", "1", "Op", 1_700_000_000_000);
+	env = {
+		DB: fresh.db,
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+	} as unknown as Bindings;
+});
+
+const app = () => new Hono<{ Bindings: Bindings }>().route("/admin", admin);
+
+const close = (
+	body: unknown,
+	opts: { cookie?: boolean; origin?: string | null } = {},
+) => {
+	const { cookie = true, origin = "http://localhost" } = opts;
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (cookie) headers.cookie = `garrul_sess=${SID}`;
+	if (origin) headers.origin = origin;
+	return app().request(
+		"/admin/api/posts/close",
+		{ method: "POST", headers, body: JSON.stringify(body) },
+		env as unknown as Record<string, unknown>,
+		execCtx,
+	);
+};
+
+const postClosed = (slug: string): number | null => {
+	const row = sqlite
+		.prepare("SELECT closed FROM posts WHERE slug = ?")
+		.get(slug) as { closed: number } | undefined;
+	return row ? row.closed : null;
+};
+
+const auditActions = (): string[] =>
+	(
+		sqlite.prepare("SELECT action FROM audit_log ORDER BY created_at").all() as {
+			action: string;
+		}[]
+	).map((r) => r.action);
+
+describe("POST /admin/api/posts/close", () => {
+	it("closes a thread, sets posts.closed, and audits post.close", async () => {
+		const res = await close({ slug: "hello-world", closed: true });
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { closed: boolean; slug: string };
+		expect(json.closed).toBe(true);
+		expect(postClosed("hello-world")).toBe(1);
+		expect(auditActions()).toContain("post.close");
+	});
+
+	it("reopens a thread and audits post.open", async () => {
+		await close({ slug: "hello-world", closed: true });
+		const res = await close({ slug: "hello-world", closed: false });
+		expect(res.status).toBe(200);
+		expect(postClosed("hello-world")).toBe(0);
+		expect(auditActions()).toContain("post.open");
+	});
+
+	it("pre-closes a thread that has no comments yet (creates the post row)", async () => {
+		expect(postClosed("brand-new")).toBeNull();
+		const res = await close({ slug: "brand-new", closed: true });
+		expect(res.status).toBe(200);
+		expect(postClosed("brand-new")).toBe(1);
+	});
+
+	it("rejects an unauthenticated request", async () => {
+		const res = await close({ slug: "hello-world", closed: true }, { cookie: false });
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects a cross-origin request (CSRF)", async () => {
+		const res = await close(
+			{ slug: "hello-world", closed: true },
+			{ origin: "https://evil.example" },
+		);
+		expect(res.status).toBe(403);
+	});
+
+	it("rejects a malformed slug", async () => {
+		const res = await close({ slug: "bad slug!", closed: true });
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects a non-boolean closed value", async () => {
+		const res = await close({ slug: "hello-world", closed: "yes" });
+		expect(res.status).toBe(400);
+	});
+});

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -141,6 +141,20 @@ describe("renderQueue", () => {
 		expect(html).toContain("post_slug=blog");
 	});
 
+	it("keeps the reported view on the filter form and clear link", () => {
+		const html = renderQueue(
+			[],
+			{ ...emptyQueueFilters, reported: true, q: "foo" },
+			null,
+		);
+		// The form re-submits the reported dimension, not status, so filtering
+		// within the reported view stays in it.
+		expect(html).toContain('name="reported" value="1"');
+		expect(html).not.toContain('name="status"');
+		// Clear returns to the reported tab rather than dropping to status view.
+		expect(html).toContain('href="/admin/queue?reported=1"');
+	});
+
 	it("encodes the keyset cursor into the Next link", () => {
 		const html = renderQueue(
 			[makeComment()],

--- a/tests/admin-report-resolve.test.ts
+++ b/tests/admin-report-resolve.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Report resolution lifecycle — admin route + queue filter.
+ *
+ * The reader-side report insert is covered in report-api.test.ts; this covers
+ * the *moderator* half end-to-end against REAL SQLite (every migration applied):
+ *
+ *   - POST /admin/api/comments/:id/reports/resolve flips every OPEN report on a
+ *     comment to 'resolved', returns the affected count, and audits
+ *     report.resolve with resolved_count in the meta;
+ *   - resolving drops the comment out of the "reported" queue filter
+ *     (adminListComments({ reported: true })) and zeroes the badge count;
+ *   - a fresh report from a DIFFERENT reporter re-opens the reported view
+ *     (a re-report from the same ip_hash stays deduped — the row persists as
+ *     'resolved' and ON CONFLICT DO NOTHING keeps it that way, by design);
+ *   - auth + CSRF guards: no session → 401, cross-origin → 403, unknown id → 404.
+ *
+ * The same-origin CSRF check in the admin middleware is satisfied with an Origin
+ * header matching the request URL.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { admin } from "../src/routes/admin";
+import {
+	insertComment,
+	adminListComments,
+	countOpenReportsByComment,
+} from "../src/db/queries";
+import type { Bindings } from "../src/index";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const SID = "a".repeat(64);
+const ADMIN_ID = "01HADMIN0000000000000000AB";
+const AUTHOR_ID = "01HAUTHOR000000000000000AB";
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	return { sqlite, db: makeD1(sqlite) };
+};
+
+const makeSessions = () => ({
+	async get(key: string) {
+		if (key !== `sess:${SID}`) return null;
+		return JSON.stringify({ user_id: ADMIN_ID, expires_at: 4_102_444_800_000 });
+	},
+	async put() {},
+	async delete() {},
+});
+
+const makeKv = () => {
+	const store = new Map<string, string>([
+		["meta:latest-release", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+		["meta:recent-releases", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+	]);
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+const execCtx = {
+	waitUntil() {},
+	passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+let sqlite: DatabaseSync;
+let db: any;
+let env: Bindings;
+
+const seedReport = (commentId: string, ipHash: string): void => {
+	sqlite
+		.prepare(
+			`INSERT INTO reports
+			   (id, comment_id, reporter_user_id, reporter_ip_hash, reason, status, created_at)
+			 VALUES (?, ?, NULL, ?, NULL, 'open', ?)`,
+		)
+		.run(`rep_${ipHash}`, commentId, ipHash, 1_700_000_000_000);
+};
+
+const seedComment = async (): Promise<string> => {
+	const c = await insertComment(db, {
+		post_slug: "hello",
+		parent_id: null,
+		user_id: AUTHOR_ID,
+		body_md: "a comment",
+		body_html: "<p>a comment</p>",
+		renderer_version: 1,
+		status: "approved",
+		ip_hash: null,
+		user_agent: null,
+	});
+	return c.id;
+};
+
+const reportedIds = async (): Promise<string[]> =>
+	(await adminListComments(db, { reported: true }, 50, null, null)).map(
+		(r) => r.id,
+	);
+
+const reportStatuses = (commentId: string): string[] =>
+	(
+		sqlite
+			.prepare("SELECT status FROM reports WHERE comment_id = ? ORDER BY id")
+			.all(commentId) as { status: string }[]
+	).map((r) => r.status);
+
+const lastResolveAudit = ():
+	| { action: string; meta: string | null }
+	| undefined =>
+	sqlite
+		.prepare(
+			"SELECT action, meta FROM audit_log WHERE action = 'report.resolve' ORDER BY created_at DESC LIMIT 1",
+		)
+		.get() as { action: string; meta: string | null } | undefined;
+
+beforeEach(() => {
+	const fresh = freshDb();
+	sqlite = fresh.sqlite;
+	db = fresh.db;
+	sqlite
+		.prepare(
+			`INSERT INTO users (id, provider, provider_id, name, is_admin, role, created_at)
+			 VALUES (?, 'github', '1', 'Op', 1, 'admin', ?)`,
+		)
+		.run(ADMIN_ID, 1_700_000_000_000);
+	sqlite
+		.prepare(
+			"INSERT INTO users (id, provider, provider_id, name, created_at) VALUES (?, 'anon', NULL, 'Author', ?)",
+		)
+		.run(AUTHOR_ID, 1_700_000_000_000);
+	sqlite
+		.prepare("INSERT INTO posts (slug, created_at) VALUES ('hello', ?)")
+		.run(1_700_000_000_000);
+	env = {
+		DB: db,
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+	} as unknown as Bindings;
+});
+
+const app = () => new Hono<{ Bindings: Bindings }>().route("/admin", admin);
+
+const resolve = (
+	id: string,
+	opts: { cookie?: boolean; origin?: string | null } = {},
+) => {
+	const { cookie = true, origin = "http://localhost" } = opts;
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (cookie) headers.cookie = `garrul_sess=${SID}`;
+	if (origin) headers.origin = origin;
+	return app().request(
+		`/admin/api/comments/${id}/reports/resolve`,
+		{ method: "POST", headers, body: "{}" },
+		env as unknown as Record<string, unknown>,
+		execCtx,
+	);
+};
+
+describe("POST /admin/api/comments/:id/reports/resolve", () => {
+	it("resolves open reports, drops the comment from the reported filter, audits report.resolve", async () => {
+		const id = await seedComment();
+		seedReport(id, "ip-a");
+		seedReport(id, "ip-b");
+
+		// Pre-condition: surfaced in the reported queue with two open reports.
+		expect(await reportedIds()).toContain(id);
+		expect((await countOpenReportsByComment(db, [id]))[id]).toBe(2);
+
+		const res = await resolve(id);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true, id, resolved: 2 });
+
+		// Post-condition: rows flipped, dropped from the queue, badge zeroed.
+		expect(reportStatuses(id)).toEqual(["resolved", "resolved"]);
+		expect(await reportedIds()).not.toContain(id);
+		expect((await countOpenReportsByComment(db, [id]))[id]).toBeUndefined();
+
+		const audit = lastResolveAudit();
+		expect(audit?.action).toBe("report.resolve");
+		const meta = JSON.parse(audit?.meta ?? "{}");
+		expect(meta.resolved_count).toBe(2);
+		expect(meta.post_slug).toBe("hello");
+	});
+
+	it("re-appears in the reported view when a different reporter flags it again", async () => {
+		const id = await seedComment();
+		seedReport(id, "ip-a");
+		await resolve(id);
+		expect(await reportedIds()).not.toContain(id);
+
+		// A new reporter (distinct ip_hash) opens a fresh report.
+		seedReport(id, "ip-c");
+		expect(await reportedIds()).toContain(id);
+		expect((await countOpenReportsByComment(db, [id]))[id]).toBe(1);
+	});
+
+	it("is a no-op (resolved: 0) when the comment has no open reports", async () => {
+		const id = await seedComment();
+		const res = await resolve(id);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true, id, resolved: 0 });
+	});
+
+	it("rejects an unauthenticated request", async () => {
+		const id = await seedComment();
+		seedReport(id, "ip-a");
+		const res = await resolve(id, { cookie: false });
+		expect(res.status).toBe(401);
+		expect(reportStatuses(id)).toEqual(["open"]);
+	});
+
+	it("rejects a cross-origin request (CSRF)", async () => {
+		const id = await seedComment();
+		seedReport(id, "ip-a");
+		const res = await resolve(id, { origin: "https://evil.example" });
+		expect(res.status).toBe(403);
+		expect(reportStatuses(id)).toEqual(["open"]);
+	});
+
+	it("returns 404 for a non-existent comment", async () => {
+		const res = await resolve("01HNOPE0000000000000000000");
+		expect(res.status).toBe(404);
+	});
+});

--- a/tests/admin-webhooks-render.test.ts
+++ b/tests/admin-webhooks-render.test.ts
@@ -138,7 +138,7 @@ describe("renderWebhookForm", () => {
 		expect(html).toContain('value="whsec_abcdef0123456789"');
 	});
 
-	it("renders all five known events as checkboxes", () => {
+	it("renders all known events as checkboxes", () => {
 		const html = renderWebhookForm({ endpoint: null, error: null });
 		for (const ev of [
 			"comment.posted",
@@ -146,6 +146,7 @@ describe("renderWebhookForm", () => {
 			"comment.deleted",
 			"comment.approved",
 			"comment.spam",
+			"comment.reported",
 		]) {
 			expect(html).toContain(`name="event_${ev}"`);
 		}
@@ -153,14 +154,14 @@ describe("renderWebhookForm", () => {
 
 	it("checks every event by default in new mode", () => {
 		const html = renderWebhookForm({ endpoint: null, error: null });
-		// Five checkboxes, all checked.
+		// Six checkboxes, all checked.
 		const checkedCount = (html.match(/type="checkbox" name="event_/g) ?? [])
 			.length;
 		const checkedAttrCount = (
 			html.match(/type="checkbox" name="event_[^"]+" checked/g) ?? []
 		).length;
-		expect(checkedCount).toBe(5);
-		expect(checkedAttrCount).toBe(5);
+		expect(checkedCount).toBe(6);
+		expect(checkedAttrCount).toBe(6);
 	});
 
 	it("checks only the selected events in edit mode", () => {

--- a/tests/report-api.test.ts
+++ b/tests/report-api.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Reader reporting — API endpoint (POST /api/v1/comments/:id/report).
+ *
+ * Run against REAL SQLite (node:sqlite, every migration applied) so the
+ * insertReport dedup (UNIQUE comment_id, reporter_ip_hash) is exercised for
+ * real, plus:
+ *
+ *   - a fresh report returns { ok: true } and writes one row;
+ *   - a duplicate from the same network is a silent no-op (still { ok: true },
+ *     no second row, webhook NOT re-fired);
+ *   - the per-IP-hash rate-limit blocks rapid repeats with 429;
+ *   - reporting a non-existent comment returns { ok: true } (no enumeration);
+ *   - a new report fires the comment.reported webhook.
+ *
+ * fireWebhook is mocked so we can assert it's called exactly when a NEW report
+ * lands (and not on a duplicate) without standing up a real delivery pipeline.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+vi.mock("../src/lib/webhook", () => ({ fireWebhook: vi.fn() }));
+
+import { reports } from "../src/routes/api.reports";
+import { insertComment } from "../src/db/queries";
+import { fireWebhook } from "../src/lib/webhook";
+import type { Bindings } from "../src/index";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	return { sqlite, db: makeD1(sqlite) };
+};
+
+// Counting KV: records request stamps, so the rate-limit actually triggers on
+// the second rapid call (short bucket default = 1 / 10s).
+const countingKv = () => {
+	const store = new Map<string, string>();
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+	};
+};
+
+// Always-empty KV: rate-limit reads see no prior requests, so every call is
+// allowed. Used to isolate the DB-level dedup from the rate-limit.
+const openKv = () => ({
+	async get() {
+		return null;
+	},
+	async put() {},
+	async delete() {},
+});
+
+const execCtx = {
+	waitUntil() {},
+	passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+let sqlite: DatabaseSync;
+let db: any;
+
+const mkEnv = (rateLimits: unknown): Bindings =>
+	({
+		DB: db,
+		RATE_LIMITS: rateLimits,
+		TREE_CACHE: openKv(),
+		SESSIONS: { async get() { return null; }, async put() {}, async delete() {} },
+		ANALYTICS: { writeDataPoint() {} },
+		IP_HASH_SECRET: "test-secret",
+		ENV: "dev",
+	}) as unknown as Bindings;
+
+const seedComment = async (): Promise<string> => {
+	const c = await insertComment(db, {
+		post_slug: "hello",
+		parent_id: null,
+		user_id: "01HAUTHOR000000000000000AB",
+		body_md: "a comment",
+		body_html: "<p>a comment</p>",
+		renderer_version: 1,
+		status: "approved",
+		ip_hash: null,
+		user_agent: null,
+	});
+	return c.id;
+};
+
+const app = () => new Hono<{ Bindings: Bindings }>().route("/", reports);
+
+const report = (env: Bindings, id: string, body: unknown = {}) =>
+	app().request(
+		`/${id}/report`,
+		{
+			method: "POST",
+			headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.7" },
+			body: JSON.stringify(body),
+		},
+		env as unknown as Record<string, unknown>,
+		execCtx,
+	);
+
+const reportRowCount = (commentId: string): number =>
+	(
+		sqlite
+			.prepare("SELECT COUNT(*) AS n FROM reports WHERE comment_id = ?")
+			.get(commentId) as { n: number }
+	).n;
+
+beforeEach(() => {
+	const fresh = freshDb();
+	sqlite = fresh.sqlite;
+	db = fresh.db;
+	// FK targets for insertComment: an author user and the post row.
+	sqlite
+		.prepare(
+			"INSERT INTO users (id, provider, provider_id, name, created_at) VALUES (?, 'anon', NULL, 'Author', ?)",
+		)
+		.run("01HAUTHOR000000000000000AB", 1_700_000_000_000);
+	sqlite
+		.prepare("INSERT INTO posts (slug, created_at) VALUES ('hello', ?)")
+		.run(1_700_000_000_000);
+	(fireWebhook as Mock).mockClear();
+});
+
+describe("POST /api/v1/comments/:id/report", () => {
+	it("records a fresh report and fires the comment.reported webhook", async () => {
+		const id = await seedComment();
+		const res = await report(mkEnv(openKv()), id, { reason: "spam link" });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(reportRowCount(id)).toBe(1);
+		expect(fireWebhook).toHaveBeenCalledTimes(1);
+		expect((fireWebhook as Mock).mock.calls[0][2]).toMatchObject({
+			event: "comment.reported",
+			comment_id: id,
+			post_slug: "hello",
+		});
+	});
+
+	it("dedupes a second report from the same network (no new row, no webhook)", async () => {
+		const id = await seedComment();
+		// openKv → rate-limit never blocks, so both calls reach insertReport and
+		// the UNIQUE(comment_id, ip_hash) is what makes the second a no-op.
+		const env = mkEnv(openKv());
+		await report(env, id, { reason: "first" });
+		(fireWebhook as Mock).mockClear();
+		const res = await report(env, id, { reason: "second" });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(reportRowCount(id)).toBe(1);
+		expect(fireWebhook).not.toHaveBeenCalled();
+	});
+
+	it("rate-limits rapid repeats from the same IP with 429", async () => {
+		const id = await seedComment();
+		const env = mkEnv(countingKv());
+		const first = await report(env, id);
+		expect(first.status).toBe(200);
+		const second = await report(env, id);
+		expect(second.status).toBe(429);
+		// The blocked call never reached insertReport.
+		expect(reportRowCount(id)).toBe(1);
+	});
+
+	it("returns ok for a non-existent comment without inserting (no enumeration)", async () => {
+		const res = await report(mkEnv(openKv()), "01HNOPE0000000000000000000");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(fireWebhook).not.toHaveBeenCalled();
+	});
+
+	it("caps an over-long reason instead of rejecting", async () => {
+		const id = await seedComment();
+		const res = await report(mkEnv(openKv()), id, { reason: "x".repeat(5000) });
+		expect(res.status).toBe(200);
+		const row = sqlite
+			.prepare("SELECT reason FROM reports WHERE comment_id = ?")
+			.get(id) as { reason: string };
+		expect(row.reason.length).toBe(300);
+	});
+});

--- a/tests/report-api.test.ts
+++ b/tests/report-api.test.ts
@@ -210,6 +210,16 @@ describe("POST /api/v1/comments/:id/report", () => {
 		expect(fireWebhook).not.toHaveBeenCalled();
 	});
 
+	it("returns ok for a deleted comment without opening a report", async () => {
+		const id = await seedComment();
+		sqlite.prepare("UPDATE comments SET status = 'deleted' WHERE id = ?").run(id);
+		const res = await report(mkEnv(openKv()), id);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(reportRowCount(id)).toBe(0);
+		expect(fireWebhook).not.toHaveBeenCalled();
+	});
+
 	it("caps an over-long reason instead of rejecting", async () => {
 		const id = await seedComment();
 		const res = await report(mkEnv(openKv()), id, { reason: "x".repeat(5000) });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -284,6 +284,10 @@ describe("loadNumbers — defaults", () => {
 			comments_per_page: 25,
 			replies_per_thread: 3,
 			auto_collapse_depth: 3,
+			auto_close_days: 0,
+			auto_close_at: 0,
+			community_min_votes: 5,
+			community_collapse_ratio: 0,
 		});
 	});
 

--- a/tests/thread-closure-api.test.ts
+++ b/tests/thread-closure-api.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Thread closure — API-level enforcement (src/routes/api.comments.ts).
+ *
+ * resolveThreadOpen is unit-tested in thread.test.ts; this exercises the route
+ * that consults it, against REAL SQLite (node:sqlite, every migration applied)
+ * so the upsertPost → resolveThreadOpen → insert path runs end-to-end:
+ *
+ *   - POST is rejected 403 when the post is manually closed, for both a
+ *     top-level comment AND a reply (the gate runs before the parent lookup).
+ *   - POST still succeeds on an open post.
+ *   - GET carries accepting_comments + closed_reason so the widget can render
+ *     the closed state.
+ *
+ * The signed-in POST path is used deliberately: it skips Turnstile and the
+ * rate-limit, neither of which can run offline, while still hitting the exact
+ * closure gate the anonymous path uses.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { comments } from "../src/routes/api.comments";
+import {
+	installMockCaches,
+	uninstallMockCaches,
+	type MockCache,
+} from "./helpers/mock-caches";
+import type { Bindings } from "../src/index";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+// node:sqlite → D1 adapter (same shape as queries-comments-realdb.test.ts).
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const SID = "a".repeat(64);
+const USER = "01HU000000000000000000";
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	const db = makeD1(sqlite);
+	return { sqlite, db };
+};
+
+// Far-future-expiry SESSIONS double mapping our one session to USER.
+const makeSessions = () => ({
+	async get(key: string) {
+		if (key !== `sess:${SID}`) return null;
+		return JSON.stringify({ user_id: USER, expires_at: 4_102_444_800_000 });
+	},
+	async put() {},
+	async delete() {},
+});
+
+const makeKv = () => {
+	const store = new Map<string, string>();
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+let mockCache: MockCache;
+let sqlite: DatabaseSync;
+let env: Bindings;
+
+beforeEach(() => {
+	mockCache = installMockCaches();
+	const fresh = freshDb();
+	sqlite = fresh.sqlite;
+	// One signed-in, non-banned user to author comments.
+	sqlite
+		.prepare(
+			"INSERT INTO users (id, provider, provider_id, name, created_at) VALUES (?, ?, ?, ?, ?)",
+		)
+		.run(USER, "anon", null, "Tester", 1_700_000_000_000);
+	env = {
+		DB: fresh.db,
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+		ANALYTICS: { writeDataPoint() {} },
+		ENV: "dev",
+		EDIT_WINDOW_MINUTES: "15",
+		IP_HASH_SECRET: "test-secret",
+	} as unknown as Bindings;
+});
+afterEach(() => uninstallMockCaches());
+
+const app = () => new Hono<{ Bindings: Bindings }>().route("/", comments);
+
+// Workers ExecutionContext double. The POST handler reads c.executionCtx to
+// schedule webhook/notification fanout via waitUntil; Hono throws on the getter
+// when no context is supplied, so the route needs one even in tests.
+const execCtx = {
+	waitUntil() {},
+	passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+const post = (bodyObj: Record<string, unknown>) =>
+	app().request(
+		"/",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json", cookie: `garrul_sess=${SID}` },
+			body: JSON.stringify(bodyObj),
+		},
+		env as unknown as Record<string, unknown>,
+		execCtx,
+	);
+
+const closePost = (slug: string) =>
+	sqlite.prepare("UPDATE posts SET closed = 1 WHERE slug = ?").run(slug);
+
+describe("thread closure — POST gate", () => {
+	it("accepts a comment on an open post", async () => {
+		const res = await post({ slug: "open-post", body: "hello there" });
+		expect(res.status).toBe(201);
+	});
+
+	it("rejects a new top-level comment with 403 on a closed post", async () => {
+		// Create the post via a first comment, then freeze it.
+		await post({ slug: "frozen", body: "first comment" });
+		closePost("frozen");
+		const res = await post({ slug: "frozen", body: "second comment" });
+		expect(res.status).toBe(403);
+		const json = (await res.json()) as { error: string };
+		expect(json.error).toMatch(/closed/i);
+	});
+
+	it("rejects a REPLY with 403 on a closed post (gate runs before parent lookup)", async () => {
+		const first = await post({ slug: "frozen2", body: "parent comment" });
+		const parent = (await first.json()) as { comment: { id: string } };
+		closePost("frozen2");
+		const res = await post({
+			slug: "frozen2",
+			parent_id: parent.comment.id,
+			body: "a reply",
+		});
+		expect(res.status).toBe(403);
+	});
+});
+
+describe("thread closure — GET payload", () => {
+	const list = async (slug: string) => {
+		const res = await app().request(
+			`/?slug=${slug}`,
+			{},
+			env as unknown as Record<string, unknown>,
+			execCtx,
+		);
+		return res.json() as Promise<{
+			accepting_comments: boolean;
+			closed_reason: string | null;
+		}>;
+	};
+
+	it("reports accepting_comments=true for an open post", async () => {
+		await post({ slug: "live", body: "a comment" });
+		const payload = await list("live");
+		expect(payload.accepting_comments).toBe(true);
+		expect(payload.closed_reason).toBeNull();
+	});
+
+	it("reports accepting_comments=false + reason for a closed post", async () => {
+		await post({ slug: "shut", body: "a comment" });
+		closePost("shut");
+		const payload = await list("shut");
+		expect(payload.accepting_comments).toBe(false);
+		expect(payload.closed_reason).toBe("post_closed");
+	});
+
+	it("treats a post with no row yet as open", async () => {
+		const payload = await list("never-commented");
+		expect(payload.accepting_comments).toBe(true);
+	});
+});

--- a/tests/thread-closure-api.test.ts
+++ b/tests/thread-closure-api.test.ts
@@ -180,6 +180,38 @@ describe("thread closure — POST gate", () => {
 		});
 		expect(res.status).toBe(403);
 	});
+
+	it("does not let a later request overwrite an established published_at anchor", async () => {
+		const real = 1_700_000_000_000; // host's real publish time, set on first comment
+		const bogus = 1_000_000_000_000; // ~year 2001, a poison attempt
+		const publishedAt = (slug: string) =>
+			(sqlite.prepare("SELECT published_at FROM posts WHERE slug = ?").get(slug) as {
+				published_at: number | null;
+			}).published_at;
+
+		await post({ slug: "anchored", body: "first", post_published: real });
+		expect(publishedAt("anchored")).toBe(real);
+
+		// A second comment carrying a bogus older anchor must not clobber it.
+		const res = await post({ slug: "anchored", body: "second", post_published: bogus });
+		expect(res.status).toBe(201);
+		expect(publishedAt("anchored")).toBe(real);
+	});
+
+	it("does not persist published_at when the gate rejects the request", async () => {
+		await post({ slug: "frozen3", body: "first comment" });
+		closePost("frozen3");
+		const res = await post({
+			slug: "frozen3",
+			body: "blocked",
+			post_published: 1_000_000_000_000,
+		});
+		expect(res.status).toBe(403);
+		const row = sqlite
+			.prepare("SELECT published_at FROM posts WHERE slug = ?")
+			.get("frozen3") as { published_at: number | null };
+		expect(row.published_at).toBeNull();
+	});
 });
 
 describe("thread closure — GET payload", () => {

--- a/tests/thread.test.ts
+++ b/tests/thread.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Thread acceptance resolver tests (src/lib/thread.ts).
+ *
+ * resolveThreadOpen is a pure function, so these are straight input→output
+ * assertions — no KV/D1 stubs needed. The contract under test is the
+ * precedence chain:
+ *
+ *   1. comments_enabled OFF  → closed (comments_disabled)
+ *   2. posts.closed set      → closed (post_closed)
+ *   3. auto_close_at reached  → closed (sunset)
+ *   4. auto_close_days passed → closed (aged_out), anchored on published_at
+ *                               falling back to created_at
+ *   else                     → open
+ */
+import { describe, it, expect } from "vitest";
+import { resolveThreadOpen } from "../src/lib/thread";
+
+const DAY = 86_400_000;
+const NOW = 1_700_000_000_000; // fixed "now" for all cases
+
+// Convenience builders so each test states only the field it exercises.
+const post = (
+	over: Partial<{ closed: boolean; published_at: number | null; created_at: number }> = {},
+) => ({
+	closed: false,
+	published_at: null,
+	created_at: NOW,
+	...over,
+});
+const flags = (comments_enabled = true) => ({ comments_enabled });
+const numbers = (auto_close_days = 0, auto_close_at = 0) => ({
+	auto_close_days,
+	auto_close_at,
+});
+
+describe("resolveThreadOpen", () => {
+	it("is open by default (no rules active)", () => {
+		expect(resolveThreadOpen(post(), flags(), numbers(), NOW)).toEqual({
+			open: true,
+		});
+	});
+
+	it("closes everywhere when comments_enabled is off (highest precedence)", () => {
+		// Even with the post otherwise open, the global switch wins.
+		const r = resolveThreadOpen(post(), flags(false), numbers(), NOW);
+		expect(r).toEqual({ open: false, reason: "comments_disabled" });
+	});
+
+	it("global switch beats a per-post close (precedence order)", () => {
+		const r = resolveThreadOpen(
+			post({ closed: true }),
+			flags(false),
+			numbers(),
+			NOW,
+		);
+		expect(r.reason).toBe("comments_disabled");
+	});
+
+	it("closes a manually frozen post", () => {
+		const r = resolveThreadOpen(post({ closed: true }), flags(), numbers(), NOW);
+		expect(r).toEqual({ open: false, reason: "post_closed" });
+	});
+
+	it("closes once the instance sunset is reached", () => {
+		const r = resolveThreadOpen(post(), flags(), numbers(0, NOW), NOW);
+		expect(r).toEqual({ open: false, reason: "sunset" });
+	});
+
+	it("stays open just before the sunset instant", () => {
+		const r = resolveThreadOpen(post(), flags(), numbers(0, NOW + 1), NOW);
+		expect(r.open).toBe(true);
+	});
+
+	it("sunset of 0 is disabled (epoch 0 must not close everything)", () => {
+		const r = resolveThreadOpen(post(), flags(), numbers(0, 0), NOW);
+		expect(r.open).toBe(true);
+	});
+
+	it("ages out a thread N days after published_at", () => {
+		const published_at = NOW - 6 * DAY;
+		const r = resolveThreadOpen(
+			post({ published_at }),
+			flags(),
+			numbers(5),
+			NOW,
+		);
+		expect(r).toEqual({ open: false, reason: "aged_out" });
+	});
+
+	it("stays open inside the age window", () => {
+		const published_at = NOW - 4 * DAY;
+		const r = resolveThreadOpen(
+			post({ published_at }),
+			flags(),
+			numbers(5),
+			NOW,
+		);
+		expect(r.open).toBe(true);
+	});
+
+	it("anchors age on published_at over created_at when both are present", () => {
+		// created_at (first comment) is old, but the article was published
+		// recently — the published_at anchor keeps the thread open.
+		const r = resolveThreadOpen(
+			post({ published_at: NOW - 1 * DAY, created_at: NOW - 100 * DAY }),
+			flags(),
+			numbers(5),
+			NOW,
+		);
+		expect(r.open).toBe(true);
+	});
+
+	it("falls back to created_at when published_at is null", () => {
+		const r = resolveThreadOpen(
+			post({ published_at: null, created_at: NOW - 10 * DAY }),
+			flags(),
+			numbers(5),
+			NOW,
+		);
+		expect(r).toEqual({ open: false, reason: "aged_out" });
+	});
+
+	it("auto_close_days of 0 is disabled (ancient thread stays open)", () => {
+		const r = resolveThreadOpen(
+			post({ created_at: NOW - 10_000 * DAY }),
+			flags(),
+			numbers(0),
+			NOW,
+		);
+		expect(r.open).toBe(true);
+	});
+
+	it("a manual close beats an otherwise-open age rule", () => {
+		const r = resolveThreadOpen(
+			post({ closed: true, published_at: NOW }),
+			flags(),
+			numbers(5),
+			NOW,
+		);
+		expect(r.reason).toBe("post_closed");
+	});
+});

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -64,6 +64,20 @@ OAUTH_CALLBACK_BASE = "https://comments.example.com"
 # REPLIES_PER_THREAD = "3"
 # Replies at this nesting depth or deeper start collapsed (0 = never):
 # AUTO_COLLAPSE_DEPTH = "3"
+# Thread lifecycle — auto-close threads to new comments (existing comments,
+# reactions and votes stay live). Evaluated lazily at read/write time, no cron.
+# Both default 0 = disabled. Close a thread N days after its article was
+# published (host passes data-published; falls back to first-comment time):
+# AUTO_CLOSE_DAYS = "0"
+# Hard sunset: close ALL threads at this epoch-ms timestamp (admin Settings uses
+# a date picker that writes the epoch):
+# AUTO_CLOSE_AT = "0"
+# Community auto-collapse — reader-side, reversible fold of low-scored comments
+# (requires DOWNVOTES_ENABLED). Minimum total votes before the ratio applies —
+# the brigading floor (default 5):
+# COMMUNITY_MIN_VOTES = "5"
+# Percent of downvotes/total that triggers collapse (0 = off, range 0-100):
+# COMMUNITY_COLLAPSE_RATIO = "0"
 # Optional: Cloudflare account ID — paired with the CF_API_TOKEN secret to
 # enable the /admin/usage analytics page.
 # CF_ACCOUNT_ID = "0123abcd..."


### PR DESCRIPTION
## Summary

A combined moderation/community release (targets **v1.17.0**). Six features
plus a docs-drift cleanup, landed as dependency-ordered topic commits, each
verified green (typecheck + tests) on its own snapshot.

- **Reader reporting + queue** — readers can flag a comment from the widget
  (anon-allowed, no Turnstile; rate-limited by `ip_hash` + a
  `UNIQUE(comment_id, reporter_ip_hash)` dedup; reason length-capped; `ok`
  returned regardless of new-vs-dup to avoid enumeration). Fires a new
  `comment.reported` webhook. Surfaced in the admin queue (a **Reported** tab
  with an open-count badge) and on comment detail (reasons + one-click Dismiss).
- **Per-post close + auto-close** — one resolver (`resolveThreadOpen`) answers
  "is this thread accepting comments?" from, in precedence order: global
  `comments_enabled` → per-post `closed` → instance sunset (`AUTO_CLOSE_AT`) →
  age (`AUTO_CLOSE_DAYS`, anchored on the host's `data-published`, falling back
  to first-comment time). Evaluated **lazily** at read/write — no cron, no row
  migration, no KV writes. Closing blocks new comments/replies only; existing
  comments, reactions and votes stay live.
- **One-click ban-author** — surfaces the existing ghost-ban mechanism on a
  comment, recording the originating comment in audit meta. Confirm dialog
  spells out the network-egress (CGNAT) caveat for anon authors.
- **Comment draft autosave** — client-only; debounced into `localStorage`
  (namespaced per slug + parent), restored only into an empty field, cleared on
  submit/cancel, all storage try/catch-wrapped.
- **Community auto-collapse** — reversible, **client-side** fold of low-scored
  comments past `COMMUNITY_COLLAPSE_RATIO` once `COMMUNITY_MIN_VOTES` is met
  (the brigading floor). Purely cosmetic; content stays in the payload.

Feature 7 from the original inventory (community *hide-and-hold*) is
deliberately **deferred** — reporting + collapse deliver the community-moderation
value without auto-suppressing legit content.

## Security posture

- Closure is enforced **server-side** in the POST handler (the widget flag is
  cosmetic); the gate runs before parent lookup so a reply can't bypass it.
- Reports store only `ip_hash` (never a raw IP); dedup + shared rate-limit guard
  report-bombing; report counts are operator-only (never in the public payload)
  so they can't be a brigading signal.
- New state-changing routes go through the existing Origin/CSRF middleware;
  ban-author is admin-only; report reasons are escaped on admin render.

## New operator env vars (all optional, default off)

`AUTO_CLOSE_DAYS`, `AUTO_CLOSE_AT`, `COMMUNITY_MIN_VOTES`,
`COMMUNITY_COLLAPSE_RATIO` — env defaults overridable at runtime from admin
Settings. Documented in `wrangler.example.toml` + `AGENTS-OPERATE.md §5`;
recorded in `release-manifest.json` (addedIn 1.17.0). New host attribute
`data-published` documented in `AGENTS.md`.

## Migration

`0013_thread_lifecycle_reports.sql` — adds `posts.closed`, `posts.published_at`,
and the `reports` table. Forward-only, no renderer bump.

## Verification

- `npm run typecheck`, `npm test` (**627 pass / 46 files**),
  `npm run manifest:check`, `npm run build`, `npm run size` (**11.29 KB gzip**,
  ceiling 20 KB) — all green.
- New server-side suites cover the actual gates: `resolveThreadOpen` precedence
  + `published_at` anchor/fallback; POST 403 on closed (comment **and** reply);
  GET `accepting_comments` payload; report dedup / rate-limit / webhook / no
  enumeration; per-post close authZ + CSRF; ban-author authZ + audit meta.
- The client-side widget behaviors (report button, draft autosave, collapse
  toggle, closed-state banner) are verified by typecheck + bundle only — the
  repo has no widget test harness, matching existing convention. The
  authoritative gate for each is server-side and is tested.

## Commits

Topic commits, dependency-ordered: `feat(db)` → `feat(settings)` → `feat(api)`
→ `feat(admin)` → `feat(widget)` → `docs` → `chore(release): v1.17.0`. The three
admin moderation surfaces (per-post close, reporting queue, ban-author) interleave
within the same render functions and routes, so they share one `feat(admin)`
commit to keep every commit compilable.
