### PR TITLE
feat(privacy): IP_HASH_RETENTION_DAYS retention window + manual purge runbook

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -865,7 +865,8 @@ npm run db:export -- garrul-backup-pre-purge.sql
 
 # 2. Purge. --remote hits production; drop it to rehearse against local.
 npx wrangler d1 execute garrul-db --remote --command \
-  "UPDATE comments SET ip_hash = NULL, user_agent = NULL WHERE ip_hash IS NOT NULL;"
+  "UPDATE comments SET ip_hash = NULL, user_agent = NULL
+   WHERE (ip_hash IS NOT NULL OR user_agent IS NOT NULL);"
 
 npx wrangler d1 execute garrul-db --remote --command \
   "UPDATE reports SET reporter_ip_hash = NULL WHERE reporter_ip_hash IS NOT NULL;"
@@ -879,7 +880,8 @@ npx wrangler secret put IP_HASH_SECRET
 
 # 5. Confirm nothing survived.
 npx wrangler d1 execute garrul-db --remote --command \
-  "SELECT (SELECT COUNT(*) FROM comments WHERE ip_hash IS NOT NULL) AS comments,
+  "SELECT (SELECT COUNT(*) FROM comments
+             WHERE (ip_hash IS NOT NULL OR user_agent IS NOT NULL)) AS comments,
           (SELECT COUNT(*) FROM reports WHERE reporter_ip_hash IS NOT NULL) AS reports,
           (SELECT COUNT(*) FROM users WHERE provider = 'anon' AND provider_id IS NOT NULL) AS ghosts;"
 ```

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -213,6 +213,7 @@ between the two is a build error, not a silent misclassification.
 | `AUTO_CLOSE_AT` | var | Hard sunset — close **all** threads at/after this epoch-ms timestamp. Defaults **0** (disabled). The admin Settings page writes this via a date picker. | `0` | `wrangler.toml` |
 | `COMMUNITY_MIN_VOTES` | var | Minimum total votes before `COMMUNITY_COLLAPSE_RATIO` applies — the brigading floor. Defaults **5**. | `5` | `wrangler.toml` |
 | `COMMUNITY_COLLAPSE_RATIO` | var | Percent of downvotes/total that collapses a comment in the widget. Cosmetic and reversible — the reader can expand it. `0` = off, range `[0, 100]`. Requires `DOWNVOTES_ENABLED`. | `0` | `wrangler.toml` |
+| `IP_HASH_RETENTION_DAYS` | var | Clear `comments.ip_hash` + `comments.user_agent` and `reports.reporter_ip_hash` once the row is this many days old, swept by the cron. `0` = off (the default — an upgrade never starts deleting data on its own). Range `[0, 3650]`, and the sweep refuses to run below **7** days so a fat-fingered `1` can't purge nearly everything. **Irreversible**: nothing reconstructs a cleared hash. Does *not* touch anonymous ghost `users.provider_id` — that column is the identity itself, so expiring it would delete the account rather than a hash. See `docs/ip-hashing.md`. | `0` | `wrangler.toml` |
 <!-- END:config-table -->
 
 Bindings (D1, KV, Analytics) live in `wrangler.toml` outside `[vars]`

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -823,6 +823,18 @@ in three places: `comments.ip_hash` (kept even after a soft delete),
 `users.provider_id` for `provider='anon'` ghost rows, which is the
 anonymous identity itself.
 
+**How much history that is depends on `IP_HASH_RETENTION_DAYS`** (§5, or
+Settings → Moderation). Off by default, in which case a dump carries every
+hash the instance has ever written. Set to N days, a cron pass clears the
+first two columns past that age, so a dump carries a bounded slice
+instead. The third column is never swept on a timer — the ghost hash *is*
+the account, so expiring it would delete anonymous identities rather than
+hashes. Plan for an export to always contain the full ghost set.
+
+Watch it work, and drain a backlog on demand, from `/admin/operator`.
+Clearing a hash is irreversible, and it costs you the ability to spot a
+ban evader on that network past the window.
+
 The hash is a pseudonym only against someone who *doesn't* have
 `IP_HASH_SECRET`. The construction is unsalted and IPv4 is a 2^32 input
 space, so anyone holding both an export and the secret can rebuild every
@@ -901,6 +913,11 @@ these columns, so there are no orphans to clean up afterwards.
 For a single person's data rather than the whole table, use **Erase
 personal data** on `/admin/users/<id>` instead — admin-only,
 audit-logged, and scoped to that user's rows.
+
+`IP_HASH_RETENTION_DAYS` is not a substitute for any of this. It bounds
+how much history a future leak exposes; it does nothing about hashes a
+leaked key can already crack today. Setting it now is worth doing anyway —
+it shrinks the next incident.
 
 ## 12. Upgrades
 

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -816,12 +816,11 @@ just forces re-sign-in; `TREE_CACHE` rebuilds on next read.
 
 ### Hashed IPs in an export
 
-A `.sql` dump carries every `ip_hash` the instance has ever written, and
-those values are permanent — there is no TTL, no purge job, and no
-retention window. They land in three places: `comments.ip_hash` (kept
-even after a soft delete), `comment_reports.reporter_ip_hash` (kept after
-the flags are resolved), and `users.provider_id` for `provider='anon'`
-ghost rows, which is the anonymous identity itself.
+A `.sql` dump carries every `ip_hash` the instance still holds. They land
+in three places: `comments.ip_hash` (kept even after a soft delete),
+`reports.reporter_ip_hash` (kept after the flags are resolved), and
+`users.provider_id` for `provider='anon'` ghost rows, which is the
+anonymous identity itself.
 
 The hash is a pseudonym only against someone who *doesn't* have
 `IP_HASH_SECRET`. The construction is unsalted and IPv4 is a 2^32 input
@@ -834,6 +833,73 @@ shipped.
 
 Full posture, including what rotation breaks and what a deletion request
 costs today: [`docs/ip-hashing.md`](docs/ip-hashing.md).
+
+### Emergency purge: `IP_HASH_SECRET` leaked
+
+If the secret is exposed — committed, pasted into a chat, or leaked
+alongside a dump — rotating it does **nothing** for rows already written.
+Those stay crackable with the leaked key forever. The only real fix is to
+clear the stored values. Run this first, then rotate.
+
+Order matters: purge before rotating. Rotation doesn't break the purge,
+but it does mint new-key hashes for anyone who comments in between, and
+you want the blast radius frozen while you work.
+
+```bash
+# 1. Snapshot first — this is irreversible and takes moderation history
+#    with it. Keep the backup encrypted and off shared storage.
+npm run db:export -- garrul-backup-pre-purge.sql
+
+# 2. Purge. --remote hits production; drop it to rehearse against local.
+npx wrangler d1 execute garrul-db --remote --command \
+  "UPDATE comments SET ip_hash = NULL, user_agent = NULL WHERE ip_hash IS NOT NULL;"
+
+npx wrangler d1 execute garrul-db --remote --command \
+  "UPDATE reports SET reporter_ip_hash = NULL WHERE reporter_ip_hash IS NOT NULL;"
+
+# 3. Anonymous ghost identities. See the warning below BEFORE running this.
+npx wrangler d1 execute garrul-db --remote --command \
+  "UPDATE users SET provider_id = NULL WHERE provider = 'anon' AND provider_id IS NOT NULL;"
+
+# 4. Rotate the secret.
+npx wrangler secret put IP_HASH_SECRET
+
+# 5. Confirm nothing survived.
+npx wrangler d1 execute garrul-db --remote --command \
+  "SELECT (SELECT COUNT(*) FROM comments WHERE ip_hash IS NOT NULL) AS comments,
+          (SELECT COUNT(*) FROM reports WHERE reporter_ip_hash IS NOT NULL) AS reports,
+          (SELECT COUNT(*) FROM users WHERE provider = 'anon' AND provider_id IS NOT NULL) AS ghosts;"
+```
+
+Substitute your own `database_name` from `wrangler.toml` for `garrul-db`.
+
+**Step 3 is the destructive one.** Clearing a ghost's `provider_id`
+deletes the anonymous identity, not just a hash. Consequences, all
+permanent:
+
+- Every ghost-author **ban stops applying** to that network. Re-ban from
+  a fresh comment if you need it to hold.
+- **Vote, reaction and page-engagement dedup resets** for anonymous
+  visitors — one identity per network becomes one identity per network
+  *per future visit*.
+- Returning anonymous commenters get **new ghost rows**; their old
+  comments still render and still belong to the old rows.
+
+Steps 1–2 are the ones that matter for the leak: they cover the bulk of
+the exposure and cost you only the admin "other comments from this
+network" panel on old comments. Step 3 closes the remaining gap and is
+the right call if the export is genuinely in someone else's hands.
+Skipping it is defensible if it isn't.
+
+SQLite counts NULLs as distinct in a UNIQUE index, so
+`UNIQUE (comment_id, reporter_ip_hash)` on `reports` and
+`UNIQUE (provider, provider_id)` on `users` both survive the purge no
+matter how many rows collapse to NULL. Nothing else in the schema keys on
+these columns, so there are no orphans to clean up afterwards.
+
+For a single person's data rather than the whole table, use **Erase
+personal data** on `/admin/users/<id>` instead — admin-only,
+audit-logged, and scoped to that user's rows.
 
 ## 12. Upgrades
 

--- a/docs/ip-hashing.md
+++ b/docs/ip-hashing.md
@@ -36,25 +36,73 @@ ban a ghost author.
 
 ## Where the hash lands, and for how long
 
-Three places, all of them for the life of the row:
+Three places. Two of them can be put on a timer; the third can't.
 
 | Location | Written by | Retention |
 | --- | --- | --- |
-| `comments.ip_hash` | every comment POST | lifetime of the comment row, **including after a soft delete** |
-| `comment_reports.reporter_ip_hash` | reader reporting; `UNIQUE (comment_id, reporter_ip_hash)` is the one-report-per-network rule | lifetime of the report row, including after the flags are resolved |
-| `users.provider_id` for `provider='anon'` ghosts | first anonymous comment, vote, reaction or page-engagement event from that network | permanent — the ghost row is the anonymous identity |
+| `comments.ip_hash` | every comment POST | `IP_HASH_RETENTION_DAYS` if set, else lifetime of the comment row — **including after a soft delete** |
+| `reports.reporter_ip_hash` | reader reporting; `UNIQUE (comment_id, reporter_ip_hash)` is the one-report-per-network rule | `IP_HASH_RETENTION_DAYS` if set, else lifetime of the report row, including after the flags are resolved |
+| `users.provider_id` for `provider='anon'` ghosts | first anonymous comment, vote, reaction or page-engagement event from that network | permanent — the ghost row *is* the anonymous identity, so no timer touches it |
 
 Votes, reactions and page-engagement rows don't store a hash of their
 own; they key on the ghost `users.id`, so the hash reaches them
 indirectly through `provider_id`.
 
-There is **no TTL, no scheduled purge and no retention job.** A hash
-written on day one is still there on day one thousand. `npm run
-db:export` includes all three columns.
+`IP_HASH_RETENTION_DAYS` is **off by default**, so on a stock install
+none of these three expire and a hash written on day one is still there
+on day one thousand. `npm run db:export` includes all three columns
+regardless. See [Retention window](#retention-window) below.
 
 Two things are *not* durable and don't need to be reasoned about here:
 rate-limit counters live in the edge Cache API with short TTLs, and
 request logs never contain an IP or an `ip_hash` at all.
+
+## Retention window
+
+`IP_HASH_RETENTION_DAYS` (Settings → Moderation, or the env var) puts an
+expiry on the two sweepable columns. Past the window, the cron pass
+clears `comments.ip_hash`, `comments.user_agent` and
+`reports.reporter_ip_hash`. `/admin/operator` shows what's pending and
+can drain a backlog on demand instead of over the next few cron ticks.
+
+- **Off by default** (`0`). An upgrade never starts erasing data an
+  operator didn't ask it to.
+- **Range `[0, 3650]`, with a 7-day floor that refuses rather than
+  clamps.** A value of 1–6 logs a warning and sweeps nothing, so a
+  fat-fingered `1` can't purge nearly everything. The floor lives in the
+  sweep and not in the setting's `min` on purpose: `parseIntSetting`
+  clamps into `[min, max]`, so a `min` of 7 would have rewritten an
+  explicit `0` ("off") into the most destructive value in range.
+- **Irreversible.** Setting the window back to `0` stops future sweeps;
+  nothing restores what a sweep already cleared.
+- **Anchored on the last edit** (`COALESCE(edited_at, created_at)`) for
+  comments — an edited comment is live moderation surface, so the clock
+  restarts. Reports go on `created_at` alone, deliberately *not* gated on
+  `status='resolved'`: an open-and-forgotten report would otherwise keep
+  its reporter's hash forever, which is the exact problem the window
+  exists to bound.
+
+What you give up in exchange, once a row is past the window: you can no
+longer tell that a new comment came from the same network as an old one,
+so spotting a returning ban evader by hash stops working past the window,
+and a comment whose report has aged out can be reported again by that
+network.
+
+### What it does not cover
+
+Anonymous ghost `users.provider_id` is never swept. For a signed-out
+visitor that column *is* the account — `(provider, provider_id)` is how a
+returning visitor resolves to their existing ghost — so expiring it on a
+timer would delete accounts rather than hashes: ghost-author bans would
+stop applying and vote / reaction / page-engagement dedup would reset for
+every anonymous visitor.
+
+So **a D1 export always carries the full set of ghost identities**, no
+matter what the window says. Don't write a privacy policy claiming
+otherwise. Clearing them is a per-person decision (**Erase personal
+data** on a user's page) or a deliberate operator one (the purge runbook
+in [`../AGENTS-OPERATE.md`](../AGENTS-OPERATE.md) §11), never a scheduled
+job.
 
 ## What the hash actually protects against
 
@@ -106,17 +154,26 @@ values that nothing can tell apart. Concretely:
 
 And the part that matters most: **rotation does nothing for hashes
 already written.** Those stay crackable with the leaked key forever. If
-the secret is exposed, the only real fix is to clear or overwrite the
-stored columns, which today means hand-written SQL against D1.
+the secret is exposed, the fix is to clear the stored columns *and then*
+rotate — the break-glass runbook is
+[`../AGENTS-OPERATE.md`](../AGENTS-OPERATE.md) §11.
 
 ## What's missing
 
 Stated plainly, because someone will need it:
 
-- No key epoching — no `ip_hash_version` column, so a rotation can't be
-  reasoned about per-row and old values can't be lazily re-keyed.
-- No retention window — nothing expires an `ip_hash` after the moderation
-  value has passed.
+- **No key epoching.** There's no `ip_hash_version` column, so a rotation
+  can't be reasoned about per-row and old values can't be lazily re-keyed.
+  After a rotation the stored columns hold a mix of old-key and new-key
+  values that nothing can tell apart.
+- **Retention doesn't reach ghost identities.** The window covers the two
+  columns that are only ever *signals*; the one that is an *identity* is
+  out of scope by construction (see above), so it needs the manual purge
+  or a per-user erase.
+
+Between them, that's the gap: a retention window shrinks how much history
+a leak exposes, every day, whether or not a leak ever happens. It is not
+a remediation *for* a leak — for that you still purge and rotate by hand.
 
 There *is* a per-user erase path: **Erase personal data** on
 `/admin/users/<id>` (admin-only, audit-logged). It clears the account's
@@ -128,14 +185,15 @@ removed and their sessions are revoked. Comment bodies are kept by
 default so the thread stays readable; there's a checkbox to blank them
 too, for when the comment text itself is the personal data.
 
-That covers a deletion request for one person. It does **not** give you a
-retention window, and it can't help with a leaked secret: a bulk purge
-across every `ip_hash` is still hand-written SQL.
+That covers a deletion request for one person. It is not a substitute for
+the retention window, and on its own it can't answer a leaked secret —
+that needs the bulk purge in §11.
 
 Key epoching is tracked in
-[issue #50](https://github.com/KingPin/Garrul/issues/50). Until it ships, the practical
-posture is: keep the secret safe, keep exports encrypted, and don't
-promise an IP retention window you have no mechanism to honor.
+[issue #50](https://github.com/KingPin/Garrul/issues/50). Until it ships,
+the practical posture is: set a retention window you can actually honor,
+keep the secret safe, keep exports encrypted, and word your privacy
+policy around the two columns the window covers rather than all three.
 
 ## See also
 

--- a/docs/privacy-policy.template.md
+++ b/docs/privacy-policy.template.md
@@ -58,21 +58,21 @@ comment-id, reaction-kind)** tuple.
   without signing in. It is removed if you ask us to erase your data
   (see below).
 
-  <!-- Keep the sentence that matches your instance. Garrul's
-       IP_HASH_RETENTION_DAYS setting is OFF by default: if you haven't set
-       it, the first sentence is the true one. If you have, use the second
-       and fill in your window — and note that it deliberately says
-       "comments and abuse reports", not "everything". The anonymous
-       identity is never expired on a timer, because for a signed-out
-       visitor that hash *is* the account. Claiming otherwise would be
-       false. See docs/ip-hashing.md. -->
-
   There is no automatic expiry.
+
+  <!-- The sentence above matches a default Garrul instance, where
+       IP_HASH_RETENTION_DAYS is OFF. If you have set it, delete that
+       sentence and use this paragraph instead, filling in your window:
 
   We automatically erase the hashed IP stored against comments and abuse
   reports after **[90] days**. The anonymous identity derived from it is
   kept for as long as the account exists, because it is what lets you be
   recognised as the same commenter when you return.
+
+       Note it deliberately says "comments and abuse reports", not
+       "everything". The anonymous identity is never expired on a timer,
+       because for a signed-out visitor that hash *is* the account.
+       Claiming otherwise would be false. See docs/ip-hashing.md. -->
 - **OAuth account data**: until you ask us to remove it.
 - **Subscriptions**: until you click the unsubscribe link in any
   notification email.

--- a/docs/privacy-policy.template.md
+++ b/docs/privacy-policy.template.md
@@ -55,8 +55,24 @@ comment-id, reaction-kind)** tuple.
 - **Hashed IP**: retained for the lifetime of the row it belongs to —
   the comment (including after a soft delete), any abuse report you
   file, and the anonymous identity we derive from it if you comment
-  without signing in. There is no automatic expiry; it is removed if you
-  ask us to erase your data (see below).
+  without signing in. It is removed if you ask us to erase your data
+  (see below).
+
+  <!-- Keep the sentence that matches your instance. Garrul's
+       IP_HASH_RETENTION_DAYS setting is OFF by default: if you haven't set
+       it, the first sentence is the true one. If you have, use the second
+       and fill in your window — and note that it deliberately says
+       "comments and abuse reports", not "everything". The anonymous
+       identity is never expired on a timer, because for a signed-out
+       visitor that hash *is* the account. Claiming otherwise would be
+       false. See docs/ip-hashing.md. -->
+
+  There is no automatic expiry.
+
+  We automatically erase the hashed IP stored against comments and abuse
+  reports after **[90] days**. The anonymous identity derived from it is
+  kept for as long as the account exists, because it is what lets you be
+  recognised as the same commenter when you return.
 - **OAuth account data**: until you ask us to remove it.
 - **Subscriptions**: until you click the unsubscribe link in any
   notification email.

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -272,6 +272,11 @@
       "name": "COMMUNITY_COLLAPSE_RATIO",
       "required": false,
       "addedIn": "1.17.0"
+    },
+    {
+      "name": "IP_HASH_RETENTION_DAYS",
+      "required": false,
+      "addedIn": "2.1.0"
     }
   ],
   "kvNamespaces": [

--- a/scripts/config-registry.ts
+++ b/scripts/config-registry.ts
@@ -763,6 +763,17 @@ export const CONFIG_REGISTRY: ConfigEntry[] = [
 		example: "0",
 		addedIn: "1.17.0",
 	},
+	{
+		name: "IP_HASH_RETENTION_DAYS",
+		kind: "var",
+		required: false,
+		group: "Privacy",
+		hint: "clear stored ip_hash after N days (0 = keep forever)",
+		description:
+			"Clear `comments.ip_hash` + `comments.user_agent` and `reports.reporter_ip_hash` once the row is this many days old, swept by the cron. `0` = off (the default — an upgrade never starts deleting data on its own). Range `[0, 3650]`, and the sweep refuses to run below **7** days so a fat-fingered `1` can't purge nearly everything. **Irreversible**: nothing reconstructs a cleared hash. Does *not* touch anonymous ghost `users.provider_id` — that column is the identity itself, so expiring it would delete the account rather than a hash. See `docs/ip-hashing.md`.",
+		example: "0",
+		addedIn: "2.1.0",
+	},
 ];
 
 /** Secrets, in registry order. */

--- a/src/admin-ui/pages/operator.ts
+++ b/src/admin-ui/pages/operator.ts
@@ -1,8 +1,11 @@
 import type { RerenderStats } from "../../db/rerender";
+import type { RetentionStats } from "../../db/ip-retention";
+import { MIN_RETENTION_DAYS } from "../../db/ip-retention";
 import { MAX_XML_BYTES } from "../../lib/disqus-import";
 
 export type OperatorData = {
 	rerender: RerenderStats;
+	retention: RetentionStats;
 	seed_demo_allowed: boolean;
 };
 
@@ -10,8 +13,97 @@ export type OperatorData = {
 // error message. Whole MB by construction (MAX_XML_BYTES is N * 1024²).
 const MAX_XML_MB = Math.floor(MAX_XML_BYTES / (1024 * 1024));
 
+// Always-shown tail of the retention card. The ghost count is the honest part:
+// retention covers two of the three places an ip_hash lands, and an operator
+// reading "IP retention: 90 days" would otherwise reasonably assume an export
+// carries no hashes older than that. It does — for anonymous identities, which
+// are never expired on a timer because that column *is* the identity.
+const ghostNote = (ghosts: number): string => `
+  <p class="muted">Anonymous ghost identities: <strong>${ghosts}</strong>.
+    These are <em>never</em> swept — for a signed-out visitor the hashed IP
+    <em>is</em> the account (it's how a returning visitor finds their own
+    comments, and how a ghost ban keeps applying), so expiring it would delete
+    accounts rather than hashes. Clear them per-person from a user's page
+    ("Erase personal data"), or all at once with the purge runbook in
+    <code>AGENTS-OPERATE.md</code> §11 if the hashing secret ever leaks.</p>`;
+
+const retentionCard = (r: RetentionStats): string => {
+	if (!r.enabled) {
+		const reason =
+			r.retention_days === 0
+				? `Off. Stored hashes are kept for the life of the row.`
+				: `Set to <code>${r.retention_days}</code> day(s), which is below the
+	     ${MIN_RETENTION_DAYS}-day floor — the sweep refuses to run rather than
+	     purge nearly everything on a typo. Raise it to ${MIN_RETENTION_DAYS} or
+	     more, or set it to 0 to turn retention off deliberately.`;
+		return `
+<div class="card">
+  <h3>IP-hash retention</h3>
+  <p class="muted">${reason}
+    Change it on <a href="/admin/settings">Settings</a> (or via
+    <code>IP_HASH_RETENTION_DAYS</code>).</p>
+  <p class="muted">Comments currently holding a hashed IP:
+    <strong>${r.comments_total}</strong>.</p>
+  ${ghostNote(r.ghosts_total)}
+</div>`;
+	}
+
+	const pending = r.comments_pending + r.reports_pending;
+	return `
+<div class="card" x-data="{
+  busy: false,
+  comments: 0,
+  reports: 0,
+  done: false,
+  error: null,
+  step(first) {
+    if (this.busy) return;
+    if (first &amp;&amp; !confirm('Clear stored IP hashes older than ${r.retention_days} days? This cannot be undone.')) return;
+    this.busy = true; this.error = null;
+    return fetch('/admin/api/ops/ip-retention', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    }).then(async r => {
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || 'failed');
+      this.comments += j.comments;
+      this.reports += j.reports;
+      this.busy = false;
+      if (j.more) return this.step(false);
+      this.done = true;
+    }).catch(e => { this.error = e.message; this.busy = false; });
+  }
+}">
+  <h3>IP-hash retention</h3>
+  <p class="muted">Window: <strong>${r.retention_days}</strong> days. The cron
+    sweeps automatically; this button just drains the backlog now instead of
+    over the next few ticks. <strong>Irreversible</strong> — nothing
+    reconstructs a cleared hash.</p>
+  <p class="muted">Past the window right now — comments:
+    <strong>${r.comments_pending}</strong> · reports:
+    <strong>${r.reports_pending}</strong>.</p>
+  ${
+		pending > 0
+			? `<button :disabled="busy" @click="step(true)">
+    <span x-show="!busy &amp;&amp; !done">Sweep now</span>
+    <span x-show="busy">Sweeping…</span>
+    <span x-show="!busy &amp;&amp; done">Done</span>
+  </button>
+  <div class="muted" style="margin-top:0.5rem" x-show="comments || reports">
+    Cleared <span x-text="comments"></span> comment(s) ·
+    <span x-text="reports"></span> report(s)
+  </div>
+  <p style="color:var(--bad)" x-show="error" x-text="error"></p>`
+			: `<p class="muted">Nothing to do — the cron has already swept everything
+    past the window.</p>`
+	}
+  ${ghostNote(r.ghosts_total)}
+</div>`;
+};
+
 export const renderOperator = (data: OperatorData): string => {
-	const { rerender, seed_demo_allowed } = data;
+	const { rerender, retention, seed_demo_allowed } = data;
 	const seedCard = seed_demo_allowed
 		? `
 <div class="card" x-data="{
