### PR TITLE
feat: move the runtime-tunable dials into the admin settings panel

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -141,7 +141,7 @@ between the two is a build error, not a silent misclassification.
 | `ENV` | var | Switches dev affordances (CORS open, cookies `SameSite=Lax`). Production must be `production`. | `production` | `wrangler.toml` |
 | `ALLOWED_ORIGINS` | var | Comma-separated origins allowed to embed + call `/api/*`. Doubles as the CSRF `Origin` allowlist. See section 6. | `https://yourblog.example.com` | `wrangler.toml` |
 | `ADMIN_EMAILS` | var | Comma-separated emails. OAuth signups matching get auto-admin. | `you@example.com` | `wrangler.toml` |
-| `EDIT_WINDOW_MINUTES` | var | Minutes a commenter can edit their own post. | `15` | `wrangler.toml` |
+| `EDIT_WINDOW_MINUTES` | var | Minutes a commenter can edit their own post. Default 15; `0` disables editing. | `15` | `wrangler.toml` default; **Admin → Settings** overrides |
 | `PUBLIC_BASE_URL` | var | Public URL of the Worker; used in permalinks + email bodies. | `https://comments.example.com` | `wrangler.toml` |
 | `CANONICAL_URL` | var | Optional. Override for the public URL used by the `/AGENTS.md` route when the inbound `Host` differs from the canonical address. | `https://comments.example.com` | `wrangler.toml` |
 | `OAUTH_CALLBACK_BASE` | var | Base URL for OAuth callbacks; must match the URI registered with each provider. Usually identical to `PUBLIC_BASE_URL`. | `https://comments.example.com` | `wrangler.toml` |
@@ -171,9 +171,9 @@ between the two is a build error, not a silent misclassification.
 | `AKISMET_API_KEY` | secret | Optional. Akismet API key. Required when `SPAM_PROVIDER=akismet`. | `...` | `wrangler secret put` / `.dev.vars` |
 | `AKISMET_SITE_URL` | secret | Optional. Public site URL sent to Akismet alongside each check. Required when `SPAM_PROVIDER=akismet`. | `https://yourblog.example.com` | `wrangler secret put` / `.dev.vars` |
 | `SPAM_FORM_TS_SECRET` | secret | Optional. HMAC key for signed form-timestamp tokens. Set when `SPAM_HONEYPOT_MIN_MS` is in use, otherwise the timing check cannot be trusted. | ``openssl rand -base64 32` output` | `wrangler secret put` / `.dev.vars` |
-| `SPAM_LINK_THRESHOLD` | var | Optional. Flag a comment to `pending` when it contains more than N URLs. Unset = off. Tripped signals never silently drop a comment — they route it to the admin queue. | `3` | `wrangler.toml` |
-| `SPAM_HONEYPOT_MIN_MS` | var | Optional. Flag a comment to `pending` when the form was submitted faster than N milliseconds. Pair with `SPAM_FORM_TS_SECRET`. Unset = off. | `1500` | `wrangler.toml` |
-| `SPAM_FIRST_COMMENT_MODERATE` | var | Optional. Route the first comment from any new author to `pending`. Unset = off. | `true` | `wrangler.toml` |
+| `SPAM_LINK_THRESHOLD` | var | Optional. Flag a comment to `pending` when it contains more than N URLs. Unset (or `-1`) = off; `0` flags any comment containing a link. Tripped signals never silently drop a comment — they route it to the admin queue. | `3` | `wrangler.toml` default; **Admin → Settings** overrides |
+| `SPAM_HONEYPOT_MIN_MS` | var | Optional. Flag a comment to `pending` when the form was submitted faster than N milliseconds. Pair with `SPAM_FORM_TS_SECRET` — without it the timestamp is unsigned and the check is skipped. Unset or `0` = off. | `1500` | `wrangler.toml` default; **Admin → Settings** overrides |
+| `SPAM_FIRST_COMMENT_MODERATE` | var | Optional. Route the first comment from any new author to `pending`. Unset = off. | `true` | `wrangler.toml` default; **Admin → Settings** overrides |
 | `CF_ACCOUNT_ID` | var | Optional. Cloudflare account ID; paired with `CF_API_TOKEN` to enable the `/admin/usage` analytics page. | `0123abcd...` | `wrangler.toml` (or `wrangler secret put` — the in-app setup guide uses the secret form; both work) |
 | `CF_API_TOKEN` | secret | Optional. Cloudflare API token for `/admin/usage`. Least-privilege scopes: Account.Analytics:Read, Account.D1:Read, Account.Workers KV Storage:Read. The page renders setup instructions when either value is unset. | `...` | `wrangler secret put` / `.dev.vars` |
 | `GITHUB_TOKEN` | secret | Optional. Raises the GitHub API rate limit for the `/admin/*` "update available" check. Unauthenticated calls allow 60 req/hr per IP and Cloudflare egress IPs are shared across colos. Read-only `public_repo` scope is sufficient. | `ghp_...` | `wrangler secret put` / `.dev.vars` |
@@ -199,9 +199,10 @@ hand once a deploy has used them.
 
 ### Feature flags: runtime overrides (since v1.10.0)
 
-The seven feature flags — `COMMENTS_ENABLED`, `REACTIONS_ENABLED`,
+The eight feature flags — `COMMENTS_ENABLED`, `REACTIONS_ENABLED`,
 `VOTING_ENABLED`, `DOWNVOTES_ENABLED`, `PAGE_REACTIONS_ENABLED`,
