### PR TITLE
chore(deps): drop the redundant esbuild override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,6 @@ Each override is temporary. Re-check them when bumping `wrangler`, and drop the 
 
 | Override | Why | Drop it when |
 | --- | --- | --- |
-| `esbuild: ^0.28.1` | Force-dedupes the copy `wrangler` pins at 0.27.3. Cleared GHSA-gv7w-rqvm-qjhr (high) and GHSA-g7r4-m6w7-qqqr (low). See b8aeb6b. | `wrangler` pins esbuild ≥ 0.28.1 itself. |
 | `undici: ^7.29.0` | `miniflare` (via `wrangler`) pins undici at exactly 7.28.0. Clears five advisories, including GHSA-4cwx-7wf7-3272 (high, cross-user disclosure + parse-time crash via degenerate private cache directives). | `miniflare` pins undici ≥ 7.29.0 itself. Note the ceiling: if miniflare moves to undici 8.x, this `^7` range would pin it back — widen or remove it. |
 
 ### Commits

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "marked": "^18.0.9"
   },
   "overrides": {
-    "esbuild": "^0.28.1",
     "undici": "^7.29.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up cleanup after merging the two Dependabot PRs (#70, #71).

`CLAUDE.md` requires re-checking the `overrides` block on every `wrangler` bump, because a stale override silently holds a dependency *back* — the opposite of why it was added. #70 moved wrangler 4.115.0 → 4.119.0, so both entries were re-checked:

| Override | Upstream pin now | Verdict |
| --- | --- | --- |
| `esbuild: ^0.28.1` | wrangler 4.119.0 pins esbuild **0.28.1** | **drop** — documented condition met |
| `undici: ^7.29.0` | miniflare pins undici **7.28.0** | **keep** — still doing real work |

### Verification

- `package-lock.json` does not change — the resolved tree is byte-identical without the override.
- `esbuild` still resolves to 0.28.1 (it is also a direct devDependency), and only one copy exists in the tree.
- `undici` still resolves to 7.29.0, so the advisory that override clears stays cleared.
- `npm ci` succeeds, so package.json and the lockfile remain in sync.
- `lint`, `typecheck`, `manifest:check`, `config:check`, `build`, `size` (14.60 KB gzip / 20 KB ceiling) all pass.

The doc table drops the `esbuild` row to match, since it is meant to list only the overrides that currently exist.