### PR TITLE
chore(deps): clear remaining Dependabot alerts and drop unused dev dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,16 @@ Use `src/lib/log.ts`. Every request gets an ID; every log line is JSON. Operator
 ### Tests
 Critical paths only: API contracts, sanitizer (XSS attempts), auth cookie roundtrip, rate-limit, depth cap. No coverage threshold. Tests must not require network or paid services — hand-rolled in-memory D1/KV stubs (see `tests/helpers/`), mocks for OAuth/email/Turnstile. `@cloudflare/vitest-pool-workers` is installed but unused; moving integration tests onto the Workers pool is future work (`vitest.config.ts:8-10`).
 
+### Dependency overrides
+`package.json` has no comment syntax, so every entry in `overrides` is documented here. All of them exist for the same reason: a Cloudflare dev-tooling package pins a transitive dependency to an *exact* version that has an open advisory, so Dependabot can never open a PR for it — only an override moves it. None of these packages reach the Worker runtime; they are build- and dev-time only.
+
+Each override is temporary. Re-check them when bumping `wrangler`, and drop the entry once the upstream pin has caught up — a stale override silently holds a dependency *back*, which is the opposite of what it was added for.
+
+| Override | Why | Drop it when |
+| --- | --- | --- |
+| `esbuild: ^0.28.1` | Force-dedupes the copy `wrangler` pins at 0.27.3. Cleared GHSA-gv7w-rqvm-qjhr (high) and GHSA-g7r4-m6w7-qqqr (low). See b8aeb6b. | `wrangler` pins esbuild ≥ 0.28.1 itself. |
+| `undici: ^7.29.0` | `miniflare` (via `wrangler`) pins undici at exactly 7.28.0. Clears five advisories, including GHSA-4cwx-7wf7-3272 (high, cross-user disclosure + parse-time crash via degenerate private cache directives). | `miniflare` pins undici ≥ 7.29.0 itself. Note the ceiling: if miniflare moves to undici 8.x, this `^7` range would pin it back — widen or remove it. |
+
 ### Commits
 Atomic commits per concern. Conventional-commits style (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`). No giant "milestone done" commits.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Forward-only SQL files in `src/db/migrations/NNNN_name.sql`. The `_migrations` t
 Use `src/lib/log.ts`. Every request gets an ID; every log line is JSON. Operators tail with `wrangler tail`. No PII (names, emails, comment bodies) in logs.
 
 ### Tests
-Critical paths only: API contracts, sanitizer (XSS attempts), auth cookie roundtrip, rate-limit, depth cap. No coverage threshold. Tests must not require network or paid services — hand-rolled in-memory D1/KV stubs (see `tests/helpers/`), mocks for OAuth/email/Turnstile. `@cloudflare/vitest-pool-workers` is installed but unused; moving integration tests onto the Workers pool is future work (`vitest.config.ts:8-10`).
+Critical paths only: API contracts, sanitizer (XSS attempts), auth cookie roundtrip, rate-limit, depth cap. No coverage threshold. Tests must not require network or paid services — hand-rolled in-memory D1/KV stubs (see `tests/helpers/`), mocks for OAuth/email/Turnstile. Moving integration tests onto the Workers pool is future work; `@cloudflare/vitest-pool-workers` is deliberately *not* a dependency until then, so install it as part of that work (`vitest.config.ts:8-12`).
 
 ### Dependency overrides
 `package.json` has no comment syntax, so every entry in `overrides` is documented here. All of them exist for the same reason: a Cloudflare dev-tooling package pins a transitive dependency to an *exact* version that has an open advisory, so Dependabot can never open a PR for it — only an override moves it. None of these packages reach the Worker runtime; they are build- and dev-time only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",
-        "@cloudflare/vitest-pool-workers": "^0.19.1",
         "@cloudflare/workers-types": "^5.20260731.1",
         "@types/node": "^24.13.3",
         "esbuild": "^0.28.1",
@@ -214,25 +213,6 @@
         "workerd": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.19.1.tgz",
-      "integrity": "sha512-YzAJGOZNap12xefPgc7y74v2C1VcabPqn254wPjfgsleizy9Jj2nrvDjFnUAxoNzyiBi8p4ya8qDjA/fLOpqlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cjs-module-lexer": "1.2.3",
-        "esbuild": "0.28.1",
-        "miniflare": "4.20260730.0",
-        "wrangler": "4.116.0",
-        "zod": "3.25.76"
-      },
-      "peerDependencies": {
-        "@vitest/runner": "^4.1.0",
-        "@vitest/snapshot": "^4.1.0",
-        "vitest": "^4.1.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -2249,13 +2229,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3371,16 +3344,6 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",
-    "@cloudflare/vitest-pool-workers": "^0.19.1",
     "@cloudflare/workers-types": "^5.20260731.1",
     "@types/node": "^24.13.3",
     "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "marked": "^18.0.7"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "undici": "^7.29.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,10 @@
  * pool starts ~10x faster than the Workers pool.
  *
  * When we add integration tests (M9+) that exercise D1/KV/Turnstile via
- * Hono routes, switch those test files to the `@cloudflare/vitest-pool-
- * workers` pool — keep this config as the fast lane for unit tests.
+ * Hono routes, those test files want the `@cloudflare/vitest-pool-workers`
+ * pool — keep this config as the fast lane for unit tests. That package is
+ * not currently a dependency; install it at that point rather than carrying
+ * it (and its miniflare/undici subtree) unused.
  */
 import { defineConfig } from "vitest/config";
 


### PR DESCRIPTION
Follow-up to #66, which cleared the `hono` alert. This clears the other five and removes a dependency that was helping pull them in.

## `undici` override (1 high, 4 moderate)

`miniflare` — reached via `wrangler` — pins `undici` to **exactly** `7.28.0`. Dependabot can therefore never open a PR for it, and `miniflare@4.20260730.0` is already the latest release, so there is no upstream bump to wait for. An `overrides` entry is the only lever available.

All five advisories are fixed in `7.29.0`:

| Severity | Advisory | Issue |
| --- | --- | --- |
| **high** | GHSA-4cwx-7wf7-3272 | cross-user information disclosure and parse-time crash via degenerate private cache directives |
| moderate | GHSA-8xcm-r25x-g524 | downstream response desynchronization via retry interceptor |
| moderate | GHSA-v3r7-h72x-cjcm | cookie attribute injection via unsanitized domain and unparsed setCookie fields |
| moderate | GHSA-jr45-8vmc-qm54 | cross-user information disclosure via whitespace around equals in Cache-Control |
| moderate | GHSA-m8rv-5g2x-5cg5 | CRLF injection via blob-like body `type` |

**Real exposure was low.** `undici` is local dev and build tooling only — the deployed Worker runs on workerd and never loads it. Held to the `7.x` line rather than the `8.10.0` latest; a major bump against what miniflare expects is needless risk for a dev dependency.

## Rot guard for the overrides

`package.json` has no comment syntax, so the `esbuild` pin's "drop this once wrangler catches up" note lived only in b8aeb6b's commit message — where nobody editing `package.json` would find it. CLAUDE.md now carries a table documenting **why each override exists and the condition that retires it**.

This matters in both directions: a stale override silently holds a dependency *back*. Specifically flagged for `undici` — if miniflare ever moves to `8.x`, the `^7` range would pin it down rather than up.

## Dropping `@cloudflare/vitest-pool-workers`

Installed but unused since it was added for M9+ integration tests that never landed. Verified before removing: nothing imports `cloudflare:test`, no tsconfig lists it under `types`, and no config references `poolOptions` — `vitest.config.ts` runs everything in the node pool.

It was one of the two paths to miniflare. Removing it does **not** eliminate the undici subtree (wrangler still pulls miniflare, so the override remains load-bearing), but it drops a duplicate copy and 37 lines of lockfile.

The intent it encoded is preserved rather than lost — `vitest.config.ts` and the CLAUDE.md Tests section now state that the Workers pool is still the right destination for integration tests and that the package should be installed as part of that work.

## Verification

`lint` (208 files), `typecheck`, `test` (88 files, 1285 tests), `manifest:check`, `build`, `size` (14.14/20 KB gzip) — all pass. `npm audit` reports **0 vulnerabilities**, down from 6.

No source changes; `src/` is untouched.