-`PAGE_VOTES_ENABLED`, `SHOW_DELETED_PLACEHOLDERS` — are **hybrid config**. The env vars above are only
+`PAGE_VOTES_ENABLED`, `SHOW_DELETED_PLACEHOLDERS`,
+`SPAM_FIRST_COMMENT_MODERATE` — are **hybrid config**. The env vars above are only
 the *defaults*. Each flag is resolved with the precedence:
 
 ```
@@ -269,6 +270,38 @@ ignores them behaves exactly as before.
   recovers (on the next render). It's derived in the browser because votes
   deliberately don't bust the tree cache, so a server flag would be stale against
   the score the widget already shows. Requires `DOWNVOTES_ENABLED`.
+
+### Edit window & anti-spam dials (since v1.22.0)
+
+The last three integers to join the hybrid chain (DB settings row > env var >
+default, server-side clamped), edited from **Settings → Moderation**.
+
+- `EDIT_WINDOW_MINUTES` — minutes an author may revise their own comment.
+  Clamped to `0`–`1440`; `0` disables editing entirely (the widget hides the
+  Edit affordance and `PATCH`/`GET :id/source` both 403). **Two behavior
+  changes in v1.22.0:** the resolved default is now the documented **15**
+  rather than the 5 minutes the code actually fell back to when the var was
+  unset, and an explicit `0` means "no editing" instead of silently meaning 5.
+  Installs that set the var explicitly are unaffected.
+- `SPAM_LINK_THRESHOLD` — clamped to `-1`–`50`. `-1` (the default, and where an
+  unset or junk value lands) disables the check; `0` flags any comment carrying
+  a link. The sentinel exists because this signal has always had three states —
+  collapsing "off" onto `0` would have redefined what `0` does for anyone
+  already running it.
+- `SPAM_HONEYPOT_MIN_MS` — clamped to `0`–`60000`; `0` (default) = off. Still
+  requires `SPAM_FORM_TS_SECRET`, which stays a secret: without it the form
+  timestamp is unsigned and forgeable, so `evaluateSpam` skips the check and the
+  `/api/v1/comments/form-token` endpoint 404s. The Settings page flags this
+  combination inline rather than letting the dial sit there doing nothing.
+
+`SPAM_PROVIDER`, `AKISMET_API_KEY`, `AKISMET_SITE_URL` and `SPAM_FORM_TS_SECRET`
+stay **deploy-time**: the provider needs capability detection (`akismet` wants an
+API key, `workers-ai` wants the `[ai]` binding) and a dropdown offering a
+provider the deploy cannot serve is worse than an env var. Everything that can
+lock an operator out — all secrets, `ENV`, `ALLOWED_ORIGINS`, `ADMIN_EMAILS`, and
+the OAuth-redirect URLs — is deliberately excluded from runtime editing, because
+DB > env means one bad admin save beats the declared config and the surface you'd
+use to fix it is the one you just broke.
 
 ## 6. `ALLOWED_ORIGINS` deep-dive
 
@@ -354,10 +387,19 @@ available on top of Turnstile. **All off by default.** Flagged comments
 flip to `status='pending'` and land in the admin queue rather than
 being silently dropped.
 
+The three heuristics are runtime settings: the env vars below set the
+deploy-time default, and **Admin → Settings → Moderation** overrides
+them without a redeploy (DB row > env var > built-in default). Retune
+them there while watching what the queue catches. `SPAM_PROVIDER` and
+its credentials stay deploy-time.
+
 - `SPAM_HONEYPOT_MIN_MS` + `SPAM_FORM_TS_SECRET` — flag submissions
   that arrive faster than wall-clock `N` ms after the form rendered.
+  `0`/unset = off. Without the secret the timestamp is unsigned and the
+  check is skipped.
 - `SPAM_LINK_THRESHOLD` — flag comments containing more than `N`
-  http(s)/mailto links.
+  http(s)/mailto links. `-1`/unset = off; `0` flags any comment with a
+  link.
 - `SPAM_FIRST_COMMENT_MODERATE=true` — every commenter's first-ever
   comment goes to pending until you approve once.
 - `SPAM_PROVIDER` — set to `akismet` or `workers-ai` to enable a
@@ -515,7 +557,7 @@ Pages (top nav):
 | `/admin/audit` | Audit log with filter form (admin, action, target kind/id, date range). |
 | `/admin/subscriptions` | Email subscription list. Filter by email/post/confirmed/unsubscribed. Actions: manual unsubscribe, resend confirmation. |
 | `/admin/operator` | Batch operations: rerender stale comments (POSTs `/admin/api/ops/rerender` in 50-row chunks until done), seed-demo (idempotent; gated to `ENV != "production"`), and the Disqus import upload (see below). |
-| `/admin/settings` | Editable form for feature flags + display/pagination numbers, saved to the `settings` D1 table (no redeploy — see section 5). Also renders a read-only `(set)`/`(unset)` summary of secret-backed config (Turnstile, email, OAuth), which still changes via `wrangler secret put`. |
+| `/admin/settings` | Editable form for feature flags, display/pagination numbers, and the moderation dials (edit window, thread auto-close, community auto-collapse, the three anti-spam heuristics), saved to the `settings` D1 table (no redeploy — see section 5). Also renders a read-only `(set)`/`(unset)` summary of deploy-time config (Turnstile, email, OAuth, spam provider), which still changes via `wrangler secret put` / `wrangler.toml`. |
 | `/admin/webhooks` | Outbound webhook endpoints: add/pause/delete, per-endpoint secret + event filter, adapter (`generic` / `slack` / `discord` / `telegram`), failure counts and retry status. |
 | `/admin/telegram` | **Admin-only.** Telegram operator bot: shows whether the bot token/webhook secret are set, links your personal Telegram account (one-time code or deep link), toggles the daily digest, and unlinks. See `docs/telegram.md`. |
 | `/admin/saved-replies` | Moderator saved replies: create/edit canned responses, private or shared scope, postable onto a comment from the queue. |

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -277,12 +277,13 @@ The last three integers to join the hybrid chain (DB settings row > env var >
 default, server-side clamped), edited from **Settings → Moderation**.
 
 - `EDIT_WINDOW_MINUTES` — minutes an author may revise their own comment.
-  Clamped to `0`–`1440`; `0` disables editing entirely (the widget hides the
-  Edit affordance and `PATCH`/`GET :id/source` both 403). **Two behavior
-  changes in v1.22.0:** the resolved default is now the documented **15**
-  rather than the 5 minutes the code actually fell back to when the var was
-  unset, and an explicit `0` means "no editing" instead of silently meaning 5.
-  Installs that set the var explicitly are unaffected.
+  Clamped to `0`–`10080` (a week); `0` disables editing entirely (the widget
+  hides the Edit affordance and `PATCH`/`GET :id/source` both 403). **Two
+  behavior changes in v1.22.0:** the resolved default is now the documented
+  **15** rather than the 5 minutes the code actually fell back to when the var
+  was unset, and an explicit `0` means "no editing" instead of silently meaning
+  5. Installs that set the var explicitly are unaffected — the ceiling is a week
+  precisely so a pre-existing longer window isn't silently shortened.
 - `SPAM_LINK_THRESHOLD` — clamped to `-1`–`50`. `-1` (the default, and where an
   unset or junk value lands) disables the check; `0` flags any comment carrying
   a link. The sentinel exists because this signal has always had three states —

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -264,7 +264,7 @@ goes — is section 5 of `AGENTS-OPERATE.md`, generated from
 | `RESEND_API_KEY`               | for digests          | Sender domain must be verified in Resend. |
 | `EMAIL_FROM`                   | for digests          | e.g. `Garrul <comments@example.com>`. |
 | `WEBHOOK_URL`                  | optional             | Fire-and-forget POST on comment events. |
-| `EDIT_WINDOW_MINUTES`          | optional             | Default 15. |
+| `EDIT_WINDOW_MINUTES`          | optional             | Default 15; `0` disables editing. Overridable at runtime from Admin → Settings. |
 | `JWT_SECRET`                   | reserved             | Declared in bindings; not used yet (sessions are KV-backed). Safe to set a random value or skip. |
 
 See `wrangler.example.toml` for the `[vars]` template with inline

--- a/docs/ANTISPAM.md
+++ b/docs/ANTISPAM.md
@@ -15,6 +15,8 @@ These don't need configuration; they ship with every Garrul instance:
 
 All three heuristics + the classifier adapter flip a flagged comment to `status='pending'` so it lands in the admin queue at `/admin/queue?status=pending`. **Nothing is ever silently dropped.** You decide whether to approve.
 
+**The three heuristics are runtime-tunable.** Each one has an env var below that sets the deploy-time default, but you can retune all three from **Admin → Settings → Moderation** without a redeploy — which is how you want to work while watching the queue. An admin save writes a `settings` row that overrides the env var (precedence is DB > env > built-in default); "Reset to defaults" clears the overrides and hands control back to `wrangler.toml`. The classifier in §4 stays deploy-time: it needs credentials, and a dropdown offering a provider the deploy can't reach is worse than an env var.
+
 ### 1. Honeypot timing (`SPAM_HONEYPOT_MIN_MS`)
 
 Bots typically POST immediately. Humans take seconds. The widget asks the server for a signed timestamp when the form loads; the server checks that enough wall-clock time passed before accepting.
@@ -23,13 +25,15 @@ Bots typically POST immediately. Humans take seconds. The widget asks the server
 SPAM_HONEYPOT_MIN_MS = "1500"   # flag if submit happens within 1.5s of form load
 ```
 
+`0` (or unset) turns the check off. Tunable at runtime as **Minimum fill time (ms)**.
+
 Also requires the HMAC secret:
 
 ```
 wrangler secret put SPAM_FORM_TS_SECRET
 ```
 
-Generate a strong random value (`openssl rand -hex 32`) and paste when prompted.
+Generate a strong random value (`openssl rand -hex 32`) and paste when prompted. Without it the timestamp is unsigned and therefore forgeable, so the check is skipped entirely — the Settings page says so inline if you enable the dial without the secret in place.
 
 ### 2. Link-count threshold (`SPAM_LINK_THRESHOLD`)
 
@@ -38,6 +42,8 @@ Counts `https?://` and `mailto:` occurrences in the comment body. Above the thre
 ```toml
 SPAM_LINK_THRESHOLD = "3"   # flag any comment with more than 3 links
 ```
+
+`-1` (or unset) turns the check off; `0` flags any comment containing a link at all. Tunable at runtime as **Link threshold**.
 
 Strong signal against link-farm spam. Some legit comments (e.g. linking 4-5 papers in a technical thread) will get flagged — that's why this routes to the queue, not to the bin.
 
@@ -48,6 +54,8 @@ Every new commenter's first-ever comment goes to `pending` until you approve onc
 ```toml
 SPAM_FIRST_COMMENT_MODERATE = "true"
 ```
+
+Tunable at runtime as **Hold every author's first comment**.
 
 Highest precision of the three heuristics. Cost: you have to log in and approve. Use on low-traffic blogs; skip on busy ones.
 

