### PR TITLE
chore(deps): stop Dependabot proposing @types/node majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,14 @@ updates:
     labels:
       - dependencies
       - agents-docs-ok
+    ignore:
+      # @types/node tracks the *runtime* major, not the newest release. Types a
+      # major ahead of `engines: >=24` make tsc accept Node 26 APIs that Node 24
+      # doesn't ship — a green build that fails at runtime. Already reverted
+      # once (e9d9355). Raise this by hand together with engines and .nvmrc.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
     groups:
       # One PR for the routine noise; majors still arrive individually so a
       # breaking bump gets read on its own.


### PR DESCRIPTION
Closes #57.

`@types/node` describes the runtime, so it has to track the engine floor rather than the newest release. `@types/node` 26.x against `engines: >=24` lets `tsc` accept Node 26 APIs that Node 24 doesn't ship — the build stays green and the failure surfaces at runtime.

This was already reverted once in e9d9355 ("align @types/node with the Node 24 engine floor"), and Dependabot re-proposed the same bump in #57. Adding an `ignore` entry for `version-update:semver-major` so majors are raised by hand alongside `engines` and `.nvmrc`. In-range minor/patch updates still flow through the `dev-minor-patch` group.