@@ -101,6 +193,8 @@ export const renderOperator = (data: OperatorData): string => {
 			: `<p class="muted">Nothing to do — all comments are at the current version.</p>`
 	}
 </div>
+
+${retentionCard(retention)}
 
 ${seedCard}
 

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -117,6 +117,24 @@ const MOD_NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
 	},
 ];
 
+// Privacy retention. Lives on the Moderation tab because that's what the stored
+// hashes are *for* — the dial trades moderation depth (spotting a ban evader on
+// the same network, deduping reports) for a smaller blast radius if the database
+// or the hashing secret ever leaks.
+//
+// The only setting here whose effect can't be undone by setting it back, so the
+// help text has to say so: the cron nulls the columns, and nothing rebuilds
+// them. The 7-day floor is not expressible in the stepper's min (that has to
+// stay 0 so "off" remains reachable), so the sweep enforces it by refusing —
+// see MIN_RETENTION_DAYS in src/db/ip-retention.ts.
+const PRIVACY_NUMBER_META: { key: NumberKey; label: string; help: string }[] = [
+	{
+		key: "ip_hash_retention_days",
+		label: "Clear stored IP hashes after (days)",
+		help: "Erase the hashed IP and user-agent on comments and reports once they're this old. 0 = keep them for the life of the row (the default). Values from 1 to 6 are ignored — the sweep refuses anything under 7 days so a typo can't wipe nearly everything. Irreversible: a cleared hash is gone, and with it the ability to spot a ban evader on that network. Anonymous ghost accounts are never swept — their hash is the identity itself.",
+	},
+];
+
 // Anti-spam heuristic dials. The classifier provider and its credentials stay
 // deploy-time (see the Configuration tab) — these three are the ones worth
 // retuning while watching the queue fill up.
@@ -194,6 +212,7 @@ export const renderSettings = (
 	const numberInputs = NUMBER_META.map(stepper).join("");
 	const modNumberInputs = MOD_NUMBER_META.map(stepper).join("");
 	const spamNumberInputs = SPAM_NUMBER_META.map(stepper).join("");
+	const privacyNumberInputs = PRIVACY_NUMBER_META.map(stepper).join("");
 	const modToggles = MOD_FLAG_META.map((f) =>
 		renderSwitch({
 			name: f.key,
@@ -344,6 +363,21 @@ export const renderSettings = (
       <code>SPAM_FORM_TS_SECRET</code> to sign the form timestamp — without it an
       unsigned time is trivially forged, so the check is skipped. Set the secret
       with <code>wrangler secret put SPAM_FORM_TS_SECRET</code> and redeploy.</p>
+    </div>
+
+    <div class="card" x-show="tab === 'moderation'" x-cloak>
+      <h2>Privacy retention</h2>
+      <p class="muted">Garrul stores a keyed hash of the commenter's IP (never
+      the address itself) so you can spot a ban evader on the same network and
+      dedupe abuse reports. Retention puts an expiry on that: past the window,
+      the cron erases the hash and user-agent from comments and reports, so a
+      database export carries a bounded slice of history instead of everything
+      the instance has ever seen. Off by default.</p>
+      ${privacyNumberInputs}
+      <p class="muted"><strong>This one can't be undone.</strong> Setting the
+      window back to 0 stops future sweeps; it does not restore what a sweep
+      already erased. Watch it run, and drain a backlog on demand, from
+      <a href="/admin/operator">Operator</a>.</p>
     </div>
 
     <p class="settings-actions" x-show="tab !== 'config'">

--- a/src/db/ip-retention.ts
+++ b/src/db/ip-retention.ts
@@ -1,0 +1,275 @@
+/**
+ * IP-hash retention sweep.
+ *
+ * Clears stored `ip_hash` values once their moderation value has passed, so a
+ * D1 export carries a bounded window of history rather than everything the
+ * instance has ever seen. Driven by `IP_HASH_RETENTION_DAYS` (0 = off) from the
+ * settings chain; runs as a cron pass and on demand from `/admin/operator`.
+ *
+ * Two of the three places an `ip_hash` lands are swept:
+ *
+ *   - `comments.ip_hash` + `comments.user_agent`, anchored on the comment's
+ *     last edit (`COALESCE(edited_at, created_at)`) — an edited comment is
+ *     live moderation surface, so the clock restarts when it changes. Both
+ *     columns go together because they're written together and cleared
+ *     together everywhere else (see eraseUser in src/lib/moderation.ts).
+ *
+ *   - `reports.reporter_ip_hash`, anchored on `created_at`. Age-only, NOT
+ *     gated on `status = 'resolved'`: an open-and-forgotten report would
+ *     otherwise keep its hash forever, which is the exact "permanent" problem
+ *     this exists to fix. A report older than the retention window has no live
+ *     dedup value either way.
+ *
+ * The third — `users.provider_id` for `provider='anon'` ghosts — is
+ * deliberately NOT swept, and this is the load-bearing decision in the file.
+ * That column *is* the anonymous identity: the `(provider, provider_id)` UNIQUE
+ * is how a returning visitor resolves to their existing ghost. Expiring it on a
+ * timer would silently delete accounts rather than hashes — ghost-author bans
+ * would stop applying, and vote / reaction / page-engagement dedup would reset
+ * for every anonymous visitor. So an export always carries the full set of
+ * ghost identities regardless of this setting, which docs/ip-hashing.md states
+ * plainly. Clearing them is an operator decision (the §11 purge runbook) or a
+ * per-person one (admin "Erase personal data"), never a scheduled job.
+ *
+ * Both UNIQUE constraints survive the sweep: SQLite counts NULLs as distinct,
+ * so any number of `reports` rows for one comment can collapse to NULL without
+ * tripping `UNIQUE (comment_id, reporter_ip_hash)`. The erase path already
+ * relies on this (see src/db/queries.ts).
+ *
+ * No cursor, unlike src/db/rerender.ts. The predicate is self-draining — a
+ * swept row has `ip_hash IS NULL` and stops matching its own WHERE clause — so
+ * repeated identical batches make progress and eventually return 0. A cursor
+ * would be dead weight and one more thing to get wrong.
+ */
+
+import type { Bindings } from "../index";
+import { loadNumbers } from "../lib/settings";
+import { log } from "../lib/log";
+
+/**
+ * Refuse to sweep below this many days.
+ *
+ * The setting's clamp can't express "0, or 7 and up" — parseIntSetting clamps
+ * into [min, max], so a `min: 7` would rewrite an operator's explicit 0 ("off")
+ * into the most destructive value in range. The floor lives here instead, and
+ * it *refuses* rather than substituting: a fat-fingered `1` no-ops loudly
+ * instead of quietly purging everything older than a day. There is no
+ * legitimate reason to want a sub-week IP retention window — rate-limit buckets
+ * are minutes and live in the Cache API, and the report-dedup and same-network
+ * moderation signals are the only things reading these columns.
+ */
+export const MIN_RETENTION_DAYS = 7;
+
+const DAY_MS = 86_400_000;
+
+/** Rows touched per table per batch. Bounds a single cron tick's D1 writes. */
+export const RETENTION_BATCH = 200;
+
+export type RetentionSweepResult = {
+	/** Comment rows whose ip_hash + user_agent were cleared. */
+	comments: number;
+	/** Report rows whose reporter_ip_hash was cleared. */
+	reports: number;
+	/** True while either table still has rows past the cutoff. */
+	more: boolean;
+};
+
+export type RetentionStats = {
+	/** Resolved retention window in days; 0 = disabled. */
+	retention_days: number;
+	/** Whether the resolved value is actually sweepable (>= MIN_RETENTION_DAYS). */
+	enabled: boolean;
+	/** Comment rows still holding an ip_hash or user_agent past the cutoff. */
+	comments_pending: number;
+	/** Report rows still holding a reporter_ip_hash past the cutoff. */
+	reports_pending: number;
+	/** Comment rows still holding an ip_hash at all, cutoff or not. */
+	comments_total: number;
+	/**
+	 * Anonymous ghost rows whose provider_id is still an ip_hash. Never swept —
+	 * surfaced so the operator page can be honest about what retention does not
+	 * cover rather than implying the window clears everything.
+	 */
+	ghosts_total: number;
+};
+
+/** Epoch-ms boundary: rows at or before this are past the retention window. */
+export const retentionCutoff = (retentionDays: number, now: number): number =>
+	now - retentionDays * DAY_MS;
+
+/**
+ * Whether a resolved setting value should drive a sweep at all.
+ *
+ * Separate from the sweep so the operator page and the cron agree on what
+ * "enabled" means without duplicating the comparison.
+ */
+export const isRetentionEnabled = (retentionDays: number): boolean =>
+	retentionDays >= MIN_RETENTION_DAYS;
+
+/**
+ * Clear one batch of expired hashes. Caller supplies `now` so the cron and the
+ * admin endpoint can both be tested deterministically.
+ *
+ * Returns zeroed counts with `more: false` when retention is off or below the
+ * floor — callers don't need to pre-check, though the cron does anyway so it
+ * can log the misconfiguration.
+ */
+export const sweepExpiredIpHashes = async (
+	db: D1Database,
+	retentionDays: number,
+	now: number,
+	batchSize: number = RETENTION_BATCH,
+): Promise<RetentionSweepResult> => {
+	if (!isRetentionEnabled(retentionDays)) {
+		return { comments: 0, reports: 0, more: false };
+	}
+	const cutoff = retentionCutoff(retentionDays, now);
+
+	// LIMIT inside a subquery rather than on the UPDATE itself: SQLite only
+	// supports UPDATE ... LIMIT when compiled with SQLITE_ENABLE_UPDATE_DELETE_LIMIT,
+	// which D1 does not guarantee. The subquery form is portable and behaves
+	// identically here.
+	const commentsRes = await db
+		.prepare(
+			`UPDATE comments
+			    SET ip_hash = NULL, user_agent = NULL
+			  WHERE id IN (
+			        SELECT id FROM comments
+			         WHERE (ip_hash IS NOT NULL OR user_agent IS NOT NULL)
+			           AND COALESCE(edited_at, created_at) <= ?
+			         ORDER BY COALESCE(edited_at, created_at) ASC
+			         LIMIT ?
+			  )`,
+		)
+		.bind(cutoff, batchSize)
+		.run();
+
+	const reportsRes = await db
+		.prepare(
+			`UPDATE reports
+			    SET reporter_ip_hash = NULL
+			  WHERE id IN (
+			        SELECT id FROM reports
+			         WHERE reporter_ip_hash IS NOT NULL
+			           AND created_at <= ?
+			         ORDER BY created_at ASC
+			         LIMIT ?
+			  )`,
+		)
+		.bind(cutoff, batchSize)
+		.run();
+
+	const comments = commentsRes.meta?.changes ?? 0;
+	const reports = reportsRes.meta?.changes ?? 0;
+	// A full batch on either table means there may be more behind it. Both
+	// short means this pass drained everything past the cutoff.
+	return {
+		comments,
+		reports,
+		more: comments >= batchSize || reports >= batchSize,
+	};
+};
+
+/**
+ * Counts for the operator page. `retentionDays` is passed in already resolved
+ * so this stays a pure read against D1.
+ */
+export const retentionStats = async (
+	db: D1Database,
+	retentionDays: number,
+	now: number,
+): Promise<RetentionStats> => {
+	const cutoff = retentionCutoff(retentionDays, now);
+	const enabled = isRetentionEnabled(retentionDays);
+
+	// One round trip. The pending counts are meaningless when retention is off
+	// (cutoff would be `now`, matching essentially every row and reading as a
+	// pending purge that will never run), so they're forced to 0 in that case
+	// while the totals stay live — the totals are what an operator deciding
+	// whether to turn this on actually wants to see.
+	const row = await db
+		.prepare(
+			`SELECT
+			   (SELECT COUNT(*) FROM comments
+			     WHERE (ip_hash IS NOT NULL OR user_agent IS NOT NULL)
+			       AND COALESCE(edited_at, created_at) <= ?)      AS comments_pending,
+			   (SELECT COUNT(*) FROM reports
+			     WHERE reporter_ip_hash IS NOT NULL
+			       AND created_at <= ?)                           AS reports_pending,
+			   (SELECT COUNT(*) FROM comments
+			     WHERE ip_hash IS NOT NULL)                      AS comments_total,
+			   (SELECT COUNT(*) FROM users
+			     WHERE provider = 'anon'
+			       AND provider_id IS NOT NULL)                   AS ghosts_total`,
+		)
+		.bind(cutoff, cutoff)
+		.first<{
+			comments_pending: number;
+			reports_pending: number;
+			comments_total: number;
+			ghosts_total: number;
+		}>();
+
+	return {
+		retention_days: retentionDays,
+		enabled,
+		comments_pending: enabled ? (row?.comments_pending ?? 0) : 0,
+		reports_pending: enabled ? (row?.reports_pending ?? 0) : 0,
+		comments_total: row?.comments_total ?? 0,
+		ghosts_total: row?.ghosts_total ?? 0,
+	};
+};
+
+/**
+ * Batches a single cron tick will run before giving up the rest to the next
+ * tick. At RETENTION_BATCH=200 that's up to 1000 rows per table per tick and
+ * ~96k/day at the default 15-minute schedule — enough to drain any backlog a
+ * self-hosted instance is likely to have accumulated, while keeping one tick's
+ * D1 writes and CPU time bounded. The sweep is not urgent: a row that waits one
+ * more tick has already waited a week.
+ */
+const MAX_BATCHES_PER_TICK = 5;
+
+/**
+ * Cron pass: resolve the retention window, then sweep until drained or until
+ * MAX_BATCHES_PER_TICK is spent.
+ *
+ * Silent when retention is off, which is the default — an instance that never
+ * opted in gets no log noise every 15 minutes. Loud exactly once per tick when
+ * the setting is a non-zero value below the floor, because that combination
+ * means the operator asked for a sweep and is not getting one.
+ */
+export const runIpRetention = async (env: Bindings): Promise<void> => {
+	const { ip_hash_retention_days: days } = await loadNumbers(env);
+	if (days === 0) return;
+	if (!isRetentionEnabled(days)) {
+		log.warn("ip_retention.below_floor", {
+			retention_days: days,
+			min_days: MIN_RETENTION_DAYS,
+		});
+		return;
+	}
+
+	// One `now` for the whole tick so every batch shares a cutoff.
+	const now = Date.now();
+	let comments = 0;
+	let reports = 0;
+	let more = false;
+	for (let i = 0; i < MAX_BATCHES_PER_TICK; i++) {
+		const res = await sweepExpiredIpHashes(env.DB, days, now);
+		comments += res.comments;
+		reports += res.reports;
+		more = res.more;
+		if (!more) break;
+	}
+
+	// Only log a tick that did something. A drained instance ticks silently.
+	if (comments > 0 || reports > 0) {
+		log.info("ip_retention.swept", {
+			retention_days: days,
+			comments,
+			reports,
+			more,
+		});
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,14 @@ export type Bindings = {
 	//                              (expandable). Gated on DOWNVOTES_ENABLED.
 	COMMUNITY_MIN_VOTES?: string;
 	COMMUNITY_COLLAPSE_RATIO?: string;
+	// Privacy retention. Env-var *default*; a `settings` row overrides at runtime
+	// (see src/lib/settings.ts). 0 = disabled.
+	//   IP_HASH_RETENTION_DAYS — clear comments.ip_hash / user_agent and
+	//                            reports.reporter_ip_hash once the row is this
+	//                            many days old. Swept by the cron; irreversible.
+	//                            Does NOT touch anonymous ghost provider_id —
+	//                            that column *is* the identity.
+	IP_HASH_RETENTION_DAYS?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { subscriptions } from "./routes/api.subscriptions";
 import { runDigest } from "./lib/digest";
 import { runTelegramDigest } from "./lib/telegram-digest";
 import { runWebhookRetries } from "./lib/webhook";
+import { runIpRetention } from "./db/ip-retention";
 import { log, requestLogger } from "./lib/log";
 import { corsAndCsrf } from "./lib/cors";
 import { jsonBodyLimit } from "./lib/body-limit";
@@ -312,6 +313,14 @@ export default {
 		ctx.waitUntil(
 			runTelegramDigest(env).catch((err) => {
 				log.error("scheduled.telegram_digest", { error: String(err) });
+			}),
+		);
+		// Privacy retention. No-ops unless IP_HASH_RETENTION_DAYS (or its
+		// settings row) is set — off by default, so this costs one cached
+		// settings read per tick on an instance that hasn't opted in.
+		ctx.waitUntil(
+			runIpRetention(env).catch((err) => {
+				log.error("scheduled.ip_retention", { error: String(err) });
 			}),
 		);
 	},

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -46,7 +46,8 @@ export type NumberKey =
 	| "community_collapse_ratio"
 	| "edit_window_minutes"
 	| "spam_link_threshold"
-	| "spam_honeypot_min_ms";
+	| "spam_honeypot_min_ms"
+	| "ip_hash_retention_days";
 
 export type ResolvedNumbers = Record<NumberKey, number>;
 
@@ -185,6 +186,33 @@ const NUMBERS: Record<
 		default: 0,
 		min: 0,
 		max: 60_000,
+	},
+	// Clear `comments.ip_hash` / `user_agent` and `reports.reporter_ip_hash`
+	// once the row is this many days old. 0 = disabled (the default, so an
+	// upgrade never starts deleting data an operator didn't ask it to).
+	//
+	// Unlike every other dial here, the effect is IRREVERSIBLE — the sweep
+	// nulls columns, and nothing reconstructs them. Two consequences for the
+	// shape of this entry:
+	//
+	//   - The default has to be 0. A shipped non-zero default would purge
+	//     history on the first cron tick after an upgrade, before the operator
+	//     had any chance to read the release notes.
+	//   - The clamp cannot make the dangerous direction reachable by accident.
+	//     min is 0 rather than a floor like 7 precisely because parseIntSetting
+	//     clamps into [min, max]: a floor would rewrite an operator's explicit
+	//     0 ("off") into 7 ("purge everything older than a week"), turning the
+	//     safe value into the destructive one. The floor lives in the sweep
+	//     instead (MIN_RETENTION_DAYS in src/db/ip-retention.ts), which refuses
+	//     to run below it rather than silently substituting.
+	//
+	// Max is 3650 (10 years), matching auto_close_days — the other lifecycle
+	// timer measured in days.
+	ip_hash_retention_days: {
+		env: "IP_HASH_RETENTION_DAYS",
+		default: 0,
+		min: 0,
+		max: 3650,
 	},
 };
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -144,6 +144,12 @@ import {
 import { CURRENT_RENDERER_VERSION, renderMarkdown } from "../lib/markdown";
 import { MAX_XML_BYTES, runDisqusImport } from "../lib/disqus-import";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
+import {
+	MIN_RETENTION_DAYS,
+	isRetentionEnabled,
+	retentionStats,
+	sweepExpiredIpHashes,
+} from "../db/ip-retention";
 import { runSeedDemo } from "../db/seed-demo";
 import { renderConfirmEmailHtml } from "../lib/digest";
 import { sendEmail } from "../lib/email";
@@ -671,12 +677,19 @@ admin.get("/operator", async (c) => {
 	const user = await requireAdmin(c);
 	if (user instanceof Response) return user;
 	const stats = await rerenderStats(c.env.DB);
+	const { ip_hash_retention_days } = await loadNumbers(c.env);
+	const retention = await retentionStats(
+		c.env.DB,
+		ip_hash_retention_days,
+		Date.now(),
+	);
 	const updateInfo = await peekCachedLatestVersion(c.env);
 	return c.html(
-		renderPage(c, 
+		renderPage(c,
 			"Operator",
 			renderOperator({
 				rerender: stats,
+				retention,
 				seed_demo_allowed: isSeedDemoAllowed(c.env),
 			}),
 			user,
@@ -1886,6 +1899,49 @@ admin.post("/api/ops/rerender", async (c) => {
 		processed: result.processed,
 		next_cursor: result.next_cursor,
 	});
+});
+
+// --- IP-hash retention -----------------------------------------------------
+//
+// Runs the same sweep as the cron, one batch per call, so an operator who just
+// turned retention on doesn't have to wait out a backlog 15 minutes at a time.
+// The window itself is not settable here — it's a Settings dial — and the
+// endpoint refuses when the resolved value is off or below the floor, rather
+// than picking a window of its own. Audited: this destroys data irreversibly,
+// so "who drained the hashes" has to be answerable.
+
+admin.post("/api/ops/ip-retention", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+
+	const { ip_hash_retention_days: days } = await loadNumbers(c.env);
+	if (!isRetentionEnabled(days)) {
+		return c.json(
+			{
+				error: "retention_disabled",
+				retention_days: days,
+				min_days: MIN_RETENTION_DAYS,
+			},
+			400,
+		);
+	}
+
+	const result = await sweepExpiredIpHashes(c.env.DB, days, Date.now());
+	if (result.comments > 0 || result.reports > 0) {
+		await adminInsertAudit(c.env.DB, {
+			admin_id: user.id,
+			action: "ip_retention.sweep",
+			target_kind: "system",
+			target_id: null,
+			reason: null,
+			meta: {
+				retention_days: days,
+				comments: result.comments,
+				reports: result.reports,
+			},
+		});
+	}
+	return c.json({ ok: true, ...result });
 });
 
 // ---------------------------- Disqus import --------------------------------

--- a/tests/admin-ip-retention-endpoint.test.ts
+++ b/tests/admin-ip-retention-endpoint.test.ts
@@ -1,0 +1,271 @@
+/**
+ * POST /admin/api/ops/ip-retention — the on-demand sweep behind the Operator
+ * card's "Sweep now" button.
+ *
+ * Exercised through the real Hono route against real SQLite, because the two
+ * things worth pinning here are contracts between components rather than logic
+ * inside one:
+ *
+ *   - The response body shape the Operator card's Alpine loop reads
+ *     (`comments`, `reports`, `more`). The card self-recurses while `more` is
+ *     true, so a renamed field is an infinite spinner, not a type error.
+ *   - The window comes from the resolved setting, never from the request. An
+ *     endpoint that accepted a caller-supplied day count would route around
+ *     the Settings dial and its floor.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { admin } from "../src/routes/admin";
+import { installMockCaches, uninstallMockCaches } from "./helpers/mock-caches";
+import type { Bindings } from "../src/index";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+const DAY = 86_400_000;
+const NOW = Date.now();
+
+const ADMIN_SID = "a".repeat(64);
+const MOD_SID = "b".repeat(64);
+const ADMIN_ID = "01HADMIN0000000000000000AB";
+const MOD_ID = "01HMOD00000000000000000MOD";
+const SLUG = "hello";
+
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const makeKv = () => {
+	const store = new Map<string, string>();
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+	};
+};
+
+const makeSessions = () => ({
+	async get(key: string) {
+		if (key === `sess:${ADMIN_SID}`)
+			return JSON.stringify({ user_id: ADMIN_ID, expires_at: 4_102_444_800_000 });
+		if (key === `sess:${MOD_SID}`)
+			return JSON.stringify({ user_id: MOD_ID, expires_at: 4_102_444_800_000 });
+		return null;
+	},
+	async put() {},
+	async delete() {},
+});
+
+const execCtx = {
+	waitUntil() {},
+	passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+let sqlite: DatabaseSync;
+let env: Bindings;
+
+const addComment = (id: string, ageDays: number) =>
+	sqlite
+		.prepare(
+			`INSERT INTO comments (id, post_slug, parent_id, user_id, body_md,
+			                       body_html, renderer_version, status, ip_hash,
+			                       user_agent, created_at, depth)
+			 VALUES (?, ?, NULL, ?, 'hi', '<p>hi</p>', 1, 'approved', 'iphash',
+			         'ua', ?, 1)`,
+		)
+		.run(id, SLUG, MOD_ID, NOW - ageDays * DAY);
+
+beforeEach(() => {
+	installMockCaches();
+	sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	const seedUser = sqlite.prepare(
+		`INSERT INTO users (id, provider, provider_id, name, email, avatar_url,
+		                    is_admin, role, created_at)
+		 VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
+	);
+	seedUser.run(ADMIN_ID, "github", "1", "Op", 1, "admin", NOW - 400 * DAY);
+	seedUser.run(MOD_ID, "github", "2", "Mod", 0, "mod", NOW - 400 * DAY);
+	sqlite
+		.prepare("INSERT INTO posts (slug, title, url, created_at) VALUES (?,?,?,?)")
+		.run(SLUG, "Hello", null, NOW - 400 * DAY);
+
+	env = {
+		DB: makeD1(sqlite),
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+	} as unknown as Bindings;
+});
+
+afterEach(() => uninstallMockCaches());
+
+const sweep = (opts: { sid?: string } = {}) => {
+	const { sid = ADMIN_SID } = opts;
+	return new Hono<{ Bindings: Bindings }>()
+		.route("/admin", admin)
+		.request(
+			"/admin/api/ops/ip-retention",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: `__Host-garrul_sess=${sid}`,
+					origin: "http://localhost",
+				},
+				body: "{}",
+			},
+			env as unknown as Record<string, unknown>,
+			execCtx,
+		);
+};
+
+const hashCount = (): number =>
+	(
+		sqlite
+			.prepare("SELECT COUNT(*) AS n FROM comments WHERE ip_hash IS NOT NULL")
+			.get() as { n: number }
+	).n;
+
+const lastAudit = () =>
+	sqlite
+		.prepare(
+			"SELECT action, meta FROM audit_log ORDER BY created_at DESC, id DESC LIMIT 1",
+		)
+		.get() as { action: string; meta: string | null } | undefined;
+
+describe("POST /admin/api/ops/ip-retention", () => {
+	it("400s and changes nothing while retention is off", async () => {
+		addComment("c-old", 400);
+
+		const res = await sweep();
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toMatchObject({ error: "retention_disabled" });
+		expect(hashCount()).toBe(1);
+	});
+
+	// The floor is the sweep's, not the setting's — a stored 1 is a legal
+	// setting value that must still refuse.
+	it("400s for a window below the floor", async () => {
+		env.IP_HASH_RETENTION_DAYS = "1";
+		addComment("c-old", 400);
+
+		const res = await sweep();
+
+		expect(res.status).toBe(400);
+		expect(hashCount()).toBe(1);
+	});
+
+	it("sweeps on the resolved window and returns the shape the card reads", async () => {
+		env.IP_HASH_RETENTION_DAYS = "30";
+		addComment("c-old", 400);
+		addComment("c-new", 2);
+
+		const res = await sweep();
+
+		expect(res.status).toBe(200);
+		// Field names are the Operator card's Alpine contract: it accumulates
+		// `comments` / `reports` and self-recurses while `more` is true.
+		expect(await res.json()).toEqual({
+			ok: true,
+			comments: 1,
+			reports: 0,
+			more: false,
+		});
+		expect(hashCount()).toBe(1);
+	});
+
+	// Unrecoverable data, so "who drained the hashes" has to be answerable.
+	it("audits a sweep that cleared rows", async () => {
+		env.IP_HASH_RETENTION_DAYS = "30";
+		addComment("c-old", 400);
+
+		await sweep();
+
+		const audit = lastAudit();
+		expect(audit?.action).toBe("ip_retention.sweep");
+		expect(JSON.parse(audit?.meta ?? "{}")).toMatchObject({
+			retention_days: 30,
+			comments: 1,
+		});
+	});
+
+	it("writes no audit row when the sweep cleared nothing", async () => {
+		env.IP_HASH_RETENTION_DAYS = "30";
+		addComment("c-new", 2);
+
+		const res = await sweep();
+
+		expect(res.status).toBe(200);
+		expect(lastAudit()).toBeUndefined();
+	});
+
+	// Admin-only, matching the other /api/ops endpoints: a mod can moderate
+	// comments but not irreversibly erase the evidence behind them.
+	it("rejects a mod", async () => {
+		env.IP_HASH_RETENTION_DAYS = "30";
+		addComment("c-old", 400);
+
+		const res = await sweep({ sid: MOD_SID });
+
+		expect(res.status).toBe(403);
+		expect(hashCount()).toBe(1);
+	});
+
+	it("rejects a cross-origin POST", async () => {
+		env.IP_HASH_RETENTION_DAYS = "30";
+		addComment("c-old", 400);
+
+		const res = await new Hono<{ Bindings: Bindings }>()
+			.route("/admin", admin)
+			.request(
+				"/admin/api/ops/ip-retention",
+				{
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						cookie: `__Host-garrul_sess=${ADMIN_SID}`,
+						origin: "https://evil.example.com",
+					},
+					body: "{}",
+				},
+				env as unknown as Record<string, unknown>,
+				execCtx,
+			);
+
+		expect(res.status).toBe(403);
+		expect(hashCount()).toBe(1);
+	});
+});

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -15,6 +15,7 @@ import {
 	type SubscriptionsFilters,
 } from "../src/admin-ui/pages/subscriptions";
 import { renderOperator } from "../src/admin-ui/pages/operator";
+import type { RetentionStats } from "../src/db/ip-retention";
 import { renderSettings } from "../src/admin-ui/pages/settings";
 import { MAX_XML_BYTES } from "../src/lib/disqus-import";
 import { renderDashboard } from "../src/admin-ui/pages/dashboard";
@@ -446,10 +447,23 @@ describe("renderSubscriptions", () => {
 	});
 });
 
+// Retention off — the default, and the shape the pre-existing operator-card
+// assertions were written against. Tests that care about retention build their
+// own.
+const retentionOff: RetentionStats = {
+	retention_days: 0,
+	enabled: false,
+	comments_pending: 0,
+	reports_pending: 0,
+	comments_total: 0,
+	ghosts_total: 0,
+};
+
 describe("renderOperator", () => {
 	it("hides the seed card and explains the gate when seed_demo_allowed=false", () => {
 		const html = renderOperator({
 			rerender: { current_version: 1, up_to_date: 10, stale: 0, oldest_version: null },
+			retention: retentionOff,
 			seed_demo_allowed: false,
 		});
 		expect(html).toContain("Disabled in production");
@@ -459,6 +473,7 @@ describe("renderOperator", () => {
 	it("shows a no-op message when stale=0 and an action button when stale>0", () => {
 		const noop = renderOperator({
 			rerender: { current_version: 2, up_to_date: 100, stale: 0, oldest_version: null },
+			retention: retentionOff,
 			seed_demo_allowed: true,
 		});
 		expect(noop).toContain("all comments are at the current version");
@@ -466,6 +481,7 @@ describe("renderOperator", () => {
 
 		const work = renderOperator({
 			rerender: { current_version: 2, up_to_date: 100, stale: 7, oldest_version: 1 },
+			retention: retentionOff,
 			seed_demo_allowed: true,
 		});
 		expect(work).toContain(">Run rerender<");
@@ -475,6 +491,7 @@ describe("renderOperator", () => {
 	it("derives the import size check and UI hint from MAX_XML_BYTES (issue #15)", () => {
 		const html = renderOperator({
 			rerender: { current_version: 1, up_to_date: 10, stale: 0, oldest_version: null },
+			retention: retentionOff,
 			seed_demo_allowed: false,
 		});
 		const mb = Math.floor(MAX_XML_BYTES / (1024 * 1024));

--- a/tests/ip-retention.test.ts
+++ b/tests/ip-retention.test.ts
@@ -1,0 +1,418 @@
+/**
+ * IP-hash retention sweep, against real SQLite with every migration applied.
+ *
+ * Real SQLite rather than the substring-routing D1 stubs, for two reasons the
+ * stubs structurally can't cover:
+ *
+ *   - Every assertion here is "did this column actually get cleared, and did
+ *     that one survive". A stub that pattern-matches SQL proves nothing about
+ *     which rows an UPDATE ... WHERE id IN (SELECT ... LIMIT ?) touched.
+ *   - The sweep NULLs a column inside `UNIQUE (comment_id, reporter_ip_hash)`.
+ *     That it doesn't trip depends on SQLite counting NULLs as distinct, which
+ *     is a property of the engine, not of our code.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+	MIN_RETENTION_DAYS,
+	isRetentionEnabled,
+	retentionCutoff,
+	retentionStats,
+	runIpRetention,
+	sweepExpiredIpHashes,
+} from "../src/db/ip-retention";
+import { log } from "../src/lib/log";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+const DAY = 86_400_000;
+const NOW = 1_700_000_000_000;
+
+// Minimal D1Database adapter over node:sqlite — prepare().bind().run()/first().
+// `meta.changes` matters here: the sweep's batching decision reads it.
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+let sqlite: DatabaseSync;
+let db: any;
+
+const ageDays = (days: number): number => NOW - days * DAY;
+
+const addUser = (id: string, provider = "github", providerId = `${id}-pid`) =>
+	sqlite
+		.prepare(
+			`INSERT INTO users (id, provider, provider_id, name, created_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+		)
+		.run(id, provider, providerId, id, NOW - 365 * DAY);
+
+const addComment = (
+	id: string,
+	opts: {
+		created_at: number;
+		edited_at?: number | null;
+		ip_hash?: string | null;
+		user_agent?: string | null;
+	},
+) =>
+	sqlite
+		.prepare(
+			`INSERT INTO comments
+			   (id, post_slug, parent_id, user_id, body_md, body_html,
+			    renderer_version, status, edited_at, ip_hash, user_agent, created_at)
+			 VALUES (?, 'hello', NULL, 'u1', 'hi', '<p>hi</p>', 1, 'approved', ?, ?, ?, ?)`,
+		)
+		.run(
+			id,
+			opts.edited_at ?? null,
+			opts.ip_hash === undefined ? "iphash" : opts.ip_hash,
+			opts.user_agent === undefined ? "ua" : opts.user_agent,
+			opts.created_at,
+		);
+
+const addReport = (
+	id: string,
+	opts: {
+		comment_id?: string;
+		created_at: number;
+		ip_hash?: string | null;
+		status?: string;
+	},
+) =>
+	sqlite
+		.prepare(
+			`INSERT INTO reports
+			   (id, comment_id, reporter_user_id, reporter_ip_hash, reason,
+			    status, created_at)
+			 VALUES (?, ?, NULL, ?, 'spam', ?, ?)`,
+		)
+		.run(
+			id,
+			opts.comment_id ?? "c1",
+			opts.ip_hash === undefined ? `rh-${id}` : opts.ip_hash,
+			opts.status ?? "open",
+			opts.created_at,
+		);
+
+const comment = (id: string) =>
+	sqlite
+		.prepare("SELECT ip_hash, user_agent FROM comments WHERE id = ?")
+		.get(id) as { ip_hash: string | null; user_agent: string | null };
+
+const report = (id: string) =>
+	sqlite
+		.prepare("SELECT reporter_ip_hash FROM reports WHERE id = ?")
+		.get(id) as { reporter_ip_hash: string | null };
+
+beforeEach(() => {
+	sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	sqlite
+		.prepare("INSERT INTO posts (slug, title, url, created_at) VALUES (?,?,?,?)")
+		.run("hello", "Hello", null, NOW - 400 * DAY);
+	addUser("u1");
+	db = makeD1(sqlite);
+});
+
+describe("retention window arithmetic", () => {
+	it("puts the cutoff N days before now", () => {
+		expect(retentionCutoff(30, NOW)).toBe(NOW - 30 * DAY);
+	});
+
+	// The floor is a refusal, not a clamp — see the comment on MIN_RETENTION_DAYS.
+	// A `min: 7` on the setting itself would have rewritten an operator's explicit
+	// 0 ("off") into the most destructive value in range.
+	it("treats 0 and anything under the floor as not-enabled", () => {
+		expect(isRetentionEnabled(0)).toBe(false);
+		expect(isRetentionEnabled(1)).toBe(false);
+		expect(isRetentionEnabled(MIN_RETENTION_DAYS - 1)).toBe(false);
+		expect(isRetentionEnabled(MIN_RETENTION_DAYS)).toBe(true);
+		expect(isRetentionEnabled(365)).toBe(true);
+	});
+});
+
+describe("sweepExpiredIpHashes", () => {
+	it("clears ip_hash and user_agent on rows past the window", async () => {
+		addComment("c-old", { created_at: ageDays(60) });
+		addComment("c-new", { created_at: ageDays(1) });
+
+		const res = await sweepExpiredIpHashes(db, 30, NOW);
+
+		expect(res.comments).toBe(1);
+		expect(comment("c-old")).toEqual({ ip_hash: null, user_agent: null });
+		expect(comment("c-new")).toEqual({ ip_hash: "iphash", user_agent: "ua" });
+	});
+
+	// The clock restarts on an edit: a comment someone just changed is live
+	// moderation surface, whatever its original post date.
+	it("anchors on edited_at when the comment has been edited", async () => {
+		addComment("c-edited", { created_at: ageDays(60), edited_at: ageDays(2) });
+		addComment("c-stale-edit", {
+			created_at: ageDays(90),
+			edited_at: ageDays(60),
+		});
+
+		await sweepExpiredIpHashes(db, 30, NOW);
+
+		expect(comment("c-edited").ip_hash).toBe("iphash");
+		expect(comment("c-stale-edit").ip_hash).toBeNull();
+	});
+
+	// Age only. Gating on status='resolved' would let an open-and-forgotten
+	// report keep its reporter's hash forever, which is the exact problem
+	// retention exists to bound.
+	it("clears report hashes on age alone, open or resolved", async () => {
+		addComment("c1", { created_at: ageDays(60) });
+		addReport("r-open", { created_at: ageDays(60), status: "open" });
+		addReport("r-done", { created_at: ageDays(60), status: "resolved" });
+		addReport("r-fresh", { created_at: ageDays(1) });
+
+		const res = await sweepExpiredIpHashes(db, 30, NOW);
+
+		expect(res.reports).toBe(2);
+		expect(report("r-open").reporter_ip_hash).toBeNull();
+		expect(report("r-done").reporter_ip_hash).toBeNull();
+		expect(report("r-fresh").reporter_ip_hash).toBe("rh-r-fresh");
+	});
+
+	// UNIQUE (comment_id, reporter_ip_hash) would reject a second NULL row if
+	// SQLite treated NULLs as equal. It doesn't — and the sweep depends on that,
+	// since a popular comment can carry many expired reports.
+	it("collapses several reports on one comment to NULL without a UNIQUE conflict", async () => {
+		addComment("c1", { created_at: ageDays(60) });
+		addReport("r1", { created_at: ageDays(60) });
+		addReport("r2", { created_at: ageDays(60) });
+		addReport("r3", { created_at: ageDays(60) });
+
+		const res = await sweepExpiredIpHashes(db, 30, NOW);
+
+		expect(res.reports).toBe(3);
+		for (const id of ["r1", "r2", "r3"]) {
+			expect(report(id).reporter_ip_hash).toBeNull();
+		}
+	});
+
+	// The load-bearing exclusion. For a signed-out visitor the hashed IP *is*
+	// the account: (provider, provider_id) is how a returning visitor resolves
+	// to their existing ghost, so expiring it on a timer would delete accounts,
+	// stop ghost bans applying, and reset vote/reaction dedup for everyone.
+	it("never touches anonymous ghost provider_id", async () => {
+		addUser("ghost", "anon", "ghost-ip-hash");
+		addComment("c-old", { created_at: ageDays(400) });
+
+		await sweepExpiredIpHashes(db, MIN_RETENTION_DAYS, NOW);
+
+		const row = sqlite
+			.prepare("SELECT provider_id FROM users WHERE id = 'ghost'")
+			.get() as { provider_id: string | null };
+		expect(row.provider_id).toBe("ghost-ip-hash");
+	});
+
+	it("does nothing when retention is off or below the floor", async () => {
+		addComment("c-ancient", { created_at: ageDays(3650) });
+		addReport("r-ancient", {
+			comment_id: "c-ancient",
+			created_at: ageDays(3650),
+		});
+
+		for (const days of [0, 1, MIN_RETENTION_DAYS - 1]) {
+			const res = await sweepExpiredIpHashes(db, days, NOW);
+			expect(res).toEqual({ comments: 0, reports: 0, more: false });
+		}
+		expect(comment("c-ancient").ip_hash).toBe("iphash");
+		expect(report("r-ancient").reporter_ip_hash).toBe("rh-r-ancient");
+	});
+
+	// No cursor: the predicate is self-draining, because a swept row stops
+	// matching its own WHERE clause. Repeating the identical batch has to make
+	// progress and eventually report nothing left.
+	it("reports more work after a full batch and drains on repeat calls", async () => {
+		for (let i = 0; i < 5; i++) {
+			addComment(`c${i}`, { created_at: ageDays(60) });
+		}
+
+		const first = await sweepExpiredIpHashes(db, 30, NOW, 2);
+		expect(first).toEqual({ comments: 2, reports: 0, more: true });
+
+		const second = await sweepExpiredIpHashes(db, 30, NOW, 2);
+		expect(second.comments).toBe(2);
+		expect(second.more).toBe(true);
+
+		const third = await sweepExpiredIpHashes(db, 30, NOW, 2);
+		expect(third).toEqual({ comments: 1, reports: 0, more: false });
+
+		const drained = sqlite
+			.prepare("SELECT COUNT(*) AS n FROM comments WHERE ip_hash IS NOT NULL")
+			.get() as { n: number };
+		expect(drained.n).toBe(0);
+	});
+
+	// A row with the hash already gone but a user_agent still set is past the
+	// window too — the two columns are written together and cleared together.
+	it("sweeps a row whose user_agent outlived its ip_hash", async () => {
+		addComment("c-ua-only", {
+			created_at: ageDays(60),
+			ip_hash: null,
+			user_agent: "ua",
+		});
+
+		const res = await sweepExpiredIpHashes(db, 30, NOW);
+
+		expect(res.comments).toBe(1);
+		expect(comment("c-ua-only").user_agent).toBeNull();
+	});
+});
+
+describe("retentionStats", () => {
+	it("counts what is past the window, what still holds a hash, and ghosts", async () => {
+		addComment("c-old", { created_at: ageDays(60) });
+		addComment("c-new", { created_at: ageDays(1) });
+		addReport("r-old", { comment_id: "c-old", created_at: ageDays(60) });
+		addUser("g1", "anon", "gh1");
+		addUser("g2", "anon", "gh2");
+
+		const s = await retentionStats(db, 30, NOW);
+
+		expect(s).toEqual({
+			retention_days: 30,
+			enabled: true,
+			comments_pending: 1,
+			reports_pending: 1,
+			comments_total: 2,
+			ghosts_total: 2,
+		});
+	});
+
+	// With retention off the cutoff is `now`, so a raw pending count would match
+	// essentially every row and read on the operator page as a purge about to
+	// happen. It never will. The totals stay live — those are what an operator
+	// deciding whether to switch this on actually needs.
+	it("zeroes the pending counts while retention is off, keeping the totals", async () => {
+		addComment("c-old", { created_at: ageDays(60) });
+		addReport("r-old", { comment_id: "c-old", created_at: ageDays(60) });
+		addUser("g1", "anon", "gh1");
+
+		const off = await retentionStats(db, 0, NOW);
+
+		expect(off.enabled).toBe(false);
+		expect(off.comments_pending).toBe(0);
+		expect(off.reports_pending).toBe(0);
+		expect(off.comments_total).toBe(1);
+		expect(off.ghosts_total).toBe(1);
+	});
+
+	it("zeroes the pending counts for a below-floor window too", async () => {
+		addComment("c-old", { created_at: ageDays(60) });
+
+		const s = await retentionStats(db, MIN_RETENTION_DAYS - 1, NOW);
+
+		expect(s.enabled).toBe(false);
+		expect(s.comments_pending).toBe(0);
+		expect(s.comments_total).toBe(1);
+	});
+});
+
+// The cron pass: settings resolution + the per-tick batch loop. `loadNumbers`
+// runs for real against the settings table, so "env var drives it" and "a DB
+// row beats the env var" are exercised end to end rather than assumed.
+describe("runIpRetention", () => {
+	// The cron pass stamps its own `now` (unlike the sweep, which takes one), so
+	// the clock has to be pinned to the same instant the fixture rows are aged
+	// against or every row reads as decades expired.
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	const mkEnv = (vars: Record<string, string> = {}) =>
+		({
+			DB: db,
+			// Cold cache every call; the put is where loadNumbers would warm it.
+			TREE_CACHE: { get: async () => null, put: async () => {} },
+			...vars,
+		}) as never;
+
+	const setSetting = (key: string, value: string) =>
+		sqlite
+			.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?,?,?)")
+			.run(key, value, NOW);
+
+	it("does nothing, and says nothing, when retention is unset", async () => {
+		const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+		const info = vi.spyOn(log, "info").mockImplementation(() => {});
+		addComment("c-old", { created_at: ageDays(400) });
+
+		await runIpRetention(mkEnv());
+
+		expect(comment("c-old").ip_hash).toBe("iphash");
+		// Off is the default, so an instance that never opted in must not log
+		// every 15 minutes forever.
+		expect(warn).not.toHaveBeenCalled();
+		expect(info).not.toHaveBeenCalled();
+		warn.mockRestore();
+		info.mockRestore();
+	});
+
+	it("sweeps on the env-var window", async () => {
+		addComment("c-old", { created_at: ageDays(400) });
+		addComment("c-new", { created_at: ageDays(2) });
+
+		await runIpRetention(mkEnv({ IP_HASH_RETENTION_DAYS: "30" }));
+
+		expect(comment("c-old").ip_hash).toBeNull();
+		expect(comment("c-new").ip_hash).toBe("iphash");
+	});
+
+	it("lets a settings row override the env var", async () => {
+		setSetting("ip_hash_retention_days", "0");
+		addComment("c-old", { created_at: ageDays(400) });
+
+		await runIpRetention(mkEnv({ IP_HASH_RETENTION_DAYS: "30" }));
+
+		expect(comment("c-old").ip_hash).toBe("iphash");
+	});
+
+	// A non-zero value under the floor means the operator asked for a sweep and
+	// isn't getting one. That's the one case worth a log line every tick.
+	it("warns instead of sweeping when the window is below the floor", async () => {
+		const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+		addComment("c-old", { created_at: ageDays(400) });
+
+		await runIpRetention(mkEnv({ IP_HASH_RETENTION_DAYS: "1" }));
+
+		expect(comment("c-old").ip_hash).toBe("iphash");
+		expect(warn).toHaveBeenCalledWith(
+			"ip_retention.below_floor",
+			expect.objectContaining({ retention_days: 1 }),
+		);
+		warn.mockRestore();
+	});
+});

--- a/tests/scheduled.test.ts
+++ b/tests/scheduled.test.ts
@@ -1,10 +1,10 @@
 /**
- * Cron-pass isolation (issue #16). The scheduled handler runs three
+ * Cron-pass isolation (issue #16). The scheduled handler runs four
  * independent passes per tick — email digest + webhook retries +
- * Telegram digest — each under its own waitUntil with its own catch.
- * These tests pin that a throw in any pass (a) never skips the others
- * and (b) is caught and logged rather than surfacing as an unhandled
- * rejection.
+ * Telegram digest + IP-hash retention — each under its own waitUntil with
+ * its own catch. These tests pin that a throw in any pass (a) never skips
+ * the others and (b) is caught and logged rather than surfacing as an
+ * unhandled rejection.
  *
  * The run* functions are mocked at the module boundary; everything
  * else in src/index.ts loads for real.
@@ -23,8 +23,13 @@ vi.mock("../src/lib/telegram-digest", async (importOriginal) => ({
 	...(await importOriginal<typeof import("../src/lib/telegram-digest")>()),
 	runTelegramDigest: vi.fn(),
 }));
+vi.mock("../src/db/ip-retention", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../src/db/ip-retention")>()),
+	runIpRetention: vi.fn(),
+}));
 
 import worker from "../src/index";
+import { runIpRetention } from "../src/db/ip-retention";
 import { runDigest } from "../src/lib/digest";
 import { log } from "../src/lib/log";
 import { runTelegramDigest } from "../src/lib/telegram-digest";
@@ -57,6 +62,7 @@ describe("scheduled handler pass isolation", () => {
 		vi.mocked(runDigest).mockReset().mockResolvedValue(undefined);
 		vi.mocked(runWebhookRetries).mockReset().mockResolvedValue(undefined);
 		vi.mocked(runTelegramDigest).mockReset().mockResolvedValue(undefined);
+		vi.mocked(runIpRetention).mockReset().mockResolvedValue(undefined);
 		errSpy = vi.spyOn(log, "error").mockImplementation(() => {});
 	});
 
@@ -67,11 +73,12 @@ describe("scheduled handler pass isolation", () => {
 	it("runs all passes under separate waitUntil calls", async () => {
 		const { ctx, tracked } = makeCtx();
 		await scheduled(ctx);
-		expect(tracked).toHaveLength(3);
+		expect(tracked).toHaveLength(4);
 		await Promise.all(tracked);
 		expect(runDigest).toHaveBeenCalledTimes(1);
 		expect(runWebhookRetries).toHaveBeenCalledTimes(1);
 		expect(runTelegramDigest).toHaveBeenCalledTimes(1);
+		expect(runIpRetention).toHaveBeenCalledTimes(1);
 		expect(errSpy).not.toHaveBeenCalled();
 	});
 
@@ -114,6 +121,22 @@ describe("scheduled handler pass isolation", () => {
 		expect(errSpy).toHaveBeenCalledWith(
 			"scheduled.telegram_digest",
 			expect.objectContaining({ error: expect.stringContaining("tg boom") }),
+		);
+	});
+
+	it("an ip-retention failure doesn't skip the other passes and is caught + logged", async () => {
+		vi.mocked(runIpRetention).mockRejectedValue(new Error("retention boom"));
+		const { ctx, tracked } = makeCtx();
+		await scheduled(ctx);
+		await expect(Promise.all(tracked)).resolves.toBeDefined();
+		expect(runDigest).toHaveBeenCalledTimes(1);
+		expect(runWebhookRetries).toHaveBeenCalledTimes(1);
+		expect(runTelegramDigest).toHaveBeenCalledTimes(1);
+		expect(errSpy).toHaveBeenCalledWith(
+			"scheduled.ip_retention",
+			expect.objectContaining({
+				error: expect.stringContaining("retention boom"),
+			}),
 		);
 	});
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -319,6 +319,11 @@ describe("loadNumbers — defaults", () => {
 			edit_window_minutes: 15,
 			spam_link_threshold: -1,
 			spam_honeypot_min_ms: 0,
+			// 0 = retention off. This default is load-bearing: a non-zero value
+			// here would start irreversibly erasing ip_hash / user_agent on the
+			// first cron tick after an upgrade, on instances that never asked for
+			// it. See src/db/ip-retention.ts.
+			ip_hash_retention_days: 0,
 		});
 	});
 

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -78,6 +78,13 @@ OAUTH_CALLBACK_BASE = "https://comments.example.com"
 # COMMUNITY_MIN_VOTES = "5"
 # Percent of downvotes/total that triggers collapse (0 = off, range 0-100):
 # COMMUNITY_COLLAPSE_RATIO = "0"
+#
+# Privacy retention — clear comments.ip_hash + user_agent and
+# reports.reporter_ip_hash once a row is N days old (swept by the cron above).
+# 0 = off (default): hashes are kept for the life of the row. IRREVERSIBLE, and
+# the sweep refuses to run below 7 days. Anonymous ghost users.provider_id is
+# never swept — that column IS the identity. See docs/ip-hashing.md.
+# IP_HASH_RETENTION_DAYS = "0"
 # Optional: Cloudflare account ID — paired with the CF_API_TOKEN secret to
 # enable the /admin/usage analytics page.
 # CF_ACCOUNT_ID = "0123abcd..."


### PR DESCRIPTION
Release A of #50: put an expiry on stored `ip_hash` values, and write down how to purge them by hand when the secret leaks. Key epoching (`ip_hash_version`) is **not** in here — see the note at the bottom.

## Why this half first

A retention window and key epoching solve different problems. Epoching only pays off *after* `IP_HASH_SECRET` leaks, and even then it doesn't help the rows already written. A retention window shrinks how much history a leak exposes every single day, whether or not a leak ever happens. Reduction beats remediation when the remediation is retroactively useless.

## What ships

**`IP_HASH_RETENTION_DAYS`** (Settings → Moderation, or the env var). Past the window, the cron clears `comments.ip_hash`, `comments.user_agent` and `reports.reporter_ip_hash`.

- **Off by default (`0`).** An upgrade never starts erasing data nobody asked it to erase.
- **Range `[0, 3650]`, with a 7-day floor that refuses rather than clamps.** A stored `1`–`6` logs a warning and sweeps nothing. The floor deliberately lives in the sweep and *not* in the setting's `min`: `parseIntSetting` clamps into `[min, max]`, so a `min: 7` would have silently rewritten an operator's explicit `0` ("off") into the most destructive value in range.
- **Comments anchor on `COALESCE(edited_at, created_at)`** — an edited comment is live moderation surface, so the clock restarts. Reports go on `created_at` alone, deliberately *not* gated on `status`: an open-and-forgotten report would otherwise keep its reporter's hash forever, which is the exact thing the window exists to bound.
- Batched (200 rows/table, ≤5 batches/tick) with the `LIMIT` inside a subquery, since `UPDATE ... LIMIT` needs a compile flag D1 doesn't guarantee. No cursor is needed — a swept row stops matching its own `WHERE`, so the predicate is self-draining.
- `/admin/operator` shows what's pending and can drain a backlog on demand instead of waiting out the cron. The on-demand sweep is admin-only and audit-logged; it reads the resolved setting so nothing can route around the dial or its floor.

**Manual purge runbook** — `AGENTS-OPERATE.md` §11 now has an "Emergency purge: `IP_HASH_SECRET` leaked" section: snapshot → purge comments/reports → purge ghosts (flagged separately, because that one deletes identities) → rotate → verify counts. §11's "Hashed IPs in an export" was rewritten to match, and a `comment_reports` → `reports` table-name drift got fixed on the way through.

## What it deliberately does not cover

Anonymous ghost `users.provider_id` is **never** swept. For a signed-out visitor that column *is* the account — `(provider, provider_id)` is how a returning visitor resolves to their existing ghost — so expiring it on a timer would delete accounts rather than hashes: ghost-author bans would stop applying and vote / reaction / page-engagement dedup would reset for every anonymous visitor.

That's a structural limit, not a TODO, so it's stated in three places rather than buried: the Operator card prints the un-sweepable ghost count in *both* the on and off states, `docs/ip-hashing.md` has a "What it does not cover" section, and `docs/privacy-policy.template.md` carries an N-day wording that says "comments and abuse reports", not "everything". Clearing ghosts stays a per-person decision (**Erase personal data**) or a deliberate operator one (the §11 runbook).

## Operator impact

- One new optional env var / setting, default `0` — no behavior change on upgrade until it's set.
- Once set: **irreversible.** Setting it back to `0` stops future sweeps; nothing restores what a sweep cleared. You lose the ability to spot a returning ban evader by hash past the window, and an aged-out report can be filed again by that network.

## Verification

`typecheck` clean · `vitest` **1210 pass / 0 fail** (+24: 17 sweep, 7 endpoint) · `build` OK · `size` OK · `biome lint` clean over 201 files · `config:check` OK · `manifest:check` OK.

The new tests run against real `node:sqlite` with every migration applied, and cover the parts that reading can't confirm: the floor refusing instead of clamping, three reports on one comment collapsing to `NULL` without tripping `UNIQUE (comment_id, reporter_ip_hash)` (SQLite counts NULLs as distinct), a ghost `provider_id` surviving a sweep with a 400-day-old comment in the table, the batch loop draining across ticks, DB-row-beats-env resolution, and the exact response body the Operator card's Alpine loop reads.

## Follow-up

Key epoching (`ip_hash_version`, lazy re-keying, rotation reasoned about per row) stays open on #50. Issue updated to reflect that split.