--- a/scripts/config-registry.ts
+++ b/scripts/config-registry.ts
@@ -75,6 +75,23 @@ export type ConfigEntry = {
 	 */
 	whereToSet?: string;
 	/**
+	 * The var is also a runtime setting: an admin can override it from Admin →
+	 * Settings, which writes a `settings` row that beats this env var (see
+	 * `src/lib/settings.ts` — precedence is DB > env > default). The env var
+	 * remains the declared deploy-time default.
+	 *
+	 * Recorded here so the §5 table says so. Without it that table would drift
+	 * into being the 7th hand-maintained config list, which is exactly what #42
+	 * set out to kill.
+	 *
+	 * Only for `var` entries that genuinely cannot lock an operator out. Never
+	 * mark a secret, `ENV`, `ALLOWED_ORIGINS`, `ADMIN_EMAILS`, or any URL that
+	 * must match a registered OAuth redirect: DB > env means one bad admin save
+	 * beats the operator's declared config, and the surface they'd use to undo it
+	 * is the one they just broke.
+	 */
+	adminEditable?: boolean;
+	/**
 	 * Secrets setup.sh generates locally and streams straight into wrangler,
 	 * so the value never touches disk. Excluded from secrets.example.env.
 	 */
@@ -97,6 +114,8 @@ export type ConfigEntry = {
 
 const SECRET_TARGET = "`wrangler secret put` / `.dev.vars`";
 const VAR_TARGET = "`wrangler.toml`";
+const ADMIN_EDITABLE_TARGET =
+	"`wrangler.toml` default; **Admin → Settings** overrides";
 
 export const CONFIG_REGISTRY: ConfigEntry[] = [
 	// ---------------------------------------------------------------- core
@@ -138,8 +157,10 @@ export const CONFIG_REGISTRY: ConfigEntry[] = [
 		kind: "var",
 		required: false,
 		group: "Core",
+		adminEditable: true,
 		hint: "minutes a commenter can edit their own post",
-		description: "Minutes a commenter can edit their own post.",
+		description:
+			"Minutes a commenter can edit their own post. Default 15; `0` disables editing.",
 		example: "15",
 		addedIn: "1.0.0",
 	},
@@ -487,9 +508,10 @@ export const CONFIG_REGISTRY: ConfigEntry[] = [
 		kind: "var",
 		required: false,
 		group: "Anti-spam",
+		adminEditable: true,
 		hint: "flag if more than N URLs in a comment body",
 		description:
-			"Optional. Flag a comment to `pending` when it contains more than N URLs. Unset = off. Tripped signals never silently drop a comment — they route it to the admin queue.",
+			"Optional. Flag a comment to `pending` when it contains more than N URLs. Unset (or `-1`) = off; `0` flags any comment containing a link. Tripped signals never silently drop a comment — they route it to the admin queue.",
 		example: "3",
 		addedIn: "1.1.1",
 	},
@@ -498,9 +520,10 @@ export const CONFIG_REGISTRY: ConfigEntry[] = [
 		kind: "var",
 		required: false,
 		group: "Anti-spam",
+		adminEditable: true,
 		hint: "flag if the form was submitted faster than N ms",
 		description:
-			"Optional. Flag a comment to `pending` when the form was submitted faster than N milliseconds. Pair with `SPAM_FORM_TS_SECRET`. Unset = off.",
+			"Optional. Flag a comment to `pending` when the form was submitted faster than N milliseconds. Pair with `SPAM_FORM_TS_SECRET` — without it the timestamp is unsigned and the check is skipped. Unset or `0` = off.",
 		example: "1500",
 		addedIn: "1.1.1",
 	},
@@ -509,6 +532,7 @@ export const CONFIG_REGISTRY: ConfigEntry[] = [
 		kind: "var",
 		required: false,
 		group: "Anti-spam",
+		adminEditable: true,
 		hint: "first comment from a new author goes to the queue",
 		description:
 			"Optional. Route the first comment from any new author to `pending`. Unset = off.",
@@ -740,9 +764,18 @@ export const GENERATED_SECRET_NAMES = SECRETS.filter((e) => e.generate).map(
 	(e) => e.name,
 );
 
-/** Where the §5 table tells operators to set a given entry. */
+/**
+ * Where the §5 table tells operators to set a given entry. An explicit
+ * `whereToSet` still wins — it exists for entries whose answer needs a caveat
+ * the generic branches can't express.
+ */
 export const targetFor = (e: ConfigEntry): string =>
-	e.whereToSet ?? (e.kind === "secret" ? SECRET_TARGET : VAR_TARGET);
+	e.whereToSet ??
+	(e.kind === "secret"
+		? SECRET_TARGET
+		: e.adminEditable
+			? ADMIN_EDITABLE_TARGET
+			: VAR_TARGET);
 
 /** Registry order, grouped, preserving first-seen group order. */
 export const groupsOf = (entries: ConfigEntry[]): [string, ConfigEntry[]][] => {

--- a/src/admin-ui/components/spam-summary.ts
+++ b/src/admin-ui/components/spam-summary.ts
@@ -1,21 +1,30 @@
 import type { Bindings } from "../../index";
+import type { ResolvedFlags, ResolvedNumbers } from "../../lib/settings";
 import { escapeHtml } from "../escape";
 
-export const spamSummary = (env: Bindings): string => {
+export const spamSummary = (
+	env: Bindings,
+	flags: ResolvedFlags,
+	numbers: ResolvedNumbers,
+): string => {
 	// Match the same gating evaluateSpam uses at runtime, otherwise the
-	// dashboard would claim a layer is active when its value is invalid
-	// (e.g. SPAM_LINK_THRESHOLD='NaN', SPAM_HONEYPOT_MIN_MS='0').
+	// dashboard would claim a layer is active when it isn't (honeypot timing
+	// without SPAM_FORM_TS_SECRET, or a disabled link threshold).
+	//
+	// The three heuristic dials come from the resolved settings, not raw env, so
+	// this line reflects an admin's Settings-page override rather than the
+	// deploy-time value it replaced. The provider and its credentials stay env.
 	const provider = env.SPAM_PROVIDER || "off";
 	const heuristics: string[] = [];
-	const minMs = Number.parseInt(env.SPAM_HONEYPOT_MIN_MS ?? "", 10);
-	if (Number.isFinite(minMs) && minMs > 0 && env.SPAM_FORM_TS_SECRET) {
+	const minMs = numbers.spam_honeypot_min_ms;
+	if (minMs > 0 && env.SPAM_FORM_TS_SECRET) {
 		heuristics.push(`honeypot-timing(${minMs}ms)`);
 	}
-	const linkThreshold = Number.parseInt(env.SPAM_LINK_THRESHOLD ?? "", 10);
-	if (Number.isFinite(linkThreshold) && linkThreshold >= 0) {
+	const linkThreshold = numbers.spam_link_threshold;
+	if (linkThreshold >= 0) {
 		heuristics.push(`link-threshold(>${linkThreshold})`);
 	}
-	if (env.SPAM_FIRST_COMMENT_MODERATE === "true") {
+	if (flags.spam_first_comment_moderate) {
 		heuristics.push("first-comment-moderation");
 	}
 	const heuristicsLabel =

--- a/src/admin-ui/pages/dashboard.ts
+++ b/src/admin-ui/pages/dashboard.ts
@@ -8,6 +8,7 @@ import type {
 	TopPost,
 } from "../../db/queries";
 import { spamSummary } from "../components/spam-summary";
+import type { ResolvedFlags, ResolvedNumbers } from "../../lib/settings";
 import { identiconSvg } from "../../lib/identicon";
 import { barChartSvg } from "../charts";
 import { escapeHtml } from "../escape";
@@ -144,6 +145,8 @@ const embedCard = (env: Bindings): string => {
 export const renderDashboard = (
 	data: DashboardData,
 	env: Bindings,
+	flags: ResolvedFlags,
+	numbers: ResolvedNumbers,
 ): string => {
 	const { stats, timeline, top_posts, top_commenters, oldest_pending, spam_rate, by_host } = data;
 	return `
@@ -164,7 +167,7 @@ export const renderDashboard = (
       <div class="l">spam rate (30d)</div>
     </div>
   </div>
-  <p class="muted">Anti-spam: ${spamSummary(env)}. See <a href="/admin/settings">Settings</a> to change.</p>
+  <p class="muted">Anti-spam: ${spamSummary(env, flags, numbers)}. See <a href="/admin/settings">Settings</a> to change.</p>
 </div>
 
 ${embedCard(env)}

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -58,6 +58,18 @@ const FLAG_META: { key: FlagKey; label: string; help: string }[] = [
 	},
 ];
 
+// Moderation-tab flags. Split from FLAG_META so the Features tab stays a list
+// of reader-facing surfaces; both arrays feed the same save payload.
+const MOD_FLAG_META: { key: FlagKey; label: string; help: string }[] = [
+	{
+		key: "spam_first_comment_moderate",
+		label: "Hold every author's first comment",
+		help: "Route the first-ever comment from each author to the moderation queue. Nothing is dropped — you approve or reject it.",
+	},
+];
+
+const ALL_FLAG_META = [...FLAG_META, ...MOD_FLAG_META];
+
 // Operator-facing labels + help for each numeric display setting. Bounds are
 // pulled from the settings registry so the input min/max can't drift from the
 // server-side clamp.
@@ -84,6 +96,11 @@ const NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
 // auto-close card below.
 const MOD_NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
 	{
+		key: "edit_window_minutes",
+		label: "Edit window (minutes)",
+		help: "How long after posting an author may still revise their own comment. 0 = no editing at all.",
+	},
+	{
 		key: "auto_close_days",
 		label: "Auto-close after (days)",
 		help: "Close a thread to new comments this many days after the article's publish date (or, if the host page doesn't send one, the first comment's date). 0 = never auto-close by age. Existing comments stay visible.",
@@ -100,6 +117,22 @@ const MOD_NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
 	},
 ];
 
+// Anti-spam heuristic dials. The classifier provider and its credentials stay
+// deploy-time (see the Configuration tab) — these three are the ones worth
+// retuning while watching the queue fill up.
+const SPAM_NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
+	{
+		key: "spam_link_threshold",
+		label: "Link threshold",
+		help: "Queue a comment carrying more than this many links. -1 = check off; 0 = queue anything with a link at all.",
+	},
+	{
+		key: "spam_honeypot_min_ms",
+		label: "Minimum fill time (ms)",
+		help: "Queue a comment submitted faster than this after the form loaded — bots post instantly, people don't. 0 = check off.",
+	},
+];
+
 export const renderSettings = (
 	env: Bindings,
 	flags: ResolvedFlags,
@@ -109,7 +142,6 @@ export const renderSettings = (
 		["ENV", env.ENV ?? "(unset)"],
 		["ALLOWED_ORIGINS", env.ALLOWED_ORIGINS ?? "(unset)"],
 		["ADMIN_EMAILS", env.ADMIN_EMAILS ?? "(unset)"],
-		["EDIT_WINDOW_MINUTES", env.EDIT_WINDOW_MINUTES ?? "(default: 15)"],
 		["TURNSTILE_SITE_KEY", env.TURNSTILE_SITE_KEY ? "(set)" : "(unset)"],
 		["GH_CLIENT_ID", env.GH_CLIENT_ID ? "(set)" : "(unset)"],
 		["GOOGLE_CLIENT_ID", env.GOOGLE_CLIENT_ID ? "(set)" : "(unset)"],
@@ -124,9 +156,6 @@ export const renderSettings = (
 		["SPAM_PROVIDER", env.SPAM_PROVIDER || "(unset)"],
 		["AKISMET_API_KEY", env.AKISMET_API_KEY ? "(set)" : "(unset)"],
 		["AKISMET_SITE_URL", env.AKISMET_SITE_URL ?? "(unset)"],
-		["SPAM_LINK_THRESHOLD", env.SPAM_LINK_THRESHOLD ?? "(unset)"],
-		["SPAM_HONEYPOT_MIN_MS", env.SPAM_HONEYPOT_MIN_MS ?? "(unset)"],
-		["SPAM_FIRST_COMMENT_MODERATE", env.SPAM_FIRST_COMMENT_MODERATE ?? "(unset)"],
 		["SPAM_FORM_TS_SECRET", env.SPAM_FORM_TS_SECRET ? "(set)" : "(unset)"],
 	];
 	const body = rows
@@ -164,9 +193,25 @@ export const renderSettings = (
 	};
 	const numberInputs = NUMBER_META.map(stepper).join("");
 	const modNumberInputs = MOD_NUMBER_META.map(stepper).join("");
+	const spamNumberInputs = SPAM_NUMBER_META.map(stepper).join("");
+	const modToggles = MOD_FLAG_META.map((f) =>
+		renderSwitch({
+			name: f.key,
+			model: `flags.${f.key}`,
+			label: f.label,
+			help: f.help,
+		}),
+	).join("");
+
+	// The honeypot timing check silently does nothing without the HMAC key that
+	// signs the form timestamp — an unsigned timestamp is trivially forged, so
+	// evaluateSpam skips the check entirely. Say so rather than letting an
+	// operator turn on a dial that can't fire.
+	const honeypotNeedsSecret =
+		numbers.spam_honeypot_min_ms > 0 && !env.SPAM_FORM_TS_SECRET;
 
 	const initial = JSON.stringify(
-		Object.fromEntries(FLAG_META.map((f) => [f.key, flags[f.key]])),
+		Object.fromEntries(ALL_FLAG_META.map((f) => [f.key, flags[f.key]])),
 	);
 	// Seed the whole resolved numbers object so keys surfaced as non-stepper
 	// controls (auto_close_at, via the date picker) round-trip on save too.
@@ -252,10 +297,11 @@ export const renderSettings = (
 
     <div class="card" x-show="tab === 'moderation'" x-cloak>
       <h2>Moderation</h2>
-      <p class="muted">Thread auto-close and community auto-collapse. All off by
-      default. Closing a thread only blocks <em>new</em> comments — existing ones
-      stay visible and votes/reactions stay live. Auto-collapse just folds
-      heavily-downvoted comments; readers can still expand them.</p>
+      <p class="muted">The edit window, thread auto-close and community
+      auto-collapse. Auto-close and auto-collapse are off by default. Closing a
+      thread only blocks <em>new</em> comments — existing ones stay visible and
+      votes/reactions stay live. Auto-collapse just folds heavily-downvoted
+      comments; readers can still expand them.</p>
       ${modNumberInputs}
       <div class="field-row">
         <span class="field-control">
@@ -276,6 +322,25 @@ export const renderSettings = (
       <input type="hidden" name="auto_close_at" x-model.number="nums.auto_close_at"
              min="${numberBounds("auto_close_at").min}"
              max="${numberBounds("auto_close_at").max}">
+    </div>
+
+    <div class="card" x-show="tab === 'moderation'" x-cloak>
+      <h2>Anti-spam heuristics</h2>
+      <p class="muted">Cheap local checks that run before the (optional, paid)
+      classifier. A tripped check never drops a comment — it routes it to the
+      queue, so tune these while watching what lands there. The classifier
+      provider and its API keys stay in <code>wrangler.toml</code>; see the
+      Configuration tab.</p>
+      ${modToggles}
+      ${spamNumberInputs}${
+				honeypotNeedsSecret
+					? `
+      <p class="muted"><strong>Fill-time check is inactive.</strong> It needs
+      <code>SPAM_FORM_TS_SECRET</code> to sign the form timestamp — without it an
+      unsigned time is trivially forged, so the check is skipped. Set the secret
+      with <code>wrangler secret put SPAM_FORM_TS_SECRET</code> and redeploy.</p>`
+					: ""
+			}
     </div>
 
     <p class="settings-actions" x-show="tab !== 'config'">

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -207,8 +207,13 @@ export const renderSettings = (
 	// signs the form timestamp — an unsigned timestamp is trivially forged, so
 	// evaluateSpam skips the check entirely. Say so rather than letting an
 	// operator turn on a dial that can't fire.
-	const honeypotNeedsSecret =
-		numbers.spam_honeypot_min_ms > 0 && !env.SPAM_FORM_TS_SECRET;
+	//
+	// Seeded into Alpine rather than baked into the server render: save() does
+	// not reload, so a server-only warning would stay hidden through the exact
+	// transition that creates the problem (operator raises the dial off 0, gets
+	// a "saved" toast, and never learns the check is inert). The secret itself
+	// is deploy-time, so its presence can't change while the page is open.
+	const hasFormTsSecret = Boolean(env.SPAM_FORM_TS_SECRET);
 
 	const initial = JSON.stringify(
 		Object.fromEntries(ALL_FLAG_META.map((f) => [f.key, flags[f.key]])),
@@ -223,6 +228,7 @@ export const renderSettings = (
   busy: false,
   flags: ${escapeHtml(initial)},
   nums: ${escapeHtml(numInitial)},
+  hasFormTsSecret: ${hasFormTsSecret},
   // Friendly proxy over the epoch-ms auto_close_at: the date picker reads/writes
   // a YYYY-MM-DD string; the canonical value stays the number in nums. Empty
   // string clears it to 0 (disabled). End-of-day UTC so the chosen date is fully
@@ -332,15 +338,12 @@ export const renderSettings = (
       provider and its API keys stay in <code>wrangler.toml</code>; see the
       Configuration tab.</p>
       ${modToggles}
-      ${spamNumberInputs}${
-				honeypotNeedsSecret
-					? `
-      <p class="muted"><strong>Fill-time check is inactive.</strong> It needs
+      ${spamNumberInputs}
+      <p class="muted" x-show="nums.spam_honeypot_min_ms > 0 && !hasFormTsSecret" x-cloak>
+      <strong>Fill-time check is inactive.</strong> It needs
       <code>SPAM_FORM_TS_SECRET</code> to sign the form timestamp — without it an
       unsigned time is trivially forged, so the check is skipped. Set the secret
-      with <code>wrangler secret put SPAM_FORM_TS_SECRET</code> and redeploy.</p>`
-					: ""
-			}
+      with <code>wrangler secret put SPAM_FORM_TS_SECRET</code> and redeploy.</p>
     </div>
 
     <p class="settings-actions" x-show="tab !== 'config'">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -150,11 +150,17 @@ const NUMBERS: Record<
 	// wrangler.toml already sets explicitly. Installs that omitted the var move
 	// 5 → 15; installs that set it are unaffected. An explicit 0 now means "no
 	// editing" instead of silently meaning 5.
+	//
+	// The ceiling is a week rather than a day because the pre-settings code had
+	// no ceiling at all: parseIntSetting clamps env values too, so any max we
+	// pick silently shortens the window for an install that already configured a
+	// longer one. A week covers every realistic "let people fix typos later"
+	// policy while keeping the stepper a sane range.
 	edit_window_minutes: {
 		env: "EDIT_WINDOW_MINUTES",
 		default: 15,
 		min: 0,
-		max: 1440,
+		max: 10_080,
 	},
 	// Flag a comment to `pending` when it carries MORE than this many links.
 	// -1 = check disabled; 0 = flag any comment containing a link.

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -31,7 +31,8 @@ export type FlagKey =
 	| "downvotes_enabled"
 	| "page_reactions_enabled"
 	| "page_votes_enabled"
-	| "show_deleted_placeholders";
+	| "show_deleted_placeholders"
+	| "spam_first_comment_moderate";
 
 export type ResolvedFlags = Record<FlagKey, boolean>;
 
@@ -42,7 +43,10 @@ export type NumberKey =
 	| "auto_close_days"
 	| "auto_close_at"
 	| "community_min_votes"
-	| "community_collapse_ratio";
+	| "community_collapse_ratio"
+	| "edit_window_minutes"
+	| "spam_link_threshold"
+	| "spam_honeypot_min_ms";
 
 export type ResolvedNumbers = Record<NumberKey, number>;
 
@@ -62,6 +66,15 @@ const FLAGS: Record<FlagKey, { env: keyof Bindings; default: boolean }> = {
 	// moderator]"), so threads never silently lose entries.
 	show_deleted_placeholders: {
 		env: "SHOW_DELETED_PLACEHOLDERS",
+		default: false,
+	},
+	// Route the first-ever comment from any author to `pending`. A moderation
+	// dial an operator wants to flip while watching the queue, so it resolves
+	// here rather than requiring a redeploy. Note the env var was historically
+	// matched with `=== "true"`; parseBool is laxer (any non-falsy string is
+	// true), which only ever turns a previously-ignored value like "yes" on.
+	spam_first_comment_moderate: {
+		env: "SPAM_FIRST_COMMENT_MODERATE",
 		default: false,
 	},
 };
@@ -126,6 +139,46 @@ const NUMBERS: Record<
 		default: 0,
 		min: 0,
 		max: 100,
+	},
+	// Minutes an author may edit their own comment after posting. 0 = editing
+	// disabled outright.
+	//
+	// The pre-settings code fell back to 5 minutes when the env var was unset
+	// or non-positive, while wrangler.example.toml, INSTALL.md and the admin
+	// Configuration table all advertised 15. A single resolver can only have one
+	// default, so it's 15 — the documented number, and the one every shipped
+	// wrangler.toml already sets explicitly. Installs that omitted the var move
+	// 5 → 15; installs that set it are unaffected. An explicit 0 now means "no
+	// editing" instead of silently meaning 5.
+	edit_window_minutes: {
+		env: "EDIT_WINDOW_MINUTES",
+		default: 15,
+		min: 0,
+		max: 1440,
+	},
+	// Flag a comment to `pending` when it carries MORE than this many links.
+	// -1 = check disabled; 0 = flag any comment containing a link.
+	//
+	// The sentinel is load-bearing: this signal has always had three states, and
+	// "off" could not collapse onto 0 without redefining what 0 does for anyone
+	// running SPAM_LINK_THRESHOLD="0" today. An unset or junk env var resolves to
+	// -1, matching the old `Number.isFinite(n) && n >= 0` gate.
+	spam_link_threshold: {
+		env: "SPAM_LINK_THRESHOLD",
+		default: -1,
+		min: -1,
+		max: 50,
+	},
+	// Flag a comment to `pending` when the form was submitted faster than this
+	// many milliseconds. 0 = disabled, which is also where an unset or junk env
+	// var lands — the old gate was `> 0`, so no existing value changes meaning.
+	// Only enforced when SPAM_FORM_TS_SECRET is also set (the timestamp is
+	// HMAC-signed; unsigned timing is trivially forged).
+	spam_honeypot_min_ms: {
+		env: "SPAM_HONEYPOT_MIN_MS",
+		default: 0,
+		min: 0,
+		max: 60_000,
 	},
 };
 

--- a/src/lib/spam/heuristics.ts
+++ b/src/lib/spam/heuristics.ts
@@ -116,8 +116,9 @@ export const countLinks = (bodyMd: string): number => {
 
 /**
  * True when this is the author's first-ever comment (no prior rows in D1
- * keyed on user_id). Caller gates on SPAM_FIRST_COMMENT_MODERATE before
- * paying the query.
+ * keyed on user_id). Caller gates on the resolved
+ * `spam_first_comment_moderate` setting (or an enabled classifier, which uses
+ * this as a feature) before paying the query.
  */
 export const isFirstComment = async (
 	db: D1Database,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -241,17 +241,31 @@ admin.get("/", async (c) => {
 	const user = await requireMod(c);
 	if (user instanceof Response) return user;
 	const db = c.env.DB;
-	const [stats, timeline, topPosts, topCommenters, oldestPending, spamRate, byHost, updateInfo] =
-		await Promise.all([
-			adminStats(db),
-			adminTimeline(db, 30),
-			adminTopPosts(db, 30, 5),
-			adminTopCommenters(db, 30, 5),
-			adminOldestPending(db),
-			adminSpamRate(db, 30),
-			adminCommentsByHost(db),
-			peekCachedLatestVersion(c.env),
-		]);
+	const [
+		stats,
+		timeline,
+		topPosts,
+		topCommenters,
+		oldestPending,
+		spamRate,
+		byHost,
+		updateInfo,
+		flags,
+		numbers,
+	] = await Promise.all([
+		adminStats(db),
+		adminTimeline(db, 30),
+		adminTopPosts(db, 30, 5),
+		adminTopCommenters(db, 30, 5),
+		adminOldestPending(db),
+		adminSpamRate(db, 30),
+		adminCommentsByHost(db),
+		peekCachedLatestVersion(c.env),
+		// The anti-spam summary line reports the resolved heuristic dials, so it
+		// has to read them the same way evaluateSpam does.
+		loadFlags(c.env),
+		loadNumbers(c.env),
+	]);
 	const body = renderDashboard(
 		{
 			stats,
@@ -263,6 +277,8 @@ admin.get("/", async (c) => {
 			by_host: byHost,
 		},
 		c.env,
+		flags,
+		numbers,
 	);
 	return c.html(renderPage(c, "Dashboard", body, user, updateInfo));
 });

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -7,7 +7,7 @@
  * Routes:
  *   POST   /api/v1/comments              create
  *   GET    /api/v1/comments?slug=<slug>  list (flat; tree assembled M4)
- *   PATCH  /api/v1/comments/:id          edit (within EDIT_WINDOW_MINUTES)
+ *   PATCH  /api/v1/comments/:id          edit (within edit_window_minutes)
  *   DELETE /api/v1/comments/:id          soft-delete
  *
  * Auth:
@@ -50,7 +50,12 @@ import { readSession } from "../lib/session";
 import { verifyTurnstile } from "../lib/turnstile";
 import { writeEvent } from "../lib/analytics";
 import { fireWebhook } from "../lib/webhook";
-import { loadFlags, loadNumbers } from "../lib/settings";
+import {
+	loadFlags,
+	loadNumbers,
+	type ResolvedFlags,
+	type ResolvedNumbers,
+} from "../lib/settings";
 import { resolveThreadOpen } from "../lib/thread";
 import { bustTreeCache, TREE_CACHE_TTL, treeCacheKey } from "../lib/tree-cache";
 import {
@@ -139,10 +144,10 @@ const parsePublishedAt = (raw: number | string | null | undefined): number | nul
 	return ms;
 };
 
-const editWindowMs = (env: Bindings): number => {
-	const minutes = Number.parseInt(env.EDIT_WINDOW_MINUTES, 10);
-	return Number.isFinite(minutes) && minutes > 0 ? minutes * 60_000 : 5 * 60_000;
-};
+// Resolved edit window in ms. 0 minutes = editing disabled, and every caller
+// compares an elapsed time against this, so a 0 window rejects unconditionally.
+const editWindowMs = (numbers: ResolvedNumbers): number =>
+	numbers.edit_window_minutes * 60_000;
 
 const validName = (raw: string | undefined): { ok: true; name: string } | { ok: false; key: "err.name.required" | "err.name.too_long"; max?: number } => {
 	const name = (raw ?? "").trim();
@@ -176,8 +181,8 @@ const serializeComment = (c: Comment, author: User) => {
 
 /**
  * Mint a signed HMAC timestamp so the widget can prove how long the form was
- * displayed before submission. Verified server-side when both
- * `SPAM_HONEYPOT_MIN_MS` and `SPAM_FORM_TS_SECRET` are configured.
+ * displayed before submission. Verified server-side when both the resolved
+ * `spam_honeypot_min_ms` setting is positive and `SPAM_FORM_TS_SECRET` is set.
  *
  * 404s when either is missing — the widget always asks for a token but
  * tolerates a missing one (the existing field-honeypot still applies),
@@ -186,8 +191,12 @@ const serializeComment = (c: Comment, author: User) => {
  */
 comments.get("/form-token", async (c) => {
 	const secret = c.env.SPAM_FORM_TS_SECRET;
-	const minMs = Number.parseInt(c.env.SPAM_HONEYPOT_MIN_MS ?? "", 10);
-	if (!secret || !Number.isFinite(minMs) || minMs <= 0) {
+	// Resolved, not raw env: an admin who turns honeypot timing on from the
+	// Settings page needs this endpoint to start minting tokens immediately,
+	// otherwise every submission arrives unsigned and the check it just enabled
+	// flags nothing.
+	const { spam_honeypot_min_ms: minMs } = await loadNumbers(c.env);
+	if (!secret || minMs <= 0) {
 		return c.json({ error: "not_found" }, 404);
 	}
 	const token = await signFormTimestamp(Date.now(), secret);
@@ -209,9 +218,11 @@ type SpamEvaluation = {
 
 /**
  * Run the configured anti-spam signals against a candidate comment and
- * decide whether it goes in as `approved` or `pending`. Each signal is
- * gated by its own env var. Admins skip the check entirely. Heuristics
- * run first and short-circuit the (potentially paid) classifier call.
+ * decide whether it goes in as `approved` or `pending`. The three heuristic
+ * dials are runtime settings (DB override > env > default) so an operator can
+ * retune them from the Settings page while watching the queue; `SPAM_PROVIDER`
+ * and the credentials stay deploy-time. Admins skip the check entirely.
+ * Heuristics run first and short-circuit the (potentially paid) classifier call.
  *
  * Per-source verdicts are surfaced alongside the routing decision so the
  * caller can persist them to spam_verdicts once the comment id is known
@@ -219,6 +230,8 @@ type SpamEvaluation = {
  */
 const evaluateSpam = async (
 	env: Bindings,
+	flags: ResolvedFlags,
+	numbers: ResolvedNumbers,
 	author: User,
 	bodyMd: string,
 	postUrl: string | null,
@@ -230,8 +243,8 @@ const evaluateSpam = async (
 	const verdicts: PendingVerdict[] = [];
 	const heuristicsRaw: Record<string, unknown> = {};
 
-	const minMs = Number.parseInt(env.SPAM_HONEYPOT_MIN_MS ?? "", 10);
-	if (Number.isFinite(minMs) && minMs > 0 && env.SPAM_FORM_TS_SECRET) {
+	const minMs = numbers.spam_honeypot_min_ms;
+	if (minMs > 0 && env.SPAM_FORM_TS_SECRET) {
 		const v = await verifyFormTimestamp(
 			formTs,
 			env.SPAM_FORM_TS_SECRET,
@@ -242,8 +255,9 @@ const evaluateSpam = async (
 		if (v.flag) reasons.push(v.reason ?? "form_ts");
 	}
 
-	const linkThreshold = Number.parseInt(env.SPAM_LINK_THRESHOLD ?? "", 10);
-	if (Number.isFinite(linkThreshold) && linkThreshold >= 0) {
+	// -1 = disabled; 0 flags any comment carrying a link.
+	const linkThreshold = numbers.spam_link_threshold;
+	if (linkThreshold >= 0) {
 		const n = countLinks(bodyMd);
 		heuristicsRaw.link_count = { count: n, threshold: linkThreshold };
 		if (n > linkThreshold) reasons.push(`link_count:${n}`);
@@ -252,7 +266,7 @@ const evaluateSpam = async (
 	// Compute is_first_comment if either the moderate-on-first heuristic
 	// or the classifier is enabled — classifiers use it as a feature even
 	// when the operator hasn't asked us to auto-moderate on it.
-	const moderateFirst = env.SPAM_FIRST_COMMENT_MODERATE === "true";
+	const moderateFirst = flags.spam_first_comment_moderate;
 	let isFirst = false;
 	if (moderateFirst || env.SPAM_PROVIDER) {
 		isFirst = await isFirstComment(env.DB, author.id);
@@ -480,6 +494,8 @@ comments.post("/", async (c) => {
 	const userAgent = c.req.header("user-agent") ?? null;
 	const verdict = await evaluateSpam(
 		c.env,
+		flags,
+		numbers,
 		author,
 		bodyCheck.body,
 		postUrl,
@@ -815,7 +831,8 @@ comments.get("/:id/source", async (c) => {
 		return c.json({ error: t("err.edit.not_author") }, 403);
 	}
 
-	if (Date.now() - existing.created_at > editWindowMs(c.env)) {
+	const numbers = await loadNumbers(c.env);
+	if (Date.now() - existing.created_at > editWindowMs(numbers)) {
 		return c.json({ error: t("err.edit.window_expired") }, 403);
 	}
 
@@ -833,7 +850,8 @@ comments.patch("/:id", async (c) => {
 		return c.json({ error: t("err.edit.not_author") }, 403);
 	}
 
-	if (Date.now() - existing.created_at > editWindowMs(c.env)) {
+	const numbers = await loadNumbers(c.env);
+	if (Date.now() - existing.created_at > editWindowMs(numbers)) {
 		return c.json({ error: t("err.edit.window_expired") }, 403);
 	}
 

--- a/src/routes/api.config.ts
+++ b/src/routes/api.config.ts
@@ -16,8 +16,10 @@
  *     default precedence (see src/lib/settings.ts); operators toggle them at
  *     runtime from the admin Settings page.
  *   - numeric display settings (comments_per_page, replies_per_thread,
- *     auto_collapse_depth): page size and reply-collapse tuning, same
- *     DB-override > env > default precedence (see src/lib/settings.ts).
+ *     auto_collapse_depth, edit_window_minutes): page size, reply-collapse and
+ *     edit-window tuning, same DB-override > env > default precedence (see
+ *     src/lib/settings.ts). edit_window_minutes of 0 means editing is off; the
+ *     widget hides the Edit affordance and the PATCH route rejects regardless.
  *   - community auto-collapse thresholds (community_min_votes,
  *     community_collapse_ratio): the widget folds heavily-downvoted comments
  *     client-side using these (see src/widget). 0 ratio = disabled.
@@ -37,9 +39,6 @@ const isTruthy = (v: string | undefined): boolean =>
 	v === "1" || v?.toLowerCase() === "true";
 
 config.get("/", async (c) => {
-	const minutes = Number.parseInt(c.env.EDIT_WINDOW_MINUTES, 10);
-	const edit_window_minutes =
-		Number.isFinite(minutes) && minutes > 0 ? minutes : 5;
 	// Provider client-id/secret env-var names are typed as plain strings on
 	// ProviderConfig, so index the bindings through a string-keyed view.
 	const env = c.env as unknown as Record<string, string | undefined>;
@@ -55,7 +54,7 @@ config.get("/", async (c) => {
 	]);
 	return c.json({
 		turnstile_site_key: c.env.TURNSTILE_SITE_KEY || null,
-		edit_window_minutes,
+		edit_window_minutes: numbers.edit_window_minutes,
 		providers,
 		branding_hidden: isTruthy(c.env.BRANDING_HIDDEN),
 		comments_enabled: flags.comments_enabled,

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2085,7 +2085,9 @@ const loadOnce = async (
 	sort: SortKey,
 ) => {
 	let siteKey: string | null = null;
-	let editWindowMinutes = 5;
+	// Only used when /api/v1/config never answers — the server always sends a
+	// resolved value. Mirrors the server default (src/lib/settings.ts).
+	let editWindowMinutes = 15;
 	let providers: ReadonlyArray<OAuthProvider> = [];
 	let brandingHidden = false;
 	let commentsEnabled = true;
@@ -2122,7 +2124,7 @@ const loadOnce = async (
 				community_collapse_ratio?: number;
 			};
 			siteKey = cfg.turnstile_site_key ?? null;
-			editWindowMinutes = cfg.edit_window_minutes ?? 5;
+			editWindowMinutes = cfg.edit_window_minutes ?? 15;
 			providers = (cfg.providers ?? []).filter((p): p is OAuthProvider =>
 				Object.prototype.hasOwnProperty.call(PROVIDER_LABELS, p),
 			);

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -534,6 +534,14 @@ describe("renderDashboard", () => {
 		banned_users: 1,
 	};
 	const env = {} as Bindings;
+	// The anti-spam summary line reads the three heuristic dials from resolved
+	// settings, so the dashboard needs them alongside env.
+	const dashFlags = Object.fromEntries(
+		FLAG_KEYS.map((k) => [k, false]),
+	) as ResolvedFlags;
+	const dashNumbers = Object.fromEntries(
+		NUMBER_KEYS.map((k) => [k, 0]),
+	) as ResolvedNumbers;
 
 	it("renders the spam-rate percentage and oldest-pending link", () => {
 		const html = renderDashboard(
@@ -550,6 +558,8 @@ describe("renderDashboard", () => {
 				by_host: [],
 			},
 			env,
+			dashFlags,
+			dashNumbers,
 		);
 		expect(html).toContain("12.0%");
 		expect(html).toContain("/admin/comments/01HOLDEST");
@@ -570,6 +580,8 @@ describe("renderDashboard", () => {
 				by_host: [],
 			},
 			env,
+			dashFlags,
+			dashNumbers,
 		);
 		expect(html).toContain("No activity in this range");
 		expect(html).toContain("No pending comments");
@@ -590,6 +602,8 @@ describe("renderDashboard", () => {
 				],
 			},
 			env,
+			dashFlags,
+			dashNumbers,
 		);
 		expect(html).toContain("Comments by domain");
 		expect(html).toContain("a.example.com");
@@ -616,6 +630,8 @@ describe("renderDashboard", () => {
 				by_host: hosts,
 			},
 			env,
+			dashFlags,
+			dashNumbers,
 		);
 		expect(html).toContain("…and 3 more domains");
 		expect(html).toContain("h0.example.com");
@@ -636,6 +652,8 @@ describe("renderDashboard", () => {
 				],
 			},
 			env,
+			dashFlags,
+			dashNumbers,
 		);
 		expect(html).not.toContain("<svg/onload=alert(1)>");
 		expect(html).toContain("&lt;svg/onload=alert(1)&gt;");

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -703,4 +703,29 @@ describe("renderSettings field-name contract", () => {
 			expect(known.has(name)).toBe(true);
 		}
 	});
+
+	// The fill-time dial does nothing without SPAM_FORM_TS_SECRET, and save()
+	// doesn't reload the page — so the warning has to be client-reactive or it
+	// stays hidden through the one transition that matters (operator raises the
+	// dial off 0 and is told only "Settings saved").
+	it("drives the fill-time inactive warning from Alpine state", () => {
+		const off = renderSettings({} as Bindings, flags, {
+			...numbers,
+			spam_honeypot_min_ms: 0,
+		});
+		expect(off).toContain("hasFormTsSecret: false");
+		expect(off).toContain(
+			'x-show="nums.spam_honeypot_min_ms > 0 && !hasFormTsSecret"',
+		);
+		expect(off).toContain("Fill-time check is inactive.");
+	});
+
+	it("seeds hasFormTsSecret true once the secret is set", () => {
+		const withSecret = renderSettings(
+			{ SPAM_FORM_TS_SECRET: "s3cret" } as Bindings,
+			flags,
+			numbers,
+		);
+		expect(withSecret).toContain("hasFormTsSecret: true");
+	});
 });

--- a/tests/admin-settings.test.ts
+++ b/tests/admin-settings.test.ts
@@ -178,6 +178,27 @@ describe("POST /admin/settings — numeric writes", () => {
 		expect(settingWrites(runs)).toContainEqual(["replies_per_thread", "0"]);
 	});
 
+	// spam_link_threshold is the one key whose floor is negative: -1 is the
+	// "check off" sentinel, 0 means "flag any link". A shared clamp that
+	// assumed a 0 floor would quietly turn the off switch into flag-any-link.
+	it("preserves the -1 off sentinel for spam_link_threshold", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { spam_link_threshold: -1 },
+		});
+		expect(res.status).toBe(200);
+		expect(settingWrites(runs)).toContainEqual(["spam_link_threshold", "-1"]);
+	});
+
+	it("clamps below-sentinel link thresholds up to -1", async () => {
+		const { env, runs } = mkEnv();
+		const res = await postSettings(env, {
+			numbers: { spam_link_threshold: -9 },
+		});
+		expect(res.status).toBe(200);
+		expect(settingWrites(runs)).toContainEqual(["spam_link_threshold", "-1"]);
+	});
+
 	it("accepts a numeric string and truncates a decimal", async () => {
 		const { env, runs } = mkEnv();
 		const res = await postSettings(env, {

--- a/tests/comments-edit-source.test.ts
+++ b/tests/comments-edit-source.test.ts
@@ -72,10 +72,30 @@ const makeSessions = () => {
 	};
 };
 
+// The edit window is a runtime setting now (DB > env > default), so the route
+// resolves it through loadNumbers — which needs the KV it caches into.
+const makeKv = () => {
+	const store = new Map<string, string>();
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+	};
+};
+
 const mkEnv = (comment: ReturnType<typeof mkComment> | null) =>
 	({
 		DB: makeDb(comment),
 		SESSIONS: makeSessions(),
+		TREE_CACHE: makeKv(),
 		EDIT_WINDOW_MINUTES: "5",
 	}) as unknown as Bindings;
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -558,9 +558,19 @@ describe("promoted runtime settings — edit_window_minutes", () => {
 		expect((await loadNumbers(env)).edit_window_minutes).toBe(0);
 	});
 
-	it("clamps above the 1440-minute ceiling", async () => {
+	it("clamps above the one-week ceiling", async () => {
 		const { env } = mkEnv({}, { EDIT_WINDOW_MINUTES: "99999" });
+		expect((await loadNumbers(env)).edit_window_minutes).toBe(10_080);
+	});
+
+	// The ceiling exists to bound the stepper, not to retune existing installs:
+	// parseIntSetting clamps env values too, so anything below it must survive
+	// untouched. A day and a week are the two plausible "long window" configs.
+	it("leaves a pre-existing multi-day env window alone", async () => {
+		const { env } = mkEnv({}, { EDIT_WINDOW_MINUTES: "1440" });
 		expect((await loadNumbers(env)).edit_window_minutes).toBe(1440);
+		const week = mkEnv({}, { EDIT_WINDOW_MINUTES: "10080" });
+		expect((await loadNumbers(week.env)).edit_window_minutes).toBe(10_080);
 	});
 });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -102,6 +102,7 @@ describe("loadFlags — defaults", () => {
 			page_reactions_enabled: false,
 			page_votes_enabled: false,
 			show_deleted_placeholders: false,
+			spam_first_comment_moderate: false,
 		});
 	});
 
@@ -288,6 +289,11 @@ describe("loadNumbers — defaults", () => {
 			auto_close_at: 0,
 			community_min_votes: 5,
 			community_collapse_ratio: 0,
+			// 15 (not the old 5-minute code fallback) is the documented default;
+			// -1 / 0 are the "check disabled" sentinels for the two spam dials.
+			edit_window_minutes: 15,
+			spam_link_threshold: -1,
+			spam_honeypot_min_ms: 0,
 		});
 	});
 
@@ -474,5 +480,146 @@ describe("route gating — comments", () => {
 		expect(((await res.json()) as { error: string }).error).toBe(
 			"comments_disabled",
 		);
+	});
+});
+
+/**
+ * The four settings promoted out of deploy-time env in #45. Two of them carry
+ * a sentinel that has to keep meaning exactly what the old env-var gate meant,
+ * so pin the whole ladder: unset, junk, out-of-range, and DB-beats-env.
+ */
+describe("promoted runtime settings — spam_link_threshold", () => {
+	it("defaults to -1 (check disabled) when unset", async () => {
+		const { env } = mkEnv();
+		expect((await loadNumbers(env)).spam_link_threshold).toBe(-1);
+	});
+
+	it("treats a junk env value as disabled, matching the old isFinite gate", async () => {
+		const { env } = mkEnv({}, { SPAM_LINK_THRESHOLD: "NaN" });
+		expect((await loadNumbers(env)).spam_link_threshold).toBe(-1);
+	});
+
+	it("clamps a negative env value to the -1 sentinel (old gate: n >= 0)", async () => {
+		const { env } = mkEnv({}, { SPAM_LINK_THRESHOLD: "-5" });
+		expect((await loadNumbers(env)).spam_link_threshold).toBe(-1);
+	});
+
+	it("keeps 0 distinct from off — 0 flags any comment carrying a link", async () => {
+		const { env } = mkEnv({}, { SPAM_LINK_THRESHOLD: "0" });
+		expect((await loadNumbers(env)).spam_link_threshold).toBe(0);
+	});
+
+	it("lets a DB row override the env var", async () => {
+		const { env } = mkEnv(
+			{ spam_link_threshold: "7" },
+			{ SPAM_LINK_THRESHOLD: "3" },
+		);
+		expect((await loadNumbers(env)).spam_link_threshold).toBe(7);
+	});
+});
+
+describe("promoted runtime settings — spam_honeypot_min_ms", () => {
+	it("defaults to 0 (disabled) when unset", async () => {
+		const { env } = mkEnv();
+		expect((await loadNumbers(env)).spam_honeypot_min_ms).toBe(0);
+	});
+
+	it("floors a negative env value at 0, matching the old > 0 gate", async () => {
+		const { env } = mkEnv({}, { SPAM_HONEYPOT_MIN_MS: "-1" });
+		expect((await loadNumbers(env)).spam_honeypot_min_ms).toBe(0);
+	});
+
+	it("lets a DB row override the env var", async () => {
+		const { env } = mkEnv(
+			{ spam_honeypot_min_ms: "2500" },
+			{ SPAM_HONEYPOT_MIN_MS: "1500" },
+		);
+		expect((await loadNumbers(env)).spam_honeypot_min_ms).toBe(2500);
+	});
+});
+
+describe("promoted runtime settings — edit_window_minutes", () => {
+	// The pre-settings code fell back to 5 minutes while every doc said 15.
+	it("defaults to the documented 15, not the old 5-minute code fallback", async () => {
+		const { env } = mkEnv();
+		expect((await loadNumbers(env)).edit_window_minutes).toBe(15);
+	});
+
+	it("still honors an existing env var", async () => {
+		const { env } = mkEnv({}, { EDIT_WINDOW_MINUTES: "5" });
+		expect((await loadNumbers(env)).edit_window_minutes).toBe(5);
+	});
+
+	it("lets a DB row of 0 disable editing outright", async () => {
+		const { env } = mkEnv(
+			{ edit_window_minutes: "0" },
+			{ EDIT_WINDOW_MINUTES: "15" },
+		);
+		expect((await loadNumbers(env)).edit_window_minutes).toBe(0);
+	});
+
+	it("clamps above the 1440-minute ceiling", async () => {
+		const { env } = mkEnv({}, { EDIT_WINDOW_MINUTES: "99999" });
+		expect((await loadNumbers(env)).edit_window_minutes).toBe(1440);
+	});
+});
+
+describe("promoted runtime settings — spam_first_comment_moderate", () => {
+	it("defaults off", async () => {
+		const { env } = mkEnv();
+		expect((await loadFlags(env)).spam_first_comment_moderate).toBe(false);
+	});
+
+	it("reads the legacy env var", async () => {
+		const { env } = mkEnv({}, { SPAM_FIRST_COMMENT_MODERATE: "true" });
+		expect((await loadFlags(env)).spam_first_comment_moderate).toBe(true);
+	});
+
+	it("lets a DB row turn it back off over an enabling env var", async () => {
+		const { env } = mkEnv(
+			{ spam_first_comment_moderate: "false" },
+			{ SPAM_FIRST_COMMENT_MODERATE: "true" },
+		);
+		expect((await loadFlags(env)).spam_first_comment_moderate).toBe(false);
+	});
+});
+
+/**
+ * GET /form-token gates on the resolved honeypot setting, not raw env. If it
+ * kept reading env, an admin enabling fill-time checks from the Settings page
+ * would get a 404 here, every submission would arrive unsigned, and the check
+ * they just switched on would silently never fire.
+ */
+describe("promoted runtime settings — /form-token honors the DB override", () => {
+	const tokenReq = async (env: Bindings) => {
+		const app = new Hono<{ Bindings: Bindings }>().route("/", comments);
+		return app.request(
+			"/form-token",
+			{},
+			env as unknown as Record<string, unknown>,
+		);
+	};
+
+	it("404s while the honeypot check is disabled", async () => {
+		const { env } = mkEnv({}, { SPAM_FORM_TS_SECRET: "k" });
+		expect((await tokenReq(env)).status).toBe(404);
+	});
+
+	it("mints a token when a DB row enables the check with no env var set", async () => {
+		const { env } = mkEnv(
+			{ spam_honeypot_min_ms: "1500" },
+			{ SPAM_FORM_TS_SECRET: "k" },
+		);
+		const res = await tokenReq(env);
+		expect(res.status).toBe(200);
+		expect(((await res.json()) as { token: string }).token).toBeTruthy();
+	});
+
+	it("404s when a DB row disables a check the env var had enabled", async () => {
+		const { env } = mkEnv(
+			{ spam_honeypot_min_ms: "0" },
+			{ SPAM_FORM_TS_SECRET: "k", SPAM_HONEYPOT_MIN_MS: "1500" },
+		);
+		expect((await tokenReq(env)).status).toBe(404);
 	});
 });


### PR DESCRIPTION
Closes #45.

Moves the runtime-tunable dials into the admin settings panel. Each is resolved through the existing hybrid precedence (DB `settings` row > env var > built-in default):

| Env var | Resolved key | Registry |
| --- | --- | --- |
| `SPAM_FIRST_COMMENT_MODERATE` | `spam_first_comment_moderate` | `FLAGS` |
| `EDIT_WINDOW_MINUTES` | `edit_window_minutes` | `NUMBERS` |
| `SPAM_LINK_THRESHOLD` | `spam_link_threshold` | `NUMBERS` |
| `SPAM_HONEYPOT_MIN_MS` | `spam_honeypot_min_ms` | `NUMBERS` |

Existing `wrangler.toml` values keep working as the deploy-time default; an admin save writes an override, and "Reset to defaults" hands control back to the env.

### Three semantics that a naive lift would have broken

- **`spam_link_threshold` is tri-state.** Its floor is `-1`, not `0`: `-1` disables the check, `0` flags any comment containing a link, `N` flags more than N. A shared clamp assuming a `0` floor would silently convert the off switch into flag-any-link. Pinned by a write-path test.
- **The edit-window default was split 5 (widget) vs 15 (server).** Both are now 15, and `0` means editing is disabled — every caller compares elapsed time against the window, so a zero window rejects unconditionally.
- **`/form-token` must read the *resolved* honeypot value.** Reading the env var there would 404 the token endpoint for an operator who enabled the dial from the UI, leaving submissions unsigned and the check permanently inert. Covered by a new test.

### Admin UI

Moderation tab gains "Edit window (minutes)" and an "Anti-spam heuristics" card. The four rows they replace are dropped from the read-only Configuration table. Enabling the fill-time dial without `SPAM_FORM_TS_SECRET` renders an inline warning rather than failing quietly. The dashboard summary now reflects resolved settings, not raw env.

The POST/reset handler needed no change — it iterates `FLAG_KEYS`/`NUMBER_KEYS`, so the new keys inherit save, clamp, cache-bust, reset, and the render contract test.

### Notes

- No D1 migration (the generic `settings` table already exists) and no new KV cache key — the comment POST path reads the same two keys the GET path already warms, so no added steady-state writes.
- No new env names, so `release-manifest.json` is unchanged and `manifest:check` stays green.
- `config:check` OK (53 entries, 5 generated files in sync).

### Verification

`npm test` 757 passing / 53 files · `npm run typecheck` clean · `npm run build` dry-run OK · `npm run size` 11.53 KB gzip (ceiling 20 KB) · `npm run config:check` + `npm run manifest:check` OK.
