### PR TITLE
feat(widget): subscribe bell, labelled page reaction bar, reaction vocabulary re-cut

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -651,6 +651,19 @@ Triggers (events that produce a send):
   trigger, so it has its own ceiling — see below. A signed-in reader
   whose provider verified their address (GitHub, Google) is confirmed
   on the spot instead, so this send never happens for them.
+
+  Since v2.10.0 there are **two** ways a reader reaches this: the
+  composer's "Email me about new comments" checkbox, and a 🔔 in the
+  thread toolbar for someone who wants replies but has nothing to say.
+  Same endpoint and same limits — expect roughly the same confirmation
+  volume from a somewhat larger share of your readers. Both affordances
+  are hidden unless `EMAIL_FROM` **and** `PUBLIC_BASE_URL` are set
+  (`subscriptions_enabled` in `/api/v1/config`), since `POST
+  /api/v1/subscribe` fails closed with 503 without them — previously the
+  checkbox was offered on installs that could never deliver. Note this is
+  deliberately *not* gated on `RESEND_API_KEY`: a widget that went dark
+  when only the secret was missing would hide that misconfiguration
+  instead of surfacing it in the logs.
 - An unsubscribe-link click opens a confirmation page and sends nothing.
 
 Nothing sends *inline* on the request path: every notification is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,8 +319,13 @@ host-page wiring:
   anything reading `reactions.like` off `/api/v1/counts` or a tree
   response sees `reactions.fire` after upgrading. Both POST routes still
   accept `like` on the wire for one release and store it as `fire`, so a
-  reader holding a cached pre-2.10.0 bundle keeps working. Emoji are
-  native unicode — the widget ships no icon artwork.
+  reader holding a cached pre-2.10.0 bundle keeps working. That
+  compatibility runs both ways: a POST in the deprecated spelling gets
+  its answer echoed in the same spelling, so the response carries both
+  `fire` and a `like` key with the identical count. Without the echo the
+  old bundle would look up a key that is no longer there and blank the
+  cell it just incremented. Emoji are native unicode — the widget ships
+  no icon artwork.
 - **Comment reactions patch in place** (since v2.9.0). Toggling an emoji
   on a comment (`POST /api/v1/reactions` `{comment_id, kind}`) no longer
   re-fetches and re-renders the
@@ -328,7 +333,11 @@ host-page wiring:
   `reactions` is `{kind: count}` for that one comment, and the widget
   updates just that row. Scroll position, open reply composers and typed
   drafts survive a reaction now. Zero-count kinds are absent from
-  `reactions`, matching the list payload.
+  `reactions`, matching the list payload — with one exception: the
+  deprecated-spelling echo above always carries a value, so a POST for
+  `like` that removes the last reaction answers `{"like": 0}`. Old
+  bundles drop non-positive counts on merge, which is exactly how they
+  clear the cell.
 - **Sorting** defaults to `new` (newest top-level threads first). `top`
   orders top-level threads by net score (`score_up - score_down`,
   newer-first on ties); replies inside a thread always stay

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,9 +312,18 @@ host-page wiring:
 - **Anonymous viewers can vote.** They use the same IP-hashed ghost
   identity as anonymous comments — one vote per identity per comment.
   Authors cannot vote on their own comments.
+- **Reaction kinds** are `fire|love|wow|laugh|hmm|cry` (🔥❤️😮😂🤔😢).
+  **Changed in v2.10.0:** `like` 👍 was renamed to `fire` 🔥 (it duplicated
+  the up-vote sitting directly below it) and `wow` was added. Migration
+  0022 rewrites stored rows in both `reactions` and `page_reactions`, so
+  anything reading `reactions.like` off `/api/v1/counts` or a tree
+  response sees `reactions.fire` after upgrading. Both POST routes still
+  accept `like` on the wire for one release and store it as `fire`, so a
+  reader holding a cached pre-2.10.0 bundle keeps working. Emoji are
+  native unicode — the widget ships no icon artwork.
 - **Comment reactions patch in place** (since v2.9.0). Toggling an emoji
-  on a comment (`POST /api/v1/reactions` `{comment_id, kind}`, `kind` ∈
-  `like|love|laugh|hmm|cry`) no longer re-fetches and re-renders the
+  on a comment (`POST /api/v1/reactions` `{comment_id, kind}`) no longer
+  re-fetches and re-renders the
   thread — the response carries `{ok, added, reactions}` where
   `reactions` is `{kind: count}` for that one comment, and the widget
   updates just that row. Scroll position, open reply composers and typed
@@ -341,12 +350,44 @@ writing a comment. Both surfaces default **off** and are server-gated:
 - **API.** Initial state: `GET /api/v1/page-engagement?slug=<slug>` →
   `{ reactions, my_reactions, votes }` (only the enabled sections appear).
   Toggle a reaction: `POST /api/v1/page-engagement/reactions`
-  `{slug, kind}` (`kind` ∈ `like|love|laugh|hmm|cry`). Cast/clear a vote:
+  `{slug, kind}` (same vocabulary as comment reactions above). Cast/clear a vote:
   `POST /api/v1/page-engagement/votes` `{slug, value}` (`-1|0|1`; `0`
   clears). A disabled surface returns 403.
 - **Identity & dedup** mirror comments: authed users by session, anonymous
   viewers by the IP-hashed ghost — one reaction-kind and one vote per
   identity per page.
+- **Presentation** (since v2.10.0): the reaction bar opens with a
+  "What's your reaction?" prompt and each cell carries a word under the
+  emoji, so 🤔 isn't left ambiguous between "interesting" and "I doubt
+  that". Per-comment reactions stay compact — same label, but as the
+  button's accessible name rather than visible text.
+
+### Subscribing to a thread (since v2.10.0)
+
+A reader can follow a thread by email in two places, both server-gated
+and needing no host-page wiring:
+
+- the composer's "Email me about new comments" checkbox, and
+- a 🔔 in the thread toolbar, for a reader who wants replies but has
+  nothing to say. Signed-in readers subscribe in one click (the session
+  supplies the address; a provider-verified one confirms immediately);
+  anonymous readers get an inline email field and a confirmation mail.
+
+Both read `subscriptions_enabled` from `/api/v1/config` — a derived flag,
+true when the operator has set `EMAIL_FROM` and `PUBLIC_BASE_URL`. It is
+not an operator toggle and has no `data-*` attribute; when false, neither
+affordance renders, because `POST /api/v1/subscribe` fails closed with 503
+without those vars.
+
+Subscriptions are **thread-scoped** and unique per `(post_slug, email)`,
+so a subscriber hears about every new comment on the post, not only direct
+replies. The bell is an action, not a state toggle: the widget never
+displays whether an address is already subscribed, and there is no
+unsubscribe control in the widget — that is a tokenized link in the mail.
+This is deliberate. `POST /api/v1/subscribe` returns a constant response
+unless the caller proved they own the inbox, so that an unauthenticated
+prober cannot use it to discover which addresses follow which posts;
+rendering subscription state would require asking exactly that question.
 
 ### Markdown preview (since v1.10.0)
 
@@ -825,7 +866,10 @@ Since v1.10.0 you can also request page-engagement totals with
 unchanged (backward compatible); each extra is added only when requested
 **and** the matching page flag is enabled, gaining
 `votes: { slug: { score_up, score_down } }` and
-`reactions: { slug: { kind: count } }` — e.g. render "12 💬 · 30 👍".
+`reactions: { slug: { kind: count } }` — e.g. render "12 💬 · 30 🔥".
+The `kind` keys are the vocabulary listed under *Voting and reactions*
+above; note that `like` became `fire` in v2.10.0, so a listing page
+reading `reactions[slug].like` needs updating.
 
 ### `*.workers.dev`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,9 @@ Forward-only SQL files in `src/db/migrations/NNNN_name.sql`. The `_migrations` t
 ### Logging
 Use `src/lib/log.ts`. Every request gets an ID; every log line is JSON. Operators tail with `wrangler tail`. No PII (names, emails, comment bodies) in logs.
 
+### Lint
+`npm run lint` runs `biome lint`, deliberately **not** `biome check`. Biome classifies import sorting as an *assist* (`assist/source/organizeImports`), not a lint rule, so `check` reports it and `lint` does not. That convention has never been adopted here: `biome check` flags ~145 files, and this version also sorts named specifiers inside the braces, so adopting it means reordering imports nobody wrote wrong across the whole tree — a `git blame`-wrecking diff for zero runtime change. Don't "fix" it with a `--write` sweep. Keep new imports in sorted position where the surrounding file already is; leave the rest alone.
+
 ### Tests
 Critical paths only: API contracts, sanitizer (XSS attempts), auth cookie roundtrip, rate-limit, depth cap. No coverage threshold. Tests must not require network or paid services — hand-rolled in-memory D1/KV stubs (see `tests/helpers/`), mocks for OAuth/email/Turnstile. Moving integration tests onto the Workers pool is future work; `@cloudflare/vitest-pool-workers` is deliberately *not* a dependency until then, so install it as part of that work (`vitest.config.ts:8-12`).
 

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -88,4 +88,5 @@ useful for a single demo page.
   `&include=votes,reactions`. The response then gains
   `votes: { slug: { score_up, score_down } }` and
   `reactions: { slug: { kind: count } }` for the enabled features —
-  e.g. render "12 💬 · 30 👍".
+  e.g. render "12 💬 · 30 🔥" from `reactions[slug].fire`. (The 👍 `like`
+  kind became 🔥 `fire` in v2.10.0.)

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -372,7 +372,8 @@
     "0018_email_send_budget.sql",
     "0019_audit_log_pii.sql",
     "0020_subscriptions_locale.sql",
