### PR TITLE
fix: prefill comment edit form with original markdown

### DIFF
--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -797,6 +797,31 @@ comments.get("/", async (c) => {
 	return c.json(payload);
 });
 
+/**
+ * Return the raw markdown source of a comment so the widget's edit form can
+ * prefill with what the author originally typed. The tree endpoint only ships
+ * `body_html`; round-tripping an edit needs `body_md`. Gated identically to the
+ * PATCH below (author-only, within the edit window) since it's the same
+ * authorization surface — only the author, only while still editable.
+ */
+comments.get("/:id/source", async (c) => {
+	const id = c.req.param("id");
+	const existing = await getComment(c.env.DB, id);
+	if (!existing) return c.json({ error: t("err.not_found") }, 404);
+
+	const session = await readSession(c);
+	const sessionUserId = session?.user_id;
+	if (!sessionUserId || sessionUserId !== existing.user_id) {
+		return c.json({ error: t("err.edit.not_author") }, 403);
+	}
+
+	if (Date.now() - existing.created_at > editWindowMs(c.env)) {
+		return c.json({ error: t("err.edit.window_expired") }, 403);
+	}
+
+	return c.json({ body_md: existing.body_md });
+});
+
 comments.patch("/:id", async (c) => {
 	const id = c.req.param("id");
 	const existing = await getComment(c.env.DB, id);

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1353,13 +1353,31 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	const wrap = el("form", "gr-reply-form");
 	wrap.setAttribute("data-mode", "edit");
 	const ta = el("textarea");
-	ta.value = ""; // Plain-text rewrite would require body_md from the server;
-	// here we just let the user retype. To round-trip the source markdown,
-	// the API should also return body_md for the author within the edit
-	// window. (Tracked as a follow-up; the server-side update endpoint
-	// already accepts raw markdown.)
-	ta.placeholder = "Edit your comment…";
+	// Prefill with the original markdown source. The tree payload only carries
+	// body_html, so we fetch body_md on demand from the author-only source
+	// endpoint (same author + edit-window gate as the PATCH). Disable the field
+	// while it loads so the author can't start typing over content that's about
+	// to be replaced, then re-enable and focus once it arrives.
+	ta.value = "";
+	ta.placeholder = "Loading…";
 	ta.required = true;
+	ta.disabled = true;
+	fetch(
+		`${ctx.apiBase}/api/v1/comments/${encodeURIComponent(n.id)}/source`,
+		{ credentials: "include" },
+	)
+		.then((res) => (res.ok ? res.json() : null))
+		.then((data: { body_md?: string } | null) => {
+			if (data && typeof data.body_md === "string") ta.value = data.body_md;
+		})
+		.catch(() => {})
+		.finally(() => {
+			// The author may have hit Cancel before the fetch resolved.
+			if (!ta.isConnected) return;
+			ta.disabled = false;
+			ta.placeholder = "Edit your comment…";
+			ta.focus();
+		});
 	const actions = el("div", "gr-reply-actions");
 	const save = el("button", undefined, "Save");
 	save.type = "submit";

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1353,15 +1353,25 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	const wrap = el("form", "gr-reply-form");
 	wrap.setAttribute("data-mode", "edit");
 	const ta = el("textarea");
-	// Prefill with the original markdown source. The tree payload only carries
-	// body_html, so we fetch body_md on demand from the author-only source
-	// endpoint (same author + edit-window gate as the PATCH). Disable the field
-	// while it loads so the author can't start typing over content that's about
-	// to be replaced, then re-enable and focus once it arrives.
 	ta.value = "";
 	ta.placeholder = "Loading…";
 	ta.required = true;
+	const actions = el("div", "gr-reply-actions");
+	const save = el("button", undefined, "Save");
+	save.type = "submit";
+	const cancel = el("button", undefined, "Cancel");
+	cancel.type = "button";
+	cancel.addEventListener("click", () => wrap.remove());
+	actions.append(save, cancel);
+
+	// Prefill with the original markdown source. The tree payload only carries
+	// body_html, so we fetch body_md on demand from the author-only source
+	// endpoint (same author + edit-window gate as the PATCH). Disable both the
+	// field and Save while it loads so the author can't type over content that's
+	// about to be replaced, nor submit an empty body before the prefill lands;
+	// re-enable and focus once it arrives.
 	ta.disabled = true;
+	save.disabled = true;
 	fetch(
 		`${ctx.apiBase}/api/v1/comments/${encodeURIComponent(n.id)}/source`,
 		{ credentials: "include" },
@@ -1375,16 +1385,10 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 			// The author may have hit Cancel before the fetch resolved.
 			if (!ta.isConnected) return;
 			ta.disabled = false;
+			save.disabled = false;
 			ta.placeholder = "Edit your comment…";
 			ta.focus();
 		});
-	const actions = el("div", "gr-reply-actions");
-	const save = el("button", undefined, "Save");
-	save.type = "submit";
-	const cancel = el("button", undefined, "Cancel");
-	cancel.type = "button";
-	cancel.addEventListener("click", () => wrap.remove());
-	actions.append(save, cancel);
 	wrap.append(buildWritePreview(ta, ctx.apiBase, true), actions);
 	wrap.addEventListener("submit", async (e) => {
 		e.preventDefault();

--- a/tests/comments-edit-source.test.ts
+++ b/tests/comments-edit-source.test.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/v1/comments/:id/source — raw markdown for the edit form.
+ *
+ * The tree payload only carries `body_html`; the widget's Edit form needs the
+ * original `body_md` to prefill. This endpoint hands it back, gated exactly like
+ * the PATCH: only the author, only within the edit window. This is an authZ
+ * contract — a comment's source must never leak to other users, anonymous
+ * viewers, or the author after the window closes.
+ *
+ * No Miniflare: a hand-rolled D1 stub returns a single comment by id from
+ * `.first()`, and a SESSIONS KV double + cookie simulates sessions.
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { comments } from "../src/routes/api.comments";
+import type { Bindings } from "../src/index";
+
+const AUTHOR = "01HU000000000000000000";
+const OTHER = "01HU000000000000000001";
+const SID_AUTHOR = "a".repeat(64);
+const SID_OTHER = "b".repeat(64);
+const COMMENT_ID = "01HUCOMMENT0000000000A";
+
+const mkComment = (created_at: number) => ({
+	id: COMMENT_ID,
+	post_slug: "hello",
+	parent_id: null,
+	user_id: AUTHOR,
+	body_md: "the **original** source",
+	body_html: "<p>the <strong>original</strong> source</p>",
+	renderer_version: 1,
+	status: "approved",
+	edited_at: null,
+	deleted_at: null,
+	deleted_by: null,
+	ip_hash: null,
+	user_agent: null,
+	created_at,
+	score_up: 0,
+	score_down: 0,
+});
+
+// D1 double: getComment issues `SELECT ... FROM comments WHERE id = ?` + first().
+const makeDb = (comment: ReturnType<typeof mkComment> | null) => ({
+	prepare: (sql: string) => ({
+		bind(..._args: unknown[]) {
+			return this;
+		},
+		async first() {
+			if (sql.includes("FROM comments WHERE id = ?")) return comment;
+			return null;
+		},
+		async all() {
+			return { results: [] };
+		},
+	}),
+});
+
+const makeSessions = () => {
+	const map: Record<string, string> = {
+		[`sess:${SID_AUTHOR}`]: AUTHOR,
+		[`sess:${SID_OTHER}`]: OTHER,
+	};
+	return {
+		async get(key: string) {
+			const uid = map[key];
+			if (!uid) return null;
+			return JSON.stringify({ user_id: uid, expires_at: 4_102_444_800_000 });
+		},
+		async put() {},
+		async delete() {},
+	};
+};
+
+const mkEnv = (comment: ReturnType<typeof mkComment> | null) =>
+	({
+		DB: makeDb(comment),
+		SESSIONS: makeSessions(),
+		EDIT_WINDOW_MINUTES: "5",
+	}) as unknown as Bindings;
+
+const getSource = async (env: Bindings, cookie?: string) => {
+	const app = new Hono<{ Bindings: Bindings }>().route("/", comments);
+	const res = await app.request(
+		`/${COMMENT_ID}/source`,
+		cookie ? { headers: { cookie } } : {},
+		env as unknown as Record<string, unknown>,
+	);
+	return res;
+};
+
+describe("GET /comments/:id/source", () => {
+	it("returns body_md to the author within the edit window", async () => {
+		const env = mkEnv(mkComment(Date.now() - 60_000)); // 1 min ago
+		const res = await getSource(env, `garrul_sess=${SID_AUTHOR}`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { body_md: string };
+		expect(body.body_md).toBe("the **original** source");
+	});
+
+	it("403s for a different signed-in user", async () => {
+		const env = mkEnv(mkComment(Date.now() - 60_000));
+		const res = await getSource(env, `garrul_sess=${SID_OTHER}`);
+		expect(res.status).toBe(403);
+	});
+
+	it("403s for anonymous viewers", async () => {
+		const env = mkEnv(mkComment(Date.now() - 60_000));
+		const res = await getSource(env);
+		expect(res.status).toBe(403);
+	});
+
+	it("403s once the edit window has expired", async () => {
+		const env = mkEnv(mkComment(Date.now() - 10 * 60_000)); // 10 min ago
+		const res = await getSource(env, `garrul_sess=${SID_AUTHOR}`);
+		expect(res.status).toBe(403);
+	});
+
+	it("404s for a missing comment", async () => {
+		const env = mkEnv(null);
+		const res = await getSource(env, `garrul_sess=${SID_AUTHOR}`);
+		expect(res.status).toBe(404);
+	});
+});


### PR DESCRIPTION
## Problem

Clicking **Edit** on a comment opened a blank textarea. The tree payload only carries \`body_html\`, never the source markdown, so the widget had nothing to prefill and the author had to retype from scratch.

## Fix

- **New endpoint** \`GET /api/v1/comments/:id/source\` returns \`body_md\`, gated identically to the existing PATCH: author-only, and only within the edit window.
- **Widget** \`openEditor\` now fetches \`body_md\` on Edit click and prefills the textarea (disabled + "Loading…" placeholder while in flight, focused once it arrives; falls back to an empty box if the fetch fails).

## Tests

New \`tests/comments-edit-source.test.ts\` covers the authZ contract:
- author within window → 200 + \`body_md\`
- different signed-in user → 403
- anonymous → 403
- expired edit window → 403
- missing comment → 404

Full suite: 663 passing, typecheck clean, embed bundle 11.4KB gzipped (budget 20KB).

## Note

Server contract is fully tested. The widget fetch-and-prefill is verified by inspection + typecheck (Garrul has no DOM/widget test harness) — worth a quick manual check in a browser.