-    "0021_moderator_notifications.sql"
+    "0021_moderator_notifications.sql",
+    "0022_reaction_kind_fire.sql"
   ],
   "breakingChanges": [
     {

--- a/src/admin-ui/pages/settings.ts
+++ b/src/admin-ui/pages/settings.ts
@@ -9,8 +9,14 @@ import {
 	type ResolvedStrings,
 	numberBounds,
 } from "../../lib/settings";
+import { REACTION_KINDS } from "../../widget/reactions";
 import { renderSelect, renderStepper, renderSwitch, renderTabs } from "../controls";
 import { escapeHtml } from "../escape";
+
+// Read off the vocabulary rather than spelled out. The hand-written version
+// outlived the v2.10.0 `like` → `fire` rename by a release and only ever named
+// five of the six kinds; derived, the next rename updates this help text itself.
+const REACTION_GLYPHS = REACTION_KINDS.map((r) => r.emoji).join(" ");
 
 // Settings tabs. Email / Moderation tabs can slot in here later without
 // touching the panel-toggle wiring (each panel just keys off `tab`).
@@ -32,7 +38,7 @@ const FLAG_META: { key: FlagKey; label: string; help: string }[] = [
 	{
 		key: "reactions_enabled",
 		label: "Emoji reactions (comments)",
-		help: "Per-comment emoji reactions (like / love / laugh / hmm / cry).",
+		help: `Per-comment emoji reactions (${REACTION_GLYPHS}).`,
 	},
 	{
 		key: "votes_enabled",

--- a/src/db/migrations/0022_reaction_kind_fire.sql
+++ b/src/db/migrations/0022_reaction_kind_fire.sql
@@ -1,0 +1,37 @@
+-- Rename the `like` reaction to `fire`.
+-- Forward-only. The migration runner records this as applied; never edit
+-- once shipped — make a 0023_*.sql instead.
+--
+-- 👍 sat directly above the up-vote button and meant the same thing twice, so
+-- the kind was re-cut as 🔥 "Brilliant". `kind` is the stored value, so the
+-- rename is this file rather than an edit to the widget's list.
+--
+-- Both tables carry the same vocabulary: `reactions` (per comment, 0001) and
+-- `page_reactions` (per article, 0011). Rewriting one and not the other would
+-- leave the article bar showing counts the comment rows had lost.
+--
+-- OR IGNORE, not plain UPDATE. Both primary keys end in `kind`
+-- (comment_id/post_slug, user_id, kind), so a reader holding both a `like` and a
+-- `fire` row on the same target collides. That cannot happen on a fresh install
+-- — `fire` did not exist before this release — but it can on a re-run, and a
+-- migration that only works once is a migration that fails a restored backup.
+--
+-- The DELETE is not tidying-up, it is the other half of the rename. OR IGNORE
+-- *skips* a conflicting row rather than removing it, so without this the
+-- collision case leaves the row sitting there as `like` — still in the table,
+-- never rendered by any build, which is precisely the orphan this migration
+-- exists to prevent. Anything still spelled `like` after the UPDATE is by
+-- definition a row whose `fire` counterpart already exists, so dropping it
+-- costs that reader nothing: their reaction on that target is already recorded.
+--
+-- Net effect: no count changes and no row is orphaned. `like` and `fire` mean
+-- the same thing (generic approval), so every existing reaction keeps its
+-- meaning as well as its count. The routes also accept `like` on the wire for
+-- one release and store it as `fire` (see normalizeReactionKind), which is what
+-- makes the gap between this migration and the code deploy safe in either order.
+
+UPDATE OR IGNORE reactions      SET kind = 'fire' WHERE kind = 'like';
+DELETE FROM       reactions                       WHERE kind = 'like';
+
+UPDATE OR IGNORE page_reactions SET kind = 'fire' WHERE kind = 'like';
+DELETE FROM       page_reactions                  WHERE kind = 'like';

--- a/src/i18n/widget/de.ts
+++ b/src/i18n/widget/de.ts
@@ -83,6 +83,13 @@ export const de = {
 	"w.page.helpful": "War das hilfreich?",
 	"w.page.up": "Seite positiv bewerten",
 	"w.page.down": "Seite negativ bewerten",
+	"w.page.react_prompt": "Wie ist deine Reaktion?",
+	"w.react.fire": "Genial",
+	"w.react.love": "Liebe ich",
+	"w.react.wow": "Wow",
+	"w.react.laugh": "Lustig",
+	"w.react.hmm": "Hmm",
+	"w.react.cry": "Traurig",
 
 	// ── The thread ──────────────────────────────────────────────────────────
 	"w.replies": { one: "{n} Antwort", other: "{n} Antworten" },

--- a/src/i18n/widget/de.ts
+++ b/src/i18n/widget/de.ts
@@ -113,6 +113,7 @@ export const de = {
 	"w.subscribe.submit": "Abonnieren",
 	"w.subscribe.done": "Bitte bestätige die E-Mail, die wir dir geschickt haben.",
 	"w.subscribe.failed": "Abonnieren fehlgeschlagen. Bitte erneut versuchen.",
+	"w.subscribe.ratelimit": "Zu viele Anfragen. Bitte später erneut versuchen.",
 	"w.load_more": "Ältere Kommentare laden",
 	"w.load_more_failed": "Konnte nicht mehr laden: {detail}",
 

--- a/src/i18n/widget/de.ts
+++ b/src/i18n/widget/de.ts
@@ -109,6 +109,10 @@ export const de = {
 	"w.sort_by": "Sortieren nach {control}",
 	"w.sort.new": "Neueste",
 	"w.sort.top": "Beste",
+	"w.subscribe": "Bei neuen Kommentaren zu diesem Beitrag benachrichtigen",
+	"w.subscribe.submit": "Abonnieren",
+	"w.subscribe.done": "Bitte bestätige die E-Mail, die wir dir geschickt haben.",
+	"w.subscribe.failed": "Abonnieren fehlgeschlagen. Bitte erneut versuchen.",
 	"w.load_more": "Ältere Kommentare laden",
 	"w.load_more_failed": "Konnte nicht mehr laden: {detail}",
 

--- a/src/i18n/widget/es.ts
+++ b/src/i18n/widget/es.ts
@@ -104,6 +104,10 @@ export const es = {
 	"w.sort_by": "Ordenar por {control}",
 	"w.sort.new": "Más recientes",
 	"w.sort.top": "Mejores",
+	"w.subscribe": "Avisarme por correo de nuevos comentarios en esta entrada",
+	"w.subscribe.submit": "Suscribirme",
+	"w.subscribe.done": "Revisa tu correo para confirmar.",
+	"w.subscribe.failed": "No se pudo suscribir. Inténtalo de nuevo.",
 	"w.load_more": "Cargar comentarios anteriores",
 	"w.load_more_failed": "No se pudieron cargar más: {detail}",
 

--- a/src/i18n/widget/es.ts
+++ b/src/i18n/widget/es.ts
@@ -80,6 +80,13 @@ export const es = {
 	"w.page.helpful": "¿Te ha resultado útil?",
 	"w.page.up": "Votar a favor de esta página",
 	"w.page.down": "Votar en contra de esta página",
+	"w.page.react_prompt": "¿Cuál es tu reacción?",
+	"w.react.fire": "Brillante",
+	"w.react.love": "Me encanta",
+	"w.react.wow": "Vaya",
+	"w.react.laugh": "Divertido",
+	"w.react.hmm": "Mmm",
+	"w.react.cry": "Triste",
 
 	// ── The thread ──────────────────────────────────────────────────────────
 	"w.replies": { one: "{n} respuesta", other: "{n} respuestas" },

--- a/src/i18n/widget/es.ts
+++ b/src/i18n/widget/es.ts
@@ -108,6 +108,7 @@ export const es = {
 	"w.subscribe.submit": "Suscribirme",
 	"w.subscribe.done": "Revisa tu correo para confirmar.",
 	"w.subscribe.failed": "No se pudo suscribir. Inténtalo de nuevo.",
+	"w.subscribe.ratelimit": "Demasiadas solicitudes. Inténtalo más tarde.",
 	"w.load_more": "Cargar comentarios anteriores",
 	"w.load_more_failed": "No se pudieron cargar más: {detail}",
 

--- a/src/i18n/widget/fr.ts
+++ b/src/i18n/widget/fr.ts
@@ -106,6 +106,10 @@ export const fr = {
 	"w.sort_by": "Trier par {control}",
 	"w.sort.new": "Plus récents",
 	"w.sort.top": "Meilleurs",
+	"w.subscribe": "M'avertir par e-mail des nouveaux commentaires sur cet article",
+	"w.subscribe.submit": "S'abonner",
+	"w.subscribe.done": "Vérifiez votre e-mail pour confirmer.",
+	"w.subscribe.failed": "Impossible de s'abonner. Veuillez réessayer.",
 	"w.load_more": "Charger les commentaires plus anciens",
 	"w.load_more_failed": "Impossible d'en charger davantage : {detail}",
 

--- a/src/i18n/widget/fr.ts
+++ b/src/i18n/widget/fr.ts
@@ -110,6 +110,7 @@ export const fr = {
 	"w.subscribe.submit": "S'abonner",
 	"w.subscribe.done": "Vérifiez votre e-mail pour confirmer.",
 	"w.subscribe.failed": "Impossible de s'abonner. Veuillez réessayer.",
+	"w.subscribe.ratelimit": "Trop de requêtes. Veuillez réessayer plus tard.",
 	"w.load_more": "Charger les commentaires plus anciens",
 	"w.load_more_failed": "Impossible d'en charger davantage : {detail}",
 

--- a/src/i18n/widget/fr.ts
+++ b/src/i18n/widget/fr.ts
@@ -82,6 +82,13 @@ export const fr = {
 	"w.page.helpful": "Cette page vous a-t-elle été utile ?",
 	"w.page.up": "Voter pour cette page",
 	"w.page.down": "Voter contre cette page",
+	"w.page.react_prompt": "Quelle est votre réaction ?",
+	"w.react.fire": "Génial",
+	"w.react.love": "J'adore",
+	"w.react.wow": "Waouh",
+	"w.react.laugh": "Drôle",
+	"w.react.hmm": "Hmm",
+	"w.react.cry": "Triste",
 
 	// ── The thread ──────────────────────────────────────────────────────────
 	"w.replies": { one: "{n} réponse", other: "{n} réponses" },

--- a/src/routes/api.config.ts
+++ b/src/routes/api.config.ts
@@ -15,6 +15,10 @@
  *     surfaces the widget should render. Resolved with DB-override > env >
  *     default precedence (see src/lib/settings.ts); operators toggle them at
  *     runtime from the admin Settings page.
+ *   - subscriptions_enabled: whether this install can send mail, derived from
+ *     EMAIL_FROM + PUBLIC_BASE_URL. Not an operator toggle — it tells the widget
+ *     whether to offer the subscribe affordances at all, since `POST
+ *     /api/v1/subscribe` fails closed on the same pair.
  *   - numeric display settings (comments_per_page, replies_per_thread,
  *     auto_collapse_depth, edit_window_minutes): page size, reply-collapse and
  *     edit-window tuning, same DB-override > env > default precedence (see
@@ -105,6 +109,16 @@ config.get("/", async (c) => {
 		downvotes_enabled: flags.downvotes_enabled,
 		page_reactions_enabled: flags.page_reactions_enabled,
 		page_votes_enabled: flags.page_votes_enabled,
+		// Derived, not an operator setting: "can this install send mail at all".
+		// Both are required for a double-opt-in — without EMAIL_FROM there is
+		// nothing to send from, and without PUBLIC_BASE_URL the confirmation link
+		// in the mail has no origin to point at. `POST /api/v1/subscribe` already
+		// fails closed with 503 on exactly this pair; the flag lets the widget
+		// avoid *offering* a subscription it knows would 503. RESEND_API_KEY is
+		// deliberately not part of the test — it is a secret, and a widget that
+		// went dark when the key alone was missing would hide the misconfiguration
+		// rather than surface it (the route logs and refunds send budget instead).
+		subscriptions_enabled: !!(c.env.EMAIL_FROM && c.env.PUBLIC_BASE_URL),
 		// Display/pagination. comments_per_page drives the server-side page
 		// slice (included here for parity/debuggability); the widget consumes
 		// replies_per_thread and auto_collapse_depth for client-side reply

--- a/src/routes/api.page-engagement.ts
+++ b/src/routes/api.page-engagement.ts
@@ -34,7 +34,11 @@ import { loadFlags } from "../lib/settings";
 import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
 // Shared with the comment-level route and the widget — see ../widget/reactions.
-import { REACTION_KIND_SET, normalizeReactionKind } from "../widget/reactions";
+import {
+	REACTION_KIND_SET,
+	normalizeReactionKind,
+	withDeprecatedAlias,
+} from "../widget/reactions";
 
 const pageEngagement = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
@@ -117,8 +121,10 @@ pageEngagement.post("/reactions", async (c) => {
 	const slug = validateSlug(body.slug ?? "");
 	if (!slug) return c.json({ error: t("err.post.invalid") }, 400);
 	// Normalize before the membership test, never instead of it: unknown kinds
-	// come back unchanged and are rejected below.
-	const kind = normalizeReactionKind((body.kind ?? "").trim());
+	// come back unchanged and are rejected below. The pre-normalization spelling
+	// is kept because the response has to answer in it — see withDeprecatedAlias.
+	const requestedKind = (body.kind ?? "").trim();
+	const kind = normalizeReactionKind(requestedKind);
 	if (!REACTION_KIND_SET.has(kind))
 		return c.json({ error: "invalid_kind" }, 400);
 
@@ -149,7 +155,11 @@ pageEngagement.post("/reactions", async (c) => {
 		outcome: result.added ? "added" : "removed",
 	});
 
-	return c.json({ ok: true, added: result.added, reactions: totals });
+	return c.json({
+		ok: true,
+		added: result.added,
+		reactions: withDeprecatedAlias(totals, requestedKind),
+	});
 });
 
 // -- POST a vote -------------------------------------------------------------

--- a/src/routes/api.page-engagement.ts
+++ b/src/routes/api.page-engagement.ts
@@ -33,11 +33,12 @@ import { writeEvent } from "../lib/analytics";
 import { loadFlags } from "../lib/settings";
 import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
+// Shared with the comment-level route and the widget — see ../widget/reactions.
+import { REACTION_KIND_SET } from "../widget/reactions";
 
 const pageEngagement = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
 const SLUG_RE = /^[a-zA-Z0-9_\-./]{1,200}$/;
-const ALLOWED_KINDS = new Set(["like", "love", "laugh", "hmm", "cry"]);
 
 const normalizeValue = (raw: unknown): VoteValue | null => {
 	if (raw === 1 || raw === -1 || raw === 0) return raw;
@@ -116,7 +117,8 @@ pageEngagement.post("/reactions", async (c) => {
 	const slug = validateSlug(body.slug ?? "");
 	if (!slug) return c.json({ error: t("err.post.invalid") }, 400);
 	const kind = (body.kind ?? "").trim();
-	if (!ALLOWED_KINDS.has(kind)) return c.json({ error: "invalid_kind" }, 400);
+	if (!REACTION_KIND_SET.has(kind))
+		return c.json({ error: "invalid_kind" }, 400);
 
 	const ipHash = await requireIpHash(c);
 	if (ipHash instanceof Response) return ipHash;

--- a/src/routes/api.page-engagement.ts
+++ b/src/routes/api.page-engagement.ts
@@ -34,7 +34,7 @@ import { loadFlags } from "../lib/settings";
 import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
 // Shared with the comment-level route and the widget — see ../widget/reactions.
-import { REACTION_KIND_SET } from "../widget/reactions";
+import { REACTION_KIND_SET, normalizeReactionKind } from "../widget/reactions";
 
 const pageEngagement = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
@@ -116,7 +116,9 @@ pageEngagement.post("/reactions", async (c) => {
 
 	const slug = validateSlug(body.slug ?? "");
 	if (!slug) return c.json({ error: t("err.post.invalid") }, 400);
-	const kind = (body.kind ?? "").trim();
+	// Normalize before the membership test, never instead of it: unknown kinds
+	// come back unchanged and are rejected below.
+	const kind = normalizeReactionKind((body.kind ?? "").trim());
 	if (!REACTION_KIND_SET.has(kind))
 		return c.json({ error: "invalid_kind" }, 400);
 

--- a/src/routes/api.reactions.ts
+++ b/src/routes/api.reactions.ts
@@ -22,10 +22,11 @@ import { loadFlags } from "../lib/settings";
 import { bustTreeCache } from "../lib/tree-cache";
 import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
+// The vocabulary is the widget's, imported rather than restated: a hand-copied
+// set here is a set that silently disagrees with the buttons the reader sees.
+import { REACTION_KIND_SET } from "../widget/reactions";
 
 const reactions = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
-
-const ALLOWED_KINDS = new Set(["like", "love", "laugh", "hmm", "cry"]);
 
 type ReactionBody = {
 	comment_id?: string;
@@ -48,7 +49,7 @@ reactions.post("/", async (c) => {
 	const comment_id = (body.comment_id ?? "").trim();
 	const kind = (body.kind ?? "").trim();
 	if (!comment_id) return c.json({ error: t("err.not_found") }, 400);
-	if (!ALLOWED_KINDS.has(kind)) {
+	if (!REACTION_KIND_SET.has(kind)) {
 		return c.json({ error: "invalid_kind" }, 400);
 	}
 

--- a/src/routes/api.reactions.ts
+++ b/src/routes/api.reactions.ts
@@ -24,7 +24,11 @@ import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
 // The vocabulary is the widget's, imported rather than restated: a hand-copied
 // set here is a set that silently disagrees with the buttons the reader sees.
-import { REACTION_KIND_SET, normalizeReactionKind } from "../widget/reactions";
+import {
+	REACTION_KIND_SET,
+	normalizeReactionKind,
+	withDeprecatedAlias,
+} from "../widget/reactions";
 
 const reactions = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
@@ -48,8 +52,10 @@ reactions.post("/", async (c) => {
 
 	const comment_id = (body.comment_id ?? "").trim();
 	// Normalize before the membership test, never instead of it: unknown kinds
-	// come back unchanged and are rejected below.
-	const kind = normalizeReactionKind((body.kind ?? "").trim());
+	// come back unchanged and are rejected below. The pre-normalization spelling
+	// is kept because the response has to answer in it — see withDeprecatedAlias.
+	const requestedKind = (body.kind ?? "").trim();
+	const kind = normalizeReactionKind(requestedKind);
 	if (!comment_id) return c.json({ error: t("err.not_found") }, 400);
 	if (!REACTION_KIND_SET.has(kind)) {
 		return c.json({ error: "invalid_kind" }, 400);
@@ -104,7 +110,11 @@ reactions.post("/", async (c) => {
 		outcome: result.added ? "added" : "removed",
 	});
 
-	return c.json({ ok: true, added: result.added, reactions: totals });
+	return c.json({
+		ok: true,
+		added: result.added,
+		reactions: withDeprecatedAlias(totals, requestedKind),
+	});
 });
 
 export { reactions };

--- a/src/routes/api.reactions.ts
+++ b/src/routes/api.reactions.ts
@@ -24,7 +24,7 @@ import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
 // The vocabulary is the widget's, imported rather than restated: a hand-copied
 // set here is a set that silently disagrees with the buttons the reader sees.
-import { REACTION_KIND_SET } from "../widget/reactions";
+import { REACTION_KIND_SET, normalizeReactionKind } from "../widget/reactions";
 
 const reactions = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
@@ -47,7 +47,9 @@ reactions.post("/", async (c) => {
 	if (!body) return c.json({ error: t("err.internal") }, 400);
 
 	const comment_id = (body.comment_id ?? "").trim();
-	const kind = (body.kind ?? "").trim();
+	// Normalize before the membership test, never instead of it: unknown kinds
+	// come back unchanged and are rejected below.
+	const kind = normalizeReactionKind((body.kind ?? "").trim());
 	if (!comment_id) return c.json({ error: t("err.not_found") }, 400);
 	if (!REACTION_KIND_SET.has(kind)) {
 		return c.json({ error: "invalid_kind" }, 400);

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -945,6 +945,9 @@ const buildReactions = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 			const count = r?.count ?? 0;
 			if (r?.mine) cell.btn.dataset.mine = "1";
 			else delete cell.btn.dataset.mine;
+			// `data-mine` is what the stylesheet highlights; aria-pressed is the
+			// same fact for a reader who can't see the highlight.
+			cell.btn.setAttribute("aria-pressed", r?.mine ? "true" : "false");
 			cell.count.textContent = String(count);
 			cell.count.hidden = count === 0;
 			// An anonymous reader who un-reacts the last 👍 has to see the button
@@ -955,7 +958,7 @@ const buildReactions = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	};
 
 	const map = reactionsByKind(n.reactions);
-	for (const { kind, emoji } of REACTION_KINDS) {
+	for (const { kind, emoji, labelKey } of REACTION_KINDS) {
 		// Hide zero-count kinds unless the viewer is signed in (so signed-in
 		// users can react with a kind nobody else has used yet). Anonymous
 		// readers see only used kinds.
@@ -963,7 +966,13 @@ const buildReactions = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 		const btn = el("button", "gr-reaction");
 		btn.type = "button";
 		btn.dataset.kind = kind;
-		btn.appendChild(document.createTextNode(emoji));
+		// The label is the accessible name rather than visible text here: six
+		// labelled cells per comment would be more chrome than the comment. A
+		// screen reader otherwise announces the raw emoji, and on a couple of
+		// them ("crying face") that reads as the wrong sentiment entirely.
+		btn.setAttribute("aria-label", s(labelKey));
+		btn.title = s(labelKey);
+		btn.appendChild(el("span", "gr-reaction-emoji", emoji));
 		const count = el("span", "gr-reaction-count", "");
 		btn.appendChild(count);
 		cells.set(kind, { btn, count });
@@ -1025,14 +1034,24 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 		{ btn: HTMLButtonElement; count: HTMLElement }
 	>();
 	if (ctx.pageReactionsEnabled) {
+		// The prompt is what turns a row of chips into an invitation — without it
+		// the bar reads as a tally of what other people did.
+		wrap.appendChild(
+			el("div", "gr-page-react-prompt", s("w.page.react_prompt")),
+		);
 		const reactWrap = el("div", "gr-page-reactions");
-		for (const { kind, emoji } of REACTION_KINDS) {
-			const btn = el("button", "gr-reaction");
+		for (const { kind, emoji, labelKey } of REACTION_KINDS) {
+			const btn = el("button", "gr-reaction gr-reaction-labelled");
 			btn.type = "button";
 			btn.dataset.kind = kind;
-			btn.appendChild(document.createTextNode(emoji));
+			// Emoji and count on one line, label under it. Unlike the per-comment
+			// row there is space for the label here, and it is the only thing that
+			// says what the emoji is *for* before the reader commits to a click.
+			const face = el("span", "gr-reaction-face");
+			face.appendChild(el("span", "gr-reaction-emoji", emoji));
 			const count = el("span", "gr-reaction-count", "0");
-			btn.appendChild(count);
+			face.appendChild(count);
+			btn.append(face, el("span", "gr-reaction-label", s(labelKey)));
 			reactCells.set(kind, { btn, count });
 			reactWrap.appendChild(btn);
 		}
@@ -1046,8 +1065,10 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 		const mineSet = new Set(mine);
 		for (const [kind, cell] of reactCells) {
 			cell.count.textContent = String(totals[kind] ?? 0);
-			if (mineSet.has(kind)) cell.btn.dataset.mine = "1";
+			const isMine = mineSet.has(kind);
+			if (isMine) cell.btn.dataset.mine = "1";
 			else delete cell.btn.dataset.mine;
+			cell.btn.setAttribute("aria-pressed", isMine ? "true" : "false");
 		}
 	};
 
@@ -1076,6 +1097,7 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 			}
 			if (body.added) cell.btn.dataset.mine = "1";
 			else delete cell.btn.dataset.mine;
+			cell.btn.setAttribute("aria-pressed", body.added ? "true" : "false");
 		} catch {
 			// leave UI as-is; user can retry
 		} finally {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -615,6 +615,11 @@ type WidgetCtx = {
 	downvotesEnabled: boolean;
 	pageReactionsEnabled: boolean;
 	pageVotesEnabled: boolean;
+	// Whether this install can send mail at all (EMAIL_FROM + PUBLIC_BASE_URL,
+	// derived server-side). Gates both subscribe affordances — the bell and the
+	// composer's notify checkbox — because POST /api/v1/subscribe 503s without
+	// them, and an opt-in that cannot possibly deliver is worse than no opt-in.
+	subscriptionsEnabled: boolean;
 	// Reply-collapse tuning (server config). repliesPerThread: replies shown
 	// under a parent before a "Show N more" button (0 = all). autoCollapseDepth:
 	// a comment at depth >= this starts with its replies collapsed (0 = never).
@@ -1192,6 +1197,120 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 		}
 	})();
 
+	return wrap;
+};
+
+/**
+ * Subscribe-to-thread bell for the thread toolbar.
+ *
+ * Until this existed, the only way to subscribe was the composer's notify
+ * checkbox — so a reader who wanted replies by email but had nothing to say
+ * could not subscribe at all. No new endpoint: `POST /api/v1/subscribe` already
+ * accepts a standalone `{post_slug, email?}` with double opt-in, a per-address
+ * pending cap and a global send budget.
+ *
+ * **This is an action, never a state toggle, and that is a security property
+ * rather than a simplification.** The endpoint deliberately returns a constant
+ * shape unless the caller proved they own the inbox, because mirroring the
+ * stored `confirmed_at` would make it a subscription oracle — an unauthenticated
+ * prober could learn "this address already follows this post", from a branch
+ * that sends no mail, so the victim would never see it. A bell that rendered
+ * subscribed-vs-not would have to ask that question. So: no state query, no
+ * localStorage marker, and no unsubscribe here (unsubscribing is token-based via
+ * the emailed link, which is the only way to do it without the oracle).
+ *
+ * Repeat clicks are therefore fine by design — the upsert is non-destructive and
+ * refunds send budget when no mail actually goes out.
+ */
+const buildSubscribeBell = (
+	apiBase: string,
+	slug: string,
+	signedIn: boolean,
+): HTMLElement => {
+	const wrap = el("div", "gr-subscribe");
+	const btn = el("button", "gr-subscribe-btn");
+	btn.type = "button";
+	btn.setAttribute("aria-label", s("w.subscribe"));
+	btn.title = s("w.subscribe");
+	btn.appendChild(el("span", "gr-reaction-emoji", "🔔"));
+	const status = el("span", "gr-subscribe-status");
+	// Announce the outcome: the click's only visible result is this text, and a
+	// reader on a screen reader would otherwise get nothing back at all.
+	status.setAttribute("role", "status");
+	status.hidden = true;
+
+	const say = (msg: string): void => {
+		status.textContent = msg;
+		status.hidden = false;
+	};
+
+	// Anonymous readers need to supply an address; a signed-in reader's comes
+	// from the session (and auto-confirms when the provider vouched for it), so
+	// asking would be a worse experience *and* would let them subscribe an inbox
+	// that isn't theirs. Declared before `send` because `send` hides it on
+	// success.
+	const form = el("form", "gr-subscribe-form");
+	form.hidden = true;
+	const emailInput = el("input") as HTMLInputElement;
+
+	// `message` is already localized by the server (it negotiates from ?lang=).
+	// Rendered via textContent — as every server string in this widget is — so a
+	// future message containing markup is text, not markup.
+	const send = async (email: string): Promise<void> => {
+		btn.disabled = true;
+		try {
+			const res = await fetch(apiUrl(apiBase, "/api/v1/subscribe"), {
+				method: "POST",
+				credentials: "include",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(email ? { post_slug: slug, email } : { post_slug: slug }),
+			});
+			const body = (await res.json().catch(() => null)) as {
+				message?: string;
+			} | null;
+			if (!res.ok) {
+				// The server's own message where there is one — it distinguishes a
+				// rate limit from a bad address, and inventing a generic failure
+				// would throw that away.
+				say(body?.message ?? s("w.subscribe.failed"));
+				return;
+			}
+			say(body?.message ?? s("w.subscribe.done"));
+			form.hidden = true;
+			btn.hidden = true;
+		} catch {
+			say(s("w.subscribe.failed"));
+		} finally {
+			btn.disabled = false;
+		}
+	};
+
+	if (!signedIn) {
+		emailInput.className = "gr-email-input";
+		emailInput.type = "email";
+		emailInput.required = true;
+		emailInput.placeholder = s("w.email_ph");
+		emailInput.autocomplete = "email";
+		const submit = el("button", "gr-subscribe-submit", s("w.subscribe.submit"));
+		submit.type = "submit";
+		form.append(emailInput, submit);
+		form.addEventListener("submit", (e) => {
+			e.preventDefault();
+			const email = emailInput.value.trim();
+			if (email) void send(email);
+		});
+	}
+
+	btn.addEventListener("click", () => {
+		if (signedIn) {
+			void send("");
+			return;
+		}
+		form.hidden = !form.hidden;
+		if (!form.hidden) emailInput.focus();
+	});
+
+	wrap.append(btn, form, status);
 	return wrap;
 };
 
@@ -1889,6 +2008,7 @@ const buildForm = (
 	apiBase: string,
 	siteKey: string | null,
 	signedIn: boolean,
+	subscriptionsEnabled: boolean,
 ): HTMLFormElement => {
 	const form = document.createElement("form");
 	form.className = "gr-form";
@@ -1927,30 +2047,38 @@ const buildForm = (
 
 	// Notify-me opt-in. Anonymous: an email field appears alongside the
 	// checkbox. Signed-in: we already have their email so just the box.
-	const notifyWrap = el("label", "gr-notify");
-	const notifyCb = el("input") as HTMLInputElement;
-	notifyCb.type = "checkbox";
-	notifyCb.className = "gr-notify-cb";
-	notifyCb.name = "notify";
-	// The leading space separates the label from its checkbox; it's layout, not
-	// copy, so it stays out of the string table.
-	const notifyText = document.createTextNode(` ${s("w.notify")}`);
-	notifyWrap.append(notifyCb, notifyText);
-	form.appendChild(notifyWrap);
+	//
+	// Skipped entirely on an install with no outbound mail configured. The
+	// endpoint 503s there, so the checkbox was an opt-in that could never
+	// deliver — the reader ticked it, posted, and simply never heard anything.
+	// The submit handler reads the checkbox out of the DOM, so its absence is
+	// also what stops the POST being attempted.
+	if (subscriptionsEnabled) {
+		const notifyWrap = el("label", "gr-notify");
+		const notifyCb = el("input") as HTMLInputElement;
+		notifyCb.type = "checkbox";
+		notifyCb.className = "gr-notify-cb";
+		notifyCb.name = "notify";
+		// The leading space separates the label from its checkbox; it's layout, not
+		// copy, so it stays out of the string table.
+		const notifyText = document.createTextNode(` ${s("w.notify")}`);
+		notifyWrap.append(notifyCb, notifyText);
+		form.appendChild(notifyWrap);
 
-	if (!signedIn) {
-		const emailInput = el("input") as HTMLInputElement;
-		emailInput.className = "gr-email-input";
-		emailInput.name = "email";
-		emailInput.type = "email";
-		emailInput.placeholder = s("w.email_ph");
-		emailInput.autocomplete = "email";
-		emailInput.hidden = true;
-		notifyCb.addEventListener("change", () => {
-			emailInput.hidden = !notifyCb.checked;
-			emailInput.required = notifyCb.checked;
-		});
-		form.appendChild(emailInput);
+		if (!signedIn) {
+			const emailInput = el("input") as HTMLInputElement;
+			emailInput.className = "gr-email-input";
+			emailInput.name = "email";
+			emailInput.type = "email";
+			emailInput.placeholder = s("w.email_ph");
+			emailInput.autocomplete = "email";
+			emailInput.hidden = true;
+			notifyCb.addEventListener("change", () => {
+				emailInput.hidden = !notifyCb.checked;
+				emailInput.required = notifyCb.checked;
+			});
+			form.appendChild(emailInput);
+		}
 	}
 
 	// Turnstile only renders for anonymous posts. Signed-in posts skip it
@@ -2335,6 +2463,10 @@ const loadOnce = async (
 	let downvotesEnabled = true;
 	let pageReactionsEnabled = false;
 	let pageVotesEnabled = false;
+	// True by default, and read below as `!== false`, so a server older than this
+	// bundle — which sends no such field — keeps offering the notify checkbox it
+	// has always offered. Only an explicit `false` hides the subscribe UI.
+	let subscriptionsEnabled = true;
 	// Defaults mirror the server (src/lib/settings.ts) so a failed/absent
 	// config fetch degrades gracefully to the same behavior.
 	let repliesPerThread = 3;
@@ -2368,6 +2500,7 @@ const loadOnce = async (
 				downvotes_enabled?: boolean;
 				page_reactions_enabled?: boolean;
 				page_votes_enabled?: boolean;
+				subscriptions_enabled?: boolean;
 				replies_per_thread?: number;
 				auto_collapse_depth?: number;
 				community_min_votes?: number;
@@ -2410,6 +2543,7 @@ const loadOnce = async (
 			downvotesEnabled = cfg.downvotes_enabled !== false;
 			pageReactionsEnabled = cfg.page_reactions_enabled === true;
 			pageVotesEnabled = cfg.page_votes_enabled === true;
+			subscriptionsEnabled = cfg.subscriptions_enabled !== false;
 			if (typeof cfg.replies_per_thread === "number")
 				repliesPerThread = cfg.replies_per_thread;
 			if (typeof cfg.auto_collapse_depth === "number")
@@ -2475,6 +2609,7 @@ const loadOnce = async (
 		downvotesEnabled,
 		pageReactionsEnabled,
 		pageVotesEnabled,
+		subscriptionsEnabled,
 		repliesPerThread,
 		autoCollapseDepth,
 		communityMinVotes,
@@ -2489,7 +2624,7 @@ const loadOnce = async (
 	// The composer is always built (its submit/Turnstile wiring lives further
 	// down) but only mounted when comments are enabled. When disabled, existing
 	// comments stay visible (read-only) and we show a "closed" notice instead.
-	const form = buildForm(apiBase, siteKey, me != null);
+	const form = buildForm(apiBase, siteKey, me != null, subscriptionsEnabled);
 	// Restore/persist the top-level composer draft (cleared on successful post
 	// in submit()). Reply-form drafts are wired separately in buildReplyForm.
 	const composer = form.querySelector(
@@ -2520,31 +2655,43 @@ const loadOnce = async (
 		wrap.appendChild(el("p", "gr-empty", closedNotice(closedReason)));
 	}
 
-	// Sort selector only when voting is on (no scores to rank without it).
-	if (votingEnabled) {
-		const sortWrap = el("div", "gr-sort");
-		const label = el("label");
-		const sel = el("select") as HTMLSelectElement;
-		const newOpt = el("option") as HTMLOptionElement;
-		newOpt.value = "new";
-		newOpt.textContent = s("w.sort.new");
-		const topOpt = el("option") as HTMLOptionElement;
-		topOpt.value = "top";
-		topOpt.textContent = s("w.sort.top");
-		sel.append(newOpt, topOpt);
-		sel.value = sort;
-		// The control sits inside the label, so the label text is split around it
-		// rather than hard-coded as a "Sort by " prefix — languages that put the
-		// control first (or wrap it) can say so in the string.
-		const [beforeSel, afterSel] = sAround("w.sort_by", "control");
-		label.append(beforeSel, sel, afterSel);
-		sortWrap.appendChild(label);
-		sel.addEventListener("change", () => {
-			const v = sel.value === "top" ? "top" : "new";
-			setSort(root, v);
-			reload();
-		});
-		wrap.appendChild(sortWrap);
+	// Thread toolbar: sort on the left, subscribe bell on the right. This row
+	// used to exist only to hold the sort selector, hence the generalization
+	// rather than a second row — the bell wants exactly this slot, immediately
+	// above the list.
+	if (votingEnabled || subscriptionsEnabled) {
+		const bar = el("div", "gr-threadbar");
+		// Sort selector still only when voting is on: there are no scores to rank
+		// by without it.
+		if (votingEnabled) {
+			const sortWrap = el("div", "gr-sort");
+			const label = el("label");
+			const sel = el("select") as HTMLSelectElement;
+			const newOpt = el("option") as HTMLOptionElement;
+			newOpt.value = "new";
+			newOpt.textContent = s("w.sort.new");
+			const topOpt = el("option") as HTMLOptionElement;
+			topOpt.value = "top";
+			topOpt.textContent = s("w.sort.top");
+			sel.append(newOpt, topOpt);
+			sel.value = sort;
+			// The control sits inside the label, so the label text is split around it
+			// rather than hard-coded as a "Sort by " prefix — languages that put the
+			// control first (or wrap it) can say so in the string.
+			const [beforeSel, afterSel] = sAround("w.sort_by", "control");
+			label.append(beforeSel, sel, afterSel);
+			sortWrap.appendChild(label);
+			sel.addEventListener("change", () => {
+				const v = sel.value === "top" ? "top" : "new";
+				setSort(root, v);
+				reload();
+			});
+			bar.appendChild(sortWrap);
+		}
+		if (subscriptionsEnabled) {
+			bar.appendChild(buildSubscribeBell(apiBase, slug, me != null));
+		}
+		wrap.appendChild(bar);
 	}
 
 	wrap.appendChild(list);

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1238,15 +1238,19 @@ const buildSubscribeBell = (
 	btn.setAttribute("aria-label", s("w.subscribe"));
 	btn.title = s("w.subscribe");
 	btn.appendChild(el("span", "gr-reaction-emoji", "🔔"));
-	const status = el("span", "gr-subscribe-status");
 	// Announce the outcome: the click's only visible result is this text, and a
 	// reader on a screen reader would otherwise get nothing back at all.
-	status.setAttribute("role", "status");
-	status.hidden = true;
+	//
+	// It has to be a `statusBox`, not a hidden span promoted to a live region on
+	// use. A `hidden` element is outside the accessibility tree, so filling it and
+	// revealing it in the same task is not a mutation of a live region — it is a
+	// region appearing already-populated, which announces nothing. The box stays
+	// in the tree from mount and CSS collapses it while it is `:empty`, exactly as
+	// the composer's status box does.
+	const status = statusBox("gr-subscribe-status");
 
 	const say = (msg: string): void => {
 		status.textContent = msg;
-		status.hidden = false;
 	};
 
 	// Anonymous readers need to supply an address; a signed-in reader's comes
@@ -1325,6 +1329,12 @@ const buildSubscribeBell = (
 		submit = el("button", "gr-subscribe-submit", s("w.subscribe.submit"));
 		submit.type = "submit";
 		form.append(emailInput, submit);
+		// Only on this path is the bell a disclosure — signed in it posts straight
+		// away and controls nothing, and claiming otherwise would promise a panel
+		// that never opens. Safe to expose: this says whether the email field is
+		// showing, never whether the reader is subscribed, which is the one thing
+		// the endpoint refuses to reveal.
+		btn.setAttribute("aria-expanded", "false");
 		form.addEventListener("submit", (e) => {
 			e.preventDefault();
 			const email = emailInput.value.trim();
@@ -1338,6 +1348,7 @@ const buildSubscribeBell = (
 			return;
 		}
 		form.hidden = !form.hidden;
+		btn.setAttribute("aria-expanded", String(!form.hidden));
 		if (!form.hidden) emailInput.focus();
 	});
 

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1293,10 +1293,16 @@ const buildSubscribeBell = (
 				message?: string;
 			} | null;
 			if (!res.ok) {
-				// The server's own message where there is one — it distinguishes a
-				// rate limit from a bad address, and inventing a generic failure
-				// would throw that away.
-				say(body?.message ?? s("w.subscribe.failed"));
+				// A rate limit is the one failure where "try again" is actively bad
+				// advice: the retry cannot succeed and each one pushes the window
+				// further out. Every other status keeps the generic message, which
+				// is honest — the widget cannot tell a bad address from an outage.
+				//
+				// Deliberately not rendering `body.error`: on some paths the server
+				// puts localized prose there, on others a machine code
+				// ("invalid_email"), and there is no way to tell them apart from
+				// here. Only `message`, on success, is contracted to be prose.
+				say(res.status === 429 ? s("w.subscribe.ratelimit") : s("w.subscribe.failed"));
 				return;
 			}
 			say(body?.message ?? s("w.subscribe.done"));

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -37,7 +37,11 @@ import { watchForSignIn } from "./auth-recovery";
 import { autoSizeTextarea } from "./autosize";
 import { createTurnstileGate, type TurnstileGate } from "./turnstile-gate";
 import { makeS, type StringTable, type WidgetKey } from "./strings";
-import { type ReactionCount, mergeReactionTotals } from "./reactions";
+import {
+	type ReactionCount,
+	REACTION_KINDS,
+	mergeReactionTotals,
+} from "./reactions";
 import { absoluteTime, isoTime, relativeTime } from "./time";
 // Generated from styles.css by scripts/build-styles.ts (gitignored, rebuilt by
 // build:assets). Edit styles.css, never the .gen file.
@@ -834,14 +838,6 @@ const mountTurnstileFrame = (
 		destroy: () => ac.abort(),
 	};
 };
-
-const REACTION_KINDS: { kind: string; emoji: string }[] = [
-	{ kind: "like", emoji: "👍" },
-	{ kind: "love", emoji: "❤️" },
-	{ kind: "laugh", emoji: "😂" },
-	{ kind: "hmm", emoji: "🤔" },
-	{ kind: "cry", emoji: "😢" },
-];
 
 const reactionsByKind = (rs: ReactionCount[]): Map<string, ReactionCount> => {
 	const m = new Map<string, ReactionCount>();

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1257,12 +1257,31 @@ const buildSubscribeBell = (
 	const form = el("form", "gr-subscribe-form");
 	form.hidden = true;
 	const emailInput = el("input") as HTMLInputElement;
+	// Assigned only on the anonymous path: the signed-in bell posts straight from
+	// its own click and never builds a form, so `setBusy` has to tolerate null.
+	let submit: HTMLButtonElement | null = null;
+
+	// Disabling the bell alone left the form wide open — the submit button and the
+	// Enter key inside the input both reach `send` without going near the bell. So
+	// disable whichever control is actually live. Disabling the submit button also
+	// suppresses implicit submission, which is what closes the Enter-key path.
+	const setBusy = (busy: boolean): void => {
+		btn.disabled = busy;
+		if (submit) submit.disabled = busy;
+	};
 
 	// `message` is already localized by the server (it negotiates from ?lang=).
 	// Rendered via textContent — as every server string in this widget is — so a
 	// future message containing markup is text, not markup.
+	let inFlight = false;
 	const send = async (email: string): Promise<void> => {
-		btn.disabled = true;
+		// The disabled attributes are the affordance; this flag is the guarantee.
+		// A subscribe POST costs the operator send budget and the reader a
+		// duplicate email, so it is worth being certain rather than trusting that
+		// no path can re-enter while a request is open.
+		if (inFlight) return;
+		inFlight = true;
+		setBusy(true);
 		try {
 			const res = await fetch(apiUrl(apiBase, "/api/v1/subscribe"), {
 				method: "POST",
@@ -1286,7 +1305,8 @@ const buildSubscribeBell = (
 		} catch {
 			say(s("w.subscribe.failed"));
 		} finally {
-			btn.disabled = false;
+			inFlight = false;
+			setBusy(false);
 		}
 	};
 
@@ -1296,7 +1316,7 @@ const buildSubscribeBell = (
 		emailInput.required = true;
 		emailInput.placeholder = s("w.email_ph");
 		emailInput.autocomplete = "email";
-		const submit = el("button", "gr-subscribe-submit", s("w.subscribe.submit"));
+		submit = el("button", "gr-subscribe-submit", s("w.subscribe.submit"));
 		submit.type = "submit";
 		form.append(emailInput, submit);
 		form.addEventListener("submit", (e) => {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -971,13 +971,18 @@ const buildReactions = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 		const btn = el("button", "gr-reaction");
 		btn.type = "button";
 		btn.dataset.kind = kind;
-		// The label is the accessible name rather than visible text here: six
-		// labelled cells per comment would be more chrome than the comment. A
-		// screen reader otherwise announces the raw emoji, and on a couple of
-		// them ("crying face") that reads as the wrong sentiment entirely.
-		btn.setAttribute("aria-label", s(labelKey));
+		// The label is hidden text rather than visible text: six labelled cells per
+		// comment would be more chrome than the comment. Hidden *in the tree*
+		// though, never an aria-label — that would become the whole accessible
+		// name and drop the count child, so a screen reader announced "Funny, not
+		// pressed" and never the number the button exists to report. The emoji is
+		// taken out of the name for the reason the label is needed at all: on a
+		// couple of them ("crying face") the glyph's own name reads as the wrong
+		// sentiment entirely.
 		btn.title = s(labelKey);
-		btn.appendChild(el("span", "gr-reaction-emoji", emoji));
+		const emojiSpan = el("span", "gr-reaction-emoji", emoji);
+		emojiSpan.setAttribute("aria-hidden", "true");
+		btn.append(el("span", "gr-sr", s(labelKey)), emojiSpan);
 		const count = el("span", "gr-reaction-count", "");
 		btn.appendChild(count);
 		cells.set(kind, { btn, count });

--- a/src/widget/reactions.ts
+++ b/src/widget/reactions.ts
@@ -96,6 +96,33 @@ export const normalizeReactionKind = (kind: string): string =>
 	DEPRECATED_KINDS.get(kind) ?? kind;
 
 /**
+ * Echo a totals map back under the spelling the caller actually asked for.
+ *
+ * Accepting `like` on the way in is only half the job: the totals a route
+ * returns are keyed by the *stored* kind, so a pre-2.10.0 bundle POSTs `like`,
+ * gets `{ fire: N }` back, finds no `like` entry, and paints that cell to 0 —
+ * then hides the button outright for an anonymous reader, because zero-count
+ * kinds are hidden from them. The reader watches the button they just pressed
+ * disappear. The page bar's variant is worse: `0` next to `aria-pressed="true"`.
+ *
+ * So when normalization rewrote the kind, send the count under both spellings.
+ * A current bundle never triggers this (it asks for `fire`, nothing is
+ * rewritten, the response shape is byte-identical), and the alias is drawn from
+ * `DEPRECATED_KINDS` rather than trusting the raw wire value, so this cannot
+ * mint a key from arbitrary caller input.
+ *
+ * Goes away with `DEPRECATED_KINDS`.
+ */
+export const withDeprecatedAlias = (
+	totals: Record<string, number>,
+	requested: string,
+): Record<string, number> => {
+	const stored = DEPRECATED_KINDS.get(requested);
+	if (stored === undefined) return totals;
+	return { ...totals, [requested]: totals[stored] ?? 0 };
+};
+
+/**
  * Fold a toggle response back into a comment's reaction list.
  *
  * `totals` is authoritative for counts (it is a fresh aggregate over the

--- a/src/widget/reactions.ts
+++ b/src/widget/reactions.ts
@@ -75,8 +75,17 @@ export const REACTION_KIND_SET: ReadonlySet<string> = new Set(
  * directions.
  *
  * Removable once no deployment can still be running a pre-2.10.0 bundle.
+ *
+ * A `Map` rather than an object literal because the input is a wire value: a
+ * plain object resolves inherited keys, so `"constructor"` and `"toString"`
+ * would come back as *functions* and `"__proto__"` as `Object.prototype`, all
+ * still typed `string`. Nothing downstream is hurt by that today only because
+ * both callers immediately reject on `REACTION_KIND_SET`, which is too thin a
+ * thread to hang a type signature on.
  */
-const DEPRECATED_KINDS: Readonly<Record<string, string>> = { like: "fire" };
+const DEPRECATED_KINDS: ReadonlyMap<string, string> = new Map([
+	["like", "fire"],
+]);
 
 /**
  * Map a wire value to the kind to store. Unknown kinds pass through unchanged
@@ -84,7 +93,7 @@ const DEPRECATED_KINDS: Readonly<Record<string, string>> = { like: "fire" };
  * thing that decides whether a kind is allowed.
  */
 export const normalizeReactionKind = (kind: string): string =>
-	DEPRECATED_KINDS[kind] ?? kind;
+	DEPRECATED_KINDS.get(kind) ?? kind;
 
 /**
  * Fold a toggle response back into a comment's reaction list.

--- a/src/widget/reactions.ts
+++ b/src/widget/reactions.ts
@@ -37,8 +37,9 @@ export type ReactionKind = { kind: string; emoji: string };
  * migration, not an edit. `emoji` is presentation and can change freely.
  */
 export const REACTION_KINDS: readonly ReactionKind[] = [
-	{ kind: "like", emoji: "👍" },
+	{ kind: "fire", emoji: "🔥" },
 	{ kind: "love", emoji: "❤️" },
+	{ kind: "wow", emoji: "😮" },
 	{ kind: "laugh", emoji: "😂" },
 	{ kind: "hmm", emoji: "🤔" },
 	{ kind: "cry", emoji: "😢" },
@@ -48,6 +49,29 @@ export const REACTION_KINDS: readonly ReactionKind[] = [
 export const REACTION_KIND_SET: ReadonlySet<string> = new Set(
 	REACTION_KINDS.map((r) => r.kind),
 );
+
+/**
+ * Kinds this build still accepts on the wire but no longer renders.
+ *
+ * `like` 👍 was renamed to `fire` 🔥 in v2.10.0 — 👍 sat directly above an
+ * up-vote button and meant the same thing twice. Migration 0022 rewrites the
+ * stored rows, but a deploy and a migration are two events with a gap between
+ * them, and whichever lands second leaves a window: old code writing `like`
+ * after the rewrite would create rows no build can display. Accepting the old
+ * spelling and normalizing it on the way in closes the window in both
+ * directions.
+ *
+ * Removable once no deployment can still be running a pre-2.10.0 bundle.
+ */
+const DEPRECATED_KINDS: Readonly<Record<string, string>> = { like: "fire" };
+
+/**
+ * Map a wire value to the kind to store. Unknown kinds pass through unchanged
+ * for the caller's own membership check to reject — this must never be the
+ * thing that decides whether a kind is allowed.
+ */
+export const normalizeReactionKind = (kind: string): string =>
+	DEPRECATED_KINDS[kind] ?? kind;
 
 /**
  * Fold a toggle response back into a comment's reaction list.

--- a/src/widget/reactions.ts
+++ b/src/widget/reactions.ts
@@ -25,24 +25,37 @@
  * without a DOM.
  */
 
+import type { WidgetKey } from "./strings";
+
 export type ReactionCount = { kind: string; count: number; mine: boolean };
 
-export type ReactionKind = { kind: string; emoji: string };
+export type ReactionKind = {
+	kind: string;
+	emoji: string;
+	labelKey: WidgetKey;
+};
 
 /**
  * Every reaction a reader can leave, in render order.
  *
  * `kind` is the stored value — it goes in the `reactions.kind` /
  * `page_reactions.kind` column and travels the wire, so renaming one is a
- * migration, not an edit. `emoji` is presentation and can change freely.
+ * migration, not an edit. `emoji` and `labelKey` are presentation and can
+ * change freely.
+ *
+ * The label is a key rather than a string because an emoji alone doesn't say
+ * what it means: 🤔 could be read as "interesting" or "I doubt that". Typing it
+ * as `WidgetKey` makes a missing translation a build error instead of a widget
+ * that renders `w.react.wow` at a reader. The import is type-only, so nothing
+ * about the string table reaches the bundle or the Worker through this file.
  */
 export const REACTION_KINDS: readonly ReactionKind[] = [
-	{ kind: "fire", emoji: "🔥" },
-	{ kind: "love", emoji: "❤️" },
-	{ kind: "wow", emoji: "😮" },
-	{ kind: "laugh", emoji: "😂" },
-	{ kind: "hmm", emoji: "🤔" },
-	{ kind: "cry", emoji: "😢" },
+	{ kind: "fire", emoji: "🔥", labelKey: "w.react.fire" },
+	{ kind: "love", emoji: "❤️", labelKey: "w.react.love" },
+	{ kind: "wow", emoji: "😮", labelKey: "w.react.wow" },
+	{ kind: "laugh", emoji: "😂", labelKey: "w.react.laugh" },
+	{ kind: "hmm", emoji: "🤔", labelKey: "w.react.hmm" },
+	{ kind: "cry", emoji: "😢", labelKey: "w.react.cry" },
 ];
 
 /** Membership test for the routes, derived so it cannot drift from the list. */

--- a/src/widget/reactions.ts
+++ b/src/widget/reactions.ts
@@ -1,5 +1,18 @@
 /**
- * Reaction state merging.
+ * The reaction vocabulary, and reaction state merging.
+ *
+ * The vocabulary lives here because three places need to agree on it: the
+ * widget renders it, `POST /api/v1/reactions` validates against it, and so
+ * does `POST /api/v1/page-engagement/reactions`. It used to be spelled out
+ * three times — a hardcoded list in the widget and a hand-maintained
+ * `ALLOWED_KINDS` set in each route — so adding a kind meant remembering all
+ * three, and forgetting the routes meant a button that 400s.
+ *
+ * The *widget* side is the one that has to hold it. `tsconfig.widget.json`
+ * compiles only `src/widget/**`, so the widget cannot import from `src/lib/`;
+ * the server has no such restriction and already imports from here (same
+ * inversion as `EN` in `./strings`). This file stays DOM-free and
+ * dependency-free precisely so the Worker can import it.
  *
  * Tapping an emoji used to call `ctx.reload()`, which runs
  * `root.replaceChildren()` and rebuilds the entire shadow tree — losing scroll
@@ -13,6 +26,28 @@
  */
 
 export type ReactionCount = { kind: string; count: number; mine: boolean };
+
+export type ReactionKind = { kind: string; emoji: string };
+
+/**
+ * Every reaction a reader can leave, in render order.
+ *
+ * `kind` is the stored value — it goes in the `reactions.kind` /
+ * `page_reactions.kind` column and travels the wire, so renaming one is a
+ * migration, not an edit. `emoji` is presentation and can change freely.
+ */
+export const REACTION_KINDS: readonly ReactionKind[] = [
+	{ kind: "like", emoji: "👍" },
+	{ kind: "love", emoji: "❤️" },
+	{ kind: "laugh", emoji: "😂" },
+	{ kind: "hmm", emoji: "🤔" },
+	{ kind: "cry", emoji: "😢" },
+];
+
+/** Membership test for the routes, derived so it cannot drift from the list. */
+export const REACTION_KIND_SET: ReadonlySet<string> = new Set(
+	REACTION_KINDS.map((r) => r.kind),
+);
 
 /**
  * Fold a toggle response back into a comment's reaction list.

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -136,6 +136,15 @@ export const EN = {
 	"w.sort_by": "Sort by {control}",
 	"w.sort.new": "Newest",
 	"w.sort.top": "Top",
+	// Subscribing without commenting. `w.subscribe` is the bell's accessible name
+	// and tooltip; the visible glyph is 🔔. The two outcome strings are fallbacks
+	// only — the server sends an already-localized `message` — but they have to
+	// exist, because a server older than this bundle sends no message at all and
+	// silence after a click reads as a broken button.
+	"w.subscribe": "Email me about new comments on this post",
+	"w.subscribe.submit": "Subscribe",
+	"w.subscribe.done": "Check your email to confirm.",
+	"w.subscribe.failed": "Could not subscribe. Try again.",
 	"w.load_more": "Load older comments",
 	"w.load_more_failed": "Could not load more: {detail}",
 

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -137,14 +137,20 @@ export const EN = {
 	"w.sort.new": "Newest",
 	"w.sort.top": "Top",
 	// Subscribing without commenting. `w.subscribe` is the bell's accessible name
-	// and tooltip; the visible glyph is 🔔. The two outcome strings are fallbacks
-	// only — the server sends an already-localized `message` — but they have to
-	// exist, because a server older than this bundle sends no message at all and
-	// silence after a click reads as a broken button.
+	// and tooltip; the visible glyph is 🔔.
+	//
+	// Only `w.subscribe.done` is a fallback — the server sends an already-localized
+	// `message` on success, and this covers a server older than this bundle, where
+	// silence after a click reads as a broken button. The two failure strings are
+	// not fallbacks but the only copy there is: error responses carry `error`, not
+	// `message`, and `error` is prose on some paths and a machine code on others,
+	// so the widget picks its own words off the status code.
 	"w.subscribe": "Email me about new comments on this post",
 	"w.subscribe.submit": "Subscribe",
 	"w.subscribe.done": "Check your email to confirm.",
 	"w.subscribe.failed": "Could not subscribe. Try again.",
+	// Never "try again" — a 429 retry cannot succeed and pushes the window out.
+	"w.subscribe.ratelimit": "Too many requests. Try again later.",
 	"w.load_more": "Load older comments",
 	"w.load_more_failed": "Could not load more: {detail}",
 

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -111,6 +111,17 @@ export const EN = {
 	"w.page.helpful": "Was this helpful?",
 	"w.page.up": "Upvote this page",
 	"w.page.down": "Downvote this page",
+	"w.page.react_prompt": "What's your reaction?",
+	// One word each: these sit under a 🔥-sized emoji in a six-across row on the
+	// article bar, and double as the accessible name of the compact per-comment
+	// button. A phrase wraps and breaks the grid. The emoji carries the tone; the
+	// label only has to disambiguate it (🤔 is "Hmm", not "I doubt that").
+	"w.react.fire": "Brilliant",
+	"w.react.love": "Love",
+	"w.react.wow": "Wow",
+	"w.react.laugh": "Funny",
+	"w.react.hmm": "Hmm",
+	"w.react.cry": "Sad",
 
 	// ── The thread ──────────────────────────────────────────────────────────
 	"w.replies": { one: "{n} reply", other: "{n} replies" },

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -260,7 +260,8 @@
    harmless in the light theme only because a UA textarea is white and so is the
    default --garrul-input-bg; in dark mode it was a white box with black text. */
 .gr-form input, .gr-form textarea,
-.gr-reply-form input, .gr-reply-form textarea {
+.gr-reply-form input, .gr-reply-form textarea,
+.gr-subscribe-form input {
 	font: inherit; color: inherit;
 	background: var(--gr-input-bg);
 	border: 1px solid var(--gr-border);
@@ -613,7 +614,49 @@ button:active:not([disabled]) { opacity: 0.75; }
 }
 .gr-vote[disabled] { opacity: 0.6; cursor: progress; }
 .gr-vote-score { font-variant-numeric: tabular-nums; min-width: 1.2em; text-align: center; }
-.gr-sort { display: flex; gap: 0.4rem; align-items: center; font-size: 0.85em; color: var(--gr-muted); margin-top: 0.5rem; }
+/* Thread toolbar: sort on the left, subscribe bell on the right. The row
+   predates the bell, when it held nothing but the selector — hence the
+   margin-top moving here from .gr-sort, which now has no reason to own it. */
+.gr-threadbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+}
+.gr-sort { display: flex; gap: 0.4rem; align-items: center; font-size: 0.85em; color: var(--gr-muted); }
+/* margin-inline-start:auto keeps the bell right-aligned when it is the row's
+   only child — space-between alone would park it on the left. */
+.gr-subscribe { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin-inline-start: auto; }
+.gr-subscribe-btn {
+	font: inherit;
+	background: none;
+	border: 0;
+	padding: 0.1em 0.3em;
+	line-height: 1;
+	cursor: pointer;
+	border-radius: var(--gr-radius);
+}
+.gr-subscribe-btn:hover { background: var(--gr-input-bg); }
+.gr-subscribe-form { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+/* Smaller than the composer's submit — this is an inline confirmation, not the
+   primary action on the page. */
+.gr-subscribe-form input { padding: 0.3rem 0.5rem; font-size: 0.9em; }
+.gr-subscribe-submit {
+	font: inherit;
+	font-size: 0.9em;
+	background: var(--gr-accent);
+	color: var(--gr-accent-fg);
+	border: none;
+	border-radius: var(--gr-radius);
+	padding: 0.35rem 0.7rem;
+	cursor: pointer;
+}
+.gr-subscribe-submit:hover { background: var(--gr-accent-hover); }
+.gr-subscribe-form[hidden] { display: none; }
+.gr-subscribe-status { font-size: 0.85em; color: var(--gr-muted); }
+.gr-subscribe-status[hidden] { display: none; }
 .gr-sort select {
 	font: inherit;
 	background: var(--gr-input-bg);

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -538,7 +538,9 @@ button:active:not([disabled]) { opacity: 0.75; }
 }
 .gr-page-reactions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 .gr-page-votes { display: flex; align-items: center; gap: 0.4rem; }
-.gr-page-vote-label { color: var(--gr-muted); font-size: 0.9em; }
+/* The two prompts are deliberately identical: "What's your reaction?" and "Was
+   this helpful?" are the same kind of label sitting in the same kind of slot. */
+.gr-page-vote-label, .gr-page-react-prompt { color: var(--gr-muted); font-size: 0.9em; }
 .gr-reactions { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-top: 0.4rem; }
 .gr-reaction {
 	font: inherit;
@@ -557,6 +559,36 @@ button:active:not([disabled]) { opacity: 0.75; }
 	border-color: var(--gr-accent);
 }
 .gr-reaction-count { margin-inline-start: 0.25em; font-variant-numeric: tabular-nums; }
+/* The widget ships no emoji artwork — 2-3KB gzipped of SVG for decoration would
+   spend bundle headroom that exists to absorb features. That makes the reader's
+   own font the renderer, so the stack has to be explicit: a Linux reader with a
+   monochrome fallback ahead of Noto Color Emoji gets outline glyphs, and
+   `font-variant-emoji` stops a browser rendering the text-default codepoints
+   (❤ in particular) as a black glyph. The families are listed only on the emoji
+   span so the count digits keep inheriting the host page's font. */
+.gr-reaction-emoji {
+	font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji",
+		"Twemoji Mozilla", "Android Emoji", sans-serif;
+	font-variant-emoji: emoji;
+	line-height: 1;
+}
+/* Article-bar cells only: emoji + count on one line, label under it. Six of
+   these per *comment* would be more chrome than the comment, so the per-comment
+   row keeps the compact pill and carries the label as its accessible name. */
+.gr-reaction-labelled {
+	display: inline-flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.15em;
+	border-radius: 10px;
+	padding: 0.3em 0.6em;
+	min-width: 3.5em;
+}
+.gr-reaction-labelled .gr-reaction-emoji { font-size: 1.25em; }
+.gr-reaction-face { display: inline-flex; align-items: center; }
+/* Dimmed with opacity rather than a colour, so it stays legible against both
+   the resting background and the accent one [data-mine="1"] switches to. */
+.gr-reaction-label { font-size: 0.85em; opacity: 0.75; white-space: nowrap; }
 .gr-votes { display: flex; align-items: center; gap: 0.3rem; margin-top: 0.4rem; font-size: 0.85em; }
 .gr-vote {
 	font: inherit;

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -427,6 +427,22 @@ button:active:not([disabled]) { opacity: 0.75; }
 	overflow: hidden;
 	clip-path: inset(50%);
 }
+/* Visible only to assistive tech. The rule above collapses a live region while
+   keeping it announceable; this one hides content permanently, for text that
+   belongs in an element's accessible name but not on screen. `clip-path` rather
+   than `display: none`, which takes it out of the a11y tree and so defeats the
+   point. No offsets are set, so it stays at its static position and cannot
+   extend the page. */
+.gr-sr {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	clip-path: inset(50%);
+}
 .gr-error.is-notice { color: var(--gr-notice); }
 /* Composer submit errors are inline (text only) — a box-in-a-box reads too
    heavy next to the composer. The :not(.is-notice) guard keeps the boxed
@@ -575,7 +591,8 @@ button:active:not([disabled]) { opacity: 0.75; }
 }
 /* Article-bar cells only: emoji + count on one line, label under it. Six of
    these per *comment* would be more chrome than the comment, so the per-comment
-   row keeps the compact pill and carries the label as its accessible name. */
+   row keeps the compact pill and carries the same label as hidden text (.gr-sr)
+   inside the button instead. */
 .gr-reaction-labelled {
 	display: inline-flex;
 	flex-direction: column;

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -684,7 +684,20 @@ button:active:not([disabled]) { opacity: 0.75; }
 .gr-subscribe-submit:hover:not([disabled]) { background: var(--gr-accent-hover); }
 .gr-subscribe-form[hidden] { display: none; }
 .gr-subscribe-status { font-size: 0.85em; color: var(--gr-muted); }
-.gr-subscribe-status[hidden] { display: none; }
+/* Same treatment as .gr-error:empty, and for the same reason: the box is a live
+   region that has to stay in the a11y tree from mount, so it cannot be hidden
+   between announcements. Absolute rather than zero-height because it is a flex
+   child of .gr-subscribe (gap 0.4rem) and a flex item earns its share of the gap
+   however small it is. No offsets, so it cannot extend the page. */
+.gr-subscribe-status:empty {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	clip-path: inset(50%);
+}
 .gr-sort select {
 	font: inherit;
 	background: var(--gr-input-bg);

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -629,16 +629,20 @@ button:active:not([disabled]) { opacity: 0.75; }
 /* margin-inline-start:auto keeps the bell right-aligned when it is the row's
    only child — space-between alone would park it on the left. */
 .gr-subscribe { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin-inline-start: auto; }
+/* Bordered like the sort select beside it, deliberately. A bare emoji floating
+   at the end of the row reads as decoration; the border is what says "press
+   me", and it is the only affordance a reader who never hovers will get, since
+   the meaning otherwise lives in title/aria-label alone. */
 .gr-subscribe-btn {
 	font: inherit;
-	background: none;
-	border: 0;
-	padding: 0.1em 0.3em;
+	background: var(--gr-input-bg);
+	border: 1px solid var(--gr-border);
+	padding: 0.2rem 0.45rem;
 	line-height: 1;
 	cursor: pointer;
 	border-radius: var(--gr-radius);
 }
-.gr-subscribe-btn:hover { background: var(--gr-input-bg); }
+.gr-subscribe-btn:hover { border-color: var(--gr-accent); }
 .gr-subscribe-form { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
 /* Smaller than the composer's submit — this is an inline confirmation, not the
    primary action on the page. */

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -659,7 +659,13 @@ button:active:not([disabled]) { opacity: 0.75; }
 	cursor: pointer;
 	border-radius: var(--gr-radius);
 }
-.gr-subscribe-btn:hover { border-color: var(--gr-accent); }
+/* The bell and the submit both get disabled while a subscribe POST is open, so
+   they need the same busy treatment as the composer, the vote buttons and load
+   more — a control that stops responding without changing appearance reads as
+   broken. Declared before the :hover rule so specificity ascends; :hover still
+   matches a disabled button, hence the :not() guard. */
+.gr-subscribe-btn[disabled] { opacity: 0.6; cursor: progress; }
+.gr-subscribe-btn:hover:not([disabled]) { border-color: var(--gr-accent); }
 .gr-subscribe-form { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
 /* Smaller than the composer's submit — this is an inline confirmation, not the
    primary action on the page. */
@@ -674,7 +680,8 @@ button:active:not([disabled]) { opacity: 0.75; }
 	padding: 0.35rem 0.7rem;
 	cursor: pointer;
 }
-.gr-subscribe-submit:hover { background: var(--gr-accent-hover); }
+.gr-subscribe-submit[disabled] { opacity: 0.6; cursor: progress; }
+.gr-subscribe-submit:hover:not([disabled]) { background: var(--gr-accent-hover); }
 .gr-subscribe-form[hidden] { display: none; }
 .gr-subscribe-status { font-size: 0.85em; color: var(--gr-muted); }
 .gr-subscribe-status[hidden] { display: none; }

--- a/tests/counts.test.ts
+++ b/tests/counts.test.ts
@@ -177,8 +177,8 @@ describe("counts — include=votes,reactions when flags enabled", () => {
 			{ post_slug: "a", value: -1 },
 		],
 		reactions: [
-			{ post_slug: "a", kind: "like" },
-			{ post_slug: "a", kind: "like" },
+			{ post_slug: "a", kind: "fire" },
+			{ post_slug: "a", kind: "fire" },
 			{ post_slug: "a", kind: "love" },
 		],
 		settings: {
@@ -197,7 +197,7 @@ describe("counts — include=votes,reactions when flags enabled", () => {
 		};
 		expect(body.counts).toEqual({ a: 1 });
 		expect(body.votes.a).toEqual({ score_up: 2, score_down: 1 });
-		expect(body.reactions.a).toEqual({ like: 2, love: 1 });
+		expect(body.reactions.a).toEqual({ fire: 2, love: 1 });
 	});
 });
 
@@ -206,7 +206,7 @@ describe("counts — flag gating", () => {
 		const { app, env } = mkApp({
 			comments: [{ post_slug: "a", status: "approved" }],
 			votes: [{ post_slug: "a", value: 1 }],
-			reactions: [{ post_slug: "a", kind: "like" }],
+			reactions: [{ post_slug: "a", kind: "fire" }],
 			// no settings rows → page_* default OFF
 		});
 		const res = await get(app, env, "/?slugs=a&include=votes,reactions");
@@ -218,7 +218,7 @@ describe("counts — flag gating", () => {
 		const { app, env } = mkApp({
 			comments: [{ post_slug: "a", status: "approved" }],
 			votes: [{ post_slug: "a", value: 1 }],
-			reactions: [{ post_slug: "a", kind: "like" }],
+			reactions: [{ post_slug: "a", kind: "fire" }],
 			settings: { page_votes_enabled: "true" },
 		});
 		const res = await get(app, env, "/?slugs=a&include=votes,reactions");

--- a/tests/migration-reaction-fire.test.ts
+++ b/tests/migration-reaction-fire.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Migration 0022 — renaming the `like` reaction to `fire`.
+ *
+ * A vocabulary rename is the one kind of change that can silently delete reader
+ * data: the widget renders only kinds it knows about, so a row left under the
+ * old spelling still exists and is never seen again. That makes the interesting
+ * assertions "the count survived" and "the row moved", not "the file parsed".
+ *
+ * Run against Node's built-in `node:sqlite` (no new dependency, no network) with
+ * every earlier migration applied, the same way the real-DB query suite does —
+ * a stub that routes by SQL substring would never execute the UPDATE at all.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+const RENAME = "0022_reaction_kind_fire.sql";
+
+const sqlFor = (file: string): string =>
+	readFileSync(join(MIGRATIONS_DIR, file), "utf8");
+
+/** Everything before the rename, so the rename itself can be run on demand. */
+const dbBeforeRename = (): DatabaseSync => {
+	const sqlite = new DatabaseSync(":memory:");
+	const earlier = readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql") && f < RENAME)
+		.sort();
+	for (const file of earlier) sqlite.exec(sqlFor(file));
+
+	// reactions FKs comments(id) + users(id); page_reactions FKs posts(slug) +
+	// users(id), and node:sqlite enforces both — seed the parents first.
+	sqlite.exec(
+		"INSERT INTO posts (slug, title, url, created_at) VALUES ('hello', 'Hello', NULL, 1700000000000)",
+	);
+	sqlite.exec(
+		"INSERT INTO users (id, provider, provider_id, name, created_at) VALUES ('u1', 'anon', NULL, 'u1', 1700000000000), ('u2', 'anon', 'x', 'u2', 1700000000000)",
+	);
+	sqlite.exec(
+		"INSERT INTO comments (id, post_slug, parent_id, user_id, body_md, body_html, created_at) VALUES ('c1', 'hello', NULL, 'u1', 'x', '<p>x</p>', 1700000000000)",
+	);
+	return sqlite;
+};
+
+const kinds = (sqlite: DatabaseSync, table: string): string[] =>
+	(sqlite.prepare(`SELECT kind FROM ${table} ORDER BY kind`).all() as {
+		kind: string;
+	}[]).map((r) => r.kind);
+
+describe("migration 0022 — like → fire", () => {
+	it("renames comment reactions and keeps the count", () => {
+		const sqlite = dbBeforeRename();
+		sqlite.exec(
+			"INSERT INTO reactions (comment_id, user_id, kind, created_at) VALUES ('c1', 'u1', 'like', 1), ('c1', 'u2', 'like', 2), ('c1', 'u1', 'love', 3)",
+		);
+		sqlite.exec(sqlFor(RENAME));
+		expect(kinds(sqlite, "reactions")).toEqual(["fire", "fire", "love"]);
+	});
+
+	it("renames article reactions too", () => {
+		// The article bar and the comment rows share one vocabulary, so rewriting
+		// only `reactions` would leave the bar counting a kind nothing renders.
+		const sqlite = dbBeforeRename();
+		sqlite.exec(
+			"INSERT INTO page_reactions (post_slug, user_id, kind, created_at) VALUES ('hello', 'u1', 'like', 1), ('hello', 'u2', 'hmm', 2)",
+		);
+		sqlite.exec(sqlFor(RENAME));
+		expect(kinds(sqlite, "page_reactions")).toEqual(["fire", "hmm"]);
+	});
+
+	it("is a no-op on a second run", () => {
+		// A migration that only works once fails a restored backup.
+		const sqlite = dbBeforeRename();
+		sqlite.exec(
+			"INSERT INTO reactions (comment_id, user_id, kind, created_at) VALUES ('c1', 'u1', 'like', 1)",
+		);
+		sqlite.exec(sqlFor(RENAME));
+		sqlite.exec(sqlFor(RENAME));
+		expect(kinds(sqlite, "reactions")).toEqual(["fire"]);
+	});
+
+	it("survives a reader who holds both spellings", () => {
+		// Impossible on a fresh install — `fire` did not exist before this release
+		// — but reachable on a re-run against partially-migrated data. Plain UPDATE
+		// would abort on the (comment_id, user_id, kind) primary key and take the
+		// whole migration with it, so the rename is OR IGNORE.
+		//
+		// Not throwing is only half of it, and the half that hid the bug: OR IGNORE
+		// *skips* the conflicting row instead of removing it, so the migration used
+		// to leave the `like` row sitting in the table where no build renders it —
+		// the exact orphan it exists to prevent. Hence the second assertion, and
+		// the DELETE that makes it pass.
+		const sqlite = dbBeforeRename();
+		sqlite.exec(
+			"INSERT INTO reactions (comment_id, user_id, kind, created_at) VALUES ('c1', 'u1', 'like', 1), ('c1', 'u1', 'fire', 2)",
+		);
+		expect(() => sqlite.exec(sqlFor(RENAME))).not.toThrow();
+		expect(kinds(sqlite, "reactions")).toEqual(["fire"]);
+	});
+
+	it("keeps a reaction the reader holds only under the old spelling", () => {
+		// The guard on the DELETE above: it may only drop rows the UPDATE refused
+		// to move. A DELETE that ran unconditionally would silently discard every
+		// `like` on a target with no `fire` counterpart — data loss dressed as a
+		// rename, and invisible because the count simply comes back smaller.
+		const sqlite = dbBeforeRename();
+		sqlite.exec(
+			"INSERT INTO reactions (comment_id, user_id, kind, created_at) VALUES ('c1', 'u1', 'like', 1), ('c1', 'u2', 'like', 2)",
+		);
+		sqlite.exec(sqlFor(RENAME));
+		expect(kinds(sqlite, "reactions")).toEqual(["fire", "fire"]);
+	});
+});

--- a/tests/page-engagement.test.ts
+++ b/tests/page-engagement.test.ts
@@ -238,7 +238,7 @@ const post = (
 describe("page reactions — flag gating", () => {
 	it("403s when page_reactions_enabled is off", async () => {
 		const { app, env } = mkApp({ page_reactions_enabled: false });
-		const res = await post(app, env, "/reactions", { slug: "p", kind: "like" });
+		const res = await post(app, env, "/reactions", { slug: "p", kind: "fire" });
 		expect(res.status).toBe(403);
 		expect(((await res.json()) as { error: string }).error).toBe(
 			"page_reactions_disabled",
@@ -249,21 +249,21 @@ describe("page reactions — flag gating", () => {
 describe("page reactions — toggle/dedup", () => {
 	it("adds then removes on a repeat click from the same IP", async () => {
 		const { app, env } = mkApp({ page_reactions_enabled: true });
-		const r1 = await post(app, env, "/reactions", { slug: "p", kind: "like" });
+		const r1 = await post(app, env, "/reactions", { slug: "p", kind: "fire" });
 		const b1 = (await r1.json()) as {
 			added: boolean;
 			reactions: Record<string, number>;
 		};
 		expect(b1.added).toBe(true);
-		expect(b1.reactions.like).toBe(1);
+		expect(b1.reactions.fire).toBe(1);
 
-		const r2 = await post(app, env, "/reactions", { slug: "p", kind: "like" });
+		const r2 = await post(app, env, "/reactions", { slug: "p", kind: "fire" });
 		const b2 = (await r2.json()) as {
 			added: boolean;
 			reactions: Record<string, number>;
 		};
 		expect(b2.added).toBe(false);
-		expect(b2.reactions.like ?? 0).toBe(0);
+		expect(b2.reactions.fire ?? 0).toBe(0);
 	});
 
 	it("rejects an unknown reaction kind with 400", async () => {
@@ -272,11 +272,23 @@ describe("page reactions — toggle/dedup", () => {
 		expect(res.status).toBe(400);
 	});
 
+	it("counts the deprecated `like` as `fire`", async () => {
+		// Same alias as the comment-level route: an old cached bundle keeps working
+		// and lands its row under the kind this build renders. The article bar and
+		// the comment rows share one vocabulary, so they have to share this too.
+		const { app, env } = mkApp({ page_reactions_enabled: true });
+		const res = await post(app, env, "/reactions", { slug: "p", kind: "like" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { reactions: Record<string, number> };
+		expect(body.reactions.fire).toBe(1);
+		expect(body.reactions.like).toBeUndefined();
+	});
+
 	it("rejects a bad slug with 400", async () => {
 		const { app, env } = mkApp({ page_reactions_enabled: true });
 		const res = await post(app, env, "/reactions", {
 			slug: "bad slug!",
-			kind: "like",
+			kind: "fire",
 		});
 		expect(res.status).toBe(400);
 	});

--- a/tests/page-engagement.test.ts
+++ b/tests/page-engagement.test.ts
@@ -272,16 +272,31 @@ describe("page reactions — toggle/dedup", () => {
 		expect(res.status).toBe(400);
 	});
 
-	it("counts the deprecated `like` as `fire`", async () => {
+	it("counts the deprecated `like` as `fire` and answers in both spellings", async () => {
 		// Same alias as the comment-level route: an old cached bundle keeps working
 		// and lands its row under the kind this build renders. The article bar and
 		// the comment rows share one vocabulary, so they have to share this too.
+		//
+		// This used to assert `reactions.like` was *absent*, which pinned the bug:
+		// the only client that asks in that spelling is also the only one that reads
+		// the count back by it, and `{ fire: 1 }` alone makes its bar render 0 under
+		// a button it has just marked aria-pressed="true".
 		const { app, env } = mkApp({ page_reactions_enabled: true });
 		const res = await post(app, env, "/reactions", { slug: "p", kind: "like" });
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { reactions: Record<string, number> };
 		expect(body.reactions.fire).toBe(1);
-		expect(body.reactions.like).toBeUndefined();
+		expect(body.reactions.like).toBe(1);
+	});
+
+	it("does not invent an alias key for a current kind", async () => {
+		// The alias is strictly for callers that asked in the old spelling; a
+		// current bundle must see the response shape it has always seen.
+		const { app, env } = mkApp({ page_reactions_enabled: true });
+		const res = await post(app, env, "/reactions", { slug: "p", kind: "fire" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { reactions: Record<string, number> };
+		expect(Object.keys(body.reactions)).toEqual(["fire"]);
 	});
 
 	it("rejects a bad slug with 400", async () => {

--- a/tests/reactions.test.ts
+++ b/tests/reactions.test.ts
@@ -19,9 +19,13 @@ import { installMockCaches, uninstallMockCaches } from "./helpers/mock-caches";
 const COMMENT_ID = "01HC000000000000000000ABCD";
 const GHOST_ID = "01HU000000000000000000";
 
-const makeDb = (status: string) => ({
+// `writes` collects every (sql, args) pair a test cares to inspect. Only the
+// deprecated-alias test uses it — the kind that gets *stored* is not visible in
+// the response, so it has to be read off the statement.
+const makeDb = (status: string, writes: { sql: string; args: unknown[] }[] = []) => ({
 	prepare: (sql: string) => ({
-		bind(..._args: unknown[]) {
+		bind(...args: unknown[]) {
+			writes.push({ sql, args });
 			return this;
 		},
 		async first() {
@@ -74,7 +78,7 @@ const makeDb = (status: string) => ({
 			if (sql.includes("FROM reactions") && sql.includes("COUNT(*)")) {
 				return {
 					results: [
-						{ kind: "like", count: 3 },
+						{ kind: "fire", count: 3 },
 						{ kind: "love", count: 1 },
 					],
 				};
@@ -98,11 +102,14 @@ const makeKv = () => ({
 	async delete() {},
 });
 
-const mkApp = (status = "approved") => {
+const mkApp = (
+	status = "approved",
+	writes: { sql: string; args: unknown[] }[] = [],
+) => {
 	const app = new Hono<{ Bindings: Record<string, unknown> }>();
 	app.route("/r", reactions);
 	const env = {
-		DB: makeDb(status),
+		DB: makeDb(status, writes),
 		TREE_CACHE: makeKv(),
 		SESSIONS: makeKv(),
 		ANALYTICS: { writeDataPoint: () => {} },
@@ -138,7 +145,7 @@ afterEach(() => {
 describe("POST /reactions — input validation", () => {
 	it("rejects a missing comment_id with 400", async () => {
 		const { app, env } = mkApp();
-		const res = await post(app, env, { kind: "like" });
+		const res = await post(app, env, { kind: "fire" });
 		expect(res.status).toBe(400);
 	});
 
@@ -151,6 +158,20 @@ describe("POST /reactions — input validation", () => {
 		expect(res.status).toBe(400);
 		const body = (await res.json()) as { error: string };
 		expect(body.error).toBe("invalid_kind");
+	});
+
+	it("accepts the deprecated `like` and stores it as `fire`", async () => {
+		// A reader holding a pre-2.10.0 bundle in cache still POSTs `like`.
+		// Rejecting it would break their buttons; storing it verbatim would land
+		// a row no build renders, which is exactly what migration 0022 cleaned up.
+		installMockCaches();
+		const writes: { sql: string; args: unknown[] }[] = [];
+		const { app, env } = mkApp("approved", writes);
+		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "like" });
+		expect(res.status).toBe(200);
+		const insert = writes.find((w) => w.sql.includes("INSERT INTO reactions"));
+		// (comment_id, user_id, kind, created_at) — see toggleReaction.
+		expect(insert?.args[2]).toBe("fire");
 	});
 
 	it("rejects a malformed JSON body with 400", async () => {
@@ -177,7 +198,7 @@ describe("POST /reactions — input validation", () => {
 		const res = await post(
 			app,
 			{ ...env, REACTIONS_ENABLED: "0" },
-			{ comment_id: COMMENT_ID, kind: "like" },
+			{ comment_id: COMMENT_ID, kind: "fire" },
 		);
 		expect(res.status).toBe(403);
 		const body = (await res.json()) as { error: string };
@@ -191,7 +212,7 @@ describe("POST /reactions — only approved comments are reactable", () => {
 			const { app, env } = mkApp(status);
 			const res = await post(app, env, {
 				comment_id: COMMENT_ID,
-				kind: "like",
+				kind: "fire",
 			});
 			expect(res.status).toBe(404);
 			// Same body as a missing row — nothing to key the moderation state off.
@@ -203,7 +224,7 @@ describe("POST /reactions — only approved comments are reactable", () => {
 	it("still accepts a reaction on an approved comment", async () => {
 		installMockCaches();
 		const { app, env } = mkApp("approved");
-		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "like" });
+		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "fire" });
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { ok: boolean };
 		expect(body.ok).toBe(true);
@@ -215,12 +236,12 @@ describe("POST /reactions — only approved comments are reactable", () => {
 		// that would visibly blank a comment's reactions.
 		installMockCaches();
 		const { app, env } = mkApp("approved");
-		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "like" });
+		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "fire" });
 		const body = (await res.json()) as {
 			added: boolean;
 			reactions: Record<string, number>;
 		};
 		expect(body.added).toBe(true);
-		expect(body.reactions).toEqual({ like: 3, love: 1 });
+		expect(body.reactions).toEqual({ fire: 3, love: 1 });
 	});
 });

--- a/tests/reactions.test.ts
+++ b/tests/reactions.test.ts
@@ -174,6 +174,32 @@ describe("POST /reactions — input validation", () => {
 		expect(insert?.args[2]).toBe("fire");
 	});
 
+	it("answers a deprecated `like` in both spellings", async () => {
+		// Storing it as `fire` is only half the alias. That old bundle patches its
+		// row with mergeReactionTotals(prev, totals, "like", true) — keyed on `fire`
+		// alone it finds nothing, paints the cell to 0, and (for an anonymous
+		// reader, who never sees zero-count kinds) hides the button that was just
+		// pressed. Both spellings carry the same count.
+		installMockCaches();
+		const { app, env } = mkApp("approved");
+		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "like" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { reactions: Record<string, number> };
+		expect(body.reactions.like).toBe(body.reactions.fire);
+		expect(body.reactions.like).toBeGreaterThan(0);
+	});
+
+	it("does not invent an alias key for a current kind", async () => {
+		// A current bundle asks for `fire`, nothing is rewritten, and it must see
+		// the response shape it has always seen.
+		installMockCaches();
+		const { app, env } = mkApp("approved");
+		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "fire" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { reactions: Record<string, number> };
+		expect(body.reactions.like).toBeUndefined();
+	});
+
 	it("rejects a malformed JSON body with 400", async () => {
 		const { app, env } = mkApp();
 		const res = await app.request(

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -593,7 +593,7 @@ describe("route gating — reactions", () => {
 		const env = mkGatedEnv({ reactions_enabled: false });
 		const res = await postJson(app, env, {
 			comment_id: "01HC000000000000000000ABCD",
-			kind: "like",
+			kind: "fire",
 		});
 		expect(res.status).toBe(403);
 		expect(((await res.json()) as { error: string }).error).toBe(

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -258,7 +258,7 @@ describe("buildTree — reactions", () => {
 		const rows = [mk("root", null, 100), mk("child", "root", 200)];
 		const reactionsById = new Map<string, { kind: string; count: number; mine: boolean }[]>();
 		reactionsById.set("root", [
-			{ kind: "like", count: 3, mine: true },
+			{ kind: "fire", count: 3, mine: true },
 			{ kind: "love", count: 1, mine: false },
 		]);
 		reactionsById.set("child", [{ kind: "laugh", count: 2, mine: false }]);
@@ -268,7 +268,7 @@ describe("buildTree — reactions", () => {
 			reactionsById,
 		);
 		expect(threads[0]!.reactions).toEqual([
-			{ kind: "like", count: 3, mine: true },
+			{ kind: "fire", count: 3, mine: true },
 			{ kind: "love", count: 1, mine: false },
 		]);
 		expect(threads[0]!.replies[0]!.reactions).toEqual([

--- a/tests/widget-reactions.test.ts
+++ b/tests/widget-reactions.test.ts
@@ -108,4 +108,15 @@ describe("normalizeReactionKind", () => {
 		expect(normalizeReactionKind("shrug")).toBe("shrug");
 		expect(REACTION_KIND_SET.has(normalizeReactionKind("shrug"))).toBe(false);
 	});
+
+	it("does not resolve inherited object keys", () => {
+		// The input is a wire value. A plain-object lookup answers for every key on
+		// Object.prototype, so these returned a function (or Object.prototype)
+		// while still typed `string` — a lie waiting for the first caller that
+		// trusts the return value instead of re-checking membership.
+		for (const key of ["constructor", "toString", "valueOf", "__proto__"]) {
+			expect(normalizeReactionKind(key)).toBe(key);
+			expect(typeof normalizeReactionKind(key)).toBe("string");
+		}
+	});
 });

--- a/tests/widget-reactions.test.ts
+++ b/tests/widget-reactions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Widget reaction merging (src/widget/reactions.ts).
+ * The reaction vocabulary and reaction merging (src/widget/reactions.ts).
  *
  * Reactions used to reload the whole thread, so there was no client state to
  * get wrong. Now there is: the server is authoritative for counts, the toggle
@@ -8,10 +8,15 @@
  * pins — the DOM paint on top of it is a loop with no arithmetic in it.
  */
 import { describe, it, expect } from "vitest";
-import { mergeReactionTotals } from "../src/widget/reactions";
+import {
+	REACTION_KINDS,
+	REACTION_KIND_SET,
+	mergeReactionTotals,
+	normalizeReactionKind,
+} from "../src/widget/reactions";
 
 const prev = [
-	{ kind: "like", count: 3, mine: false },
+	{ kind: "fire", count: 3, mine: false },
 	{ kind: "love", count: 1, mine: true },
 ];
 
@@ -19,39 +24,88 @@ describe("mergeReactionTotals", () => {
 	it("takes counts from the server, not from a local +1", () => {
 		// 3 -> 5, because somebody else reacted between the page load and the
 		// click. A local increment would have shown 4 until the next reload.
-		const out = mergeReactionTotals(prev, { like: 5, love: 1 }, "like", true);
-		expect(out).toContainEqual({ kind: "like", count: 5, mine: true });
+		const out = mergeReactionTotals(prev, { fire: 5, love: 1 }, "fire", true);
+		expect(out).toContainEqual({ kind: "fire", count: 5, mine: true });
 	});
 
 	it("sets `mine` on the toggled kind from `added`", () => {
-		const on = mergeReactionTotals(prev, { like: 4, love: 1 }, "like", true);
-		expect(on.find((r) => r.kind === "like")?.mine).toBe(true);
+		const on = mergeReactionTotals(prev, { fire: 4, love: 1 }, "fire", true);
+		expect(on.find((r) => r.kind === "fire")?.mine).toBe(true);
 
-		const off = mergeReactionTotals(prev, { love: 1 }, "like", false);
-		expect(off.find((r) => r.kind === "like")).toBeUndefined();
+		const off = mergeReactionTotals(prev, { love: 1 }, "fire", false);
+		expect(off.find((r) => r.kind === "fire")).toBeUndefined();
 	});
 
 	it("leaves every other kind's `mine` alone", () => {
 		// The response says nothing about `love`; forgetting it would un-highlight
 		// a reaction the reader can see they made.
-		const out = mergeReactionTotals(prev, { like: 4, love: 1 }, "like", true);
+		const out = mergeReactionTotals(prev, { fire: 4, love: 1 }, "fire", true);
 		expect(out.find((r) => r.kind === "love")?.mine).toBe(true);
 	});
 
 	it("drops a kind that fell to zero", () => {
 		// Matches the tree payload, whose aggregate only contains existing rows —
 		// one shape for both, so a re-render after Load more agrees with the patch.
-		const out = mergeReactionTotals(prev, { like: 3, love: 0 }, "love", false);
-		expect(out).toEqual([{ kind: "like", count: 3, mine: false }]);
+		const out = mergeReactionTotals(prev, { fire: 3, love: 0 }, "love", false);
+		expect(out).toEqual([{ kind: "fire", count: 3, mine: false }]);
 	});
 
 	it("picks up a kind nobody had reacted with before", () => {
-		const out = mergeReactionTotals(prev, { like: 3, love: 1, cry: 1 }, "cry", true);
+		const out = mergeReactionTotals(prev, { fire: 3, love: 1, cry: 1 }, "cry", true);
 		expect(out).toContainEqual({ kind: "cry", count: 1, mine: true });
 	});
 
 	it("returns an empty list when the last reaction is removed", () => {
-		const one = [{ kind: "like", count: 1, mine: true }];
-		expect(mergeReactionTotals(one, {}, "like", false)).toEqual([]);
+		const one = [{ kind: "fire", count: 1, mine: true }];
+		expect(mergeReactionTotals(one, {}, "fire", false)).toEqual([]);
+	});
+});
+
+describe("the vocabulary", () => {
+	it("derives the membership set from the list", () => {
+		// The whole reason this module holds the vocabulary: two routes validate
+		// against REACTION_KIND_SET while the widget renders REACTION_KINDS, and a
+		// kind in one but not the other is a button that 400s.
+		expect([...REACTION_KIND_SET].sort()).toEqual(
+			REACTION_KINDS.map((r) => r.kind).sort(),
+		);
+	});
+
+	it("has no duplicate kind", () => {
+		const kinds = REACTION_KINDS.map((r) => r.kind);
+		expect(new Set(kinds).size).toBe(kinds.length);
+	});
+
+	it("gives every kind an emoji", () => {
+		for (const r of REACTION_KINDS) expect(r.emoji).not.toBe("");
+	});
+
+	it("no longer offers `like`", () => {
+		// 👍 duplicated the up-vote directly below it; migration 0022 renamed the
+		// stored rows to `fire`. Re-adding it would resurrect the duplication and
+		// collide with the deprecated-alias mapping below.
+		expect(REACTION_KIND_SET.has("like")).toBe(false);
+		expect(REACTION_KIND_SET.has("fire")).toBe(true);
+	});
+});
+
+describe("normalizeReactionKind", () => {
+	it("maps the deprecated `like` onto `fire`", () => {
+		// A pre-2.10.0 bundle in a reader's cache still POSTs `like`. Without this
+		// it would 400 — or, worse, land a row no build can render.
+		expect(normalizeReactionKind("like")).toBe("fire");
+	});
+
+	it("leaves a current kind alone", () => {
+		for (const r of REACTION_KINDS) {
+			expect(normalizeReactionKind(r.kind)).toBe(r.kind);
+		}
+	});
+
+	it("passes an unknown kind through unchanged", () => {
+		// Load-bearing: the routes reject on REACTION_KIND_SET *after* normalizing,
+		// so anything this invented would become a kind the API accepts.
+		expect(normalizeReactionKind("shrug")).toBe("shrug");
+		expect(REACTION_KIND_SET.has(normalizeReactionKind("shrug"))).toBe(false);
 	});
 });


### PR DESCRIPTION
Closes the three deltas a screenshot comparison against Hyvor Talk surfaced. Everything else in that screenshot (presence indicator, image/GIF upload, in-comment search) stays out of scope per `CLAUDE.md`.

## 1. Reaction vocabulary re-cut — one shared list, zero data loss

`ALLOWED_KINDS` was hand-maintained in three places (`api.reactions.ts`, `api.page-engagement.ts`, and a third copy as `REACTION_KINDS` in `embed.ts`). `src/widget/reactions.ts` is now the canonical owner and all three import it — same server-imports-widget direction the i18n layer already uses.

The vocabulary itself: 👍 `like` sat directly on top of the up-vote and read as two ways to say the same thing.

| kind | emoji | label | |
| --- | --- | --- | --- |
| `fire` | 🔥 | Brilliant | renamed from `like` |
| `love` | ❤️ | Love | |
| `wow` | 😮 | Wow | new |
| `laugh` | 😂 | Funny | |
| `hmm` | 🤔 | Hmm | |
| `cry` | 😢 | Sad | |

**No row is orphaned in either deploy order.** Migration `0022` renames existing rows; the write path also normalizes a deprecated `like` to `fire` *before* the allowed-kind check, so a client that hasn't reloaded still lands on the right row whichever of code and migration goes first. The migration is `UPDATE OR IGNORE` + a paired `DELETE` — `OR IGNORE` *skips* a row that would collide with the composite PK rather than removing it, so without the `DELETE` a reader who had both `like` and `fire` would keep a stale `like` forever. A test covers exactly that collision, and re-running the migration is a no-op.

Native unicode emoji, no artwork: fixed presentation instead (size, color-emoji font stack, `font-variant-emoji: emoji` so a Linux reader doesn't get monochrome glyphs). Bundle delta is ~0.

## 2. Labelled page reaction bar

Was a bare chip row — emoji + count, no prompt, no labels. Nobody could tell whether 🤔 meant "interesting" or "doubtful". Now carries a prompt heading and a label under each cell. Comment-level rows keep the compact inline shape and take the same string as `aria-label`/`title`, with `aria-pressed` mirroring `data-mine` — six labelled cells per comment would have been far too much chrome.

## 3. Subscribe bell

A reader who wanted replies by email but had nothing to say could not subscribe at all — `w.notify` was a checkbox *inside* the composer. The bell is a second entry point to existing plumbing: no new route, no new env var. `POST /api/v1/subscribe` already handles standalone `{post_slug, email?}` with double-opt-in, a per-address pending cap, a global send budget, a per-IP rate limit, and a fail-closed 503.

It lives in the row above the list, which today renders only when voting is on — generalized into a thread toolbar (sort left, still voting-gated; bell right). No new layout element.

Three properties held deliberately:

- **No subscription-state oracle.** The endpoint returns a constant shape unless the caller proved inbox ownership. The bell is an *action*, never a state toggle — it never queries or reflects whether an address is subscribed. Repeat clicks are safe (non-destructive upsert, refunds send budget when no mail goes out).
- **No new stored data.** No localStorage marker for "subscribed here"; confirmation is transient.
- **No unsubscribe from the widget.** That's token-based via the emailed link — offering it here would require exactly the oracle above.

`/api/v1/config` gains `subscriptions_enabled` (derived from `EMAIL_FROM` && `PUBLIC_BASE_URL`, so no manifest change) to keep the bell off an install that cannot send.

## One scope judgment call to review

That same flag now also gates the **composer's notify checkbox**, not just the new bell. On a mail-unconfigured install the endpoint 503s, so the checkbox was an opt-in that could never deliver. This is slightly beyond the letter of the plan — happy to revert it to bell-only if you'd rather keep the change minimal.

## Verification

Gates: typecheck, biome (1 warning / 2 infos, all pre-existing), `vitest run` → **106 files / 1633 tests**, `manifest:check`, build, `npm run size` → **15.95 KB gz, 53.2% of the 30 KB ceiling**.

Exercised live against `wrangler dev` + real local D1, driven over CDP:

- Page bar renders the prompt and six labelled cells; a click patches in place.
- Anonymous sees only used kinds on a comment; signed-in sees all six.
- Deprecated `like` POSTed live → stored and read back as `fire`; an invalid kind is still rejected.
- Real local D1 upgrade path: a lone `like` becomes `fire`; a `like`+`fire` collision collapses to one `fire`; re-run is a no-op.
- Bell, anonymous: email field → submit → server-localized message in `role="status"`, button and form hidden after.
- Bell, signed-in: single click → confirmed message, email field never shown.
- `EMAIL_FROM` unset → flag false, endpoint 503, bell *and* notify checkbox absent, toolbar and page bar intact.
- The new conditional doesn't displace the Turnstile slot (verified at its DOM position, after the notify block, before submit).
- Pixel-diff screenshots across all three theme paths — which caught one real defect: the bell had no affordance (bare emoji, no border) and read as decoration. Fixed in its own commit.

## Release note

Anyone reading `reactions.like` off `/api/v1/counts` sees `reactions.fire` after this release. Cached tree payloads can carry `like` for up to `TREE_CACHE_TTL`; those counts are skipped as an unknown kind until the entry expires — self-healing, and the write-path alias means nothing is lost.
