### PR TITLE
feat(admin): ad hoc moderator replies from the admin panel

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -931,7 +931,7 @@ responding):
 - `POST /admin/api/comments/:id` — `{action: approve|spam|delete|restore, reason?}`
 - `POST /admin/api/comments/bulk` — `{ids: string[], action}` (cap 100)
 - `POST /admin/api/comments/:id/reports/resolve` — clears open reader reports on a comment (audited `report.resolve`)
-- `POST /admin/api/comments/:id/reply` — `{body_md, saved_reply_id?, notify?}` posts a moderator reply nested under `:id` (audited `comment.reply`; `notify` defaults to true and fans out to the post's confirmed subscribers; `saved_reply_id` is audit provenance only and must be a preset this mod can see)
+- `POST /admin/api/comments/:id/reply` — `{body_md, saved_reply_id?, notify?}` posts a moderator reply nested under `:id` (audited `comment.reply`; `notify` must be a real boolean when present, defaults to true, and fans out to the post's confirmed subscribers; `saved_reply_id` is audit provenance only and must be a preset this mod can see)
 - `POST /admin/api/posts/close` — `{slug, closed: boolean}` (per-post close/open; audited `post.close` / `post.open`; busts the cached first page)
 - `POST /admin/api/users/:id` — `{banned: boolean, reason?, from_comment?}` (one-click ban-author records the originating comment in audit meta; admin-only)
 - `POST /admin/api/users/:id/role` — `{role: user|mod|admin, reason?}` (admin-only; refuses self-change and the last-admin demotion)

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -921,7 +921,7 @@ Pages (top nav):
 | `/admin/settings` | Editable form for feature flags, display/pagination numbers, and the moderation dials (edit window, thread auto-close, community auto-collapse, the three anti-spam heuristics), saved to the `settings` D1 table (no redeploy — see section 5). Also renders a read-only `(set)`/`(unset)` summary of deploy-time config (Turnstile, email, OAuth, spam provider), which still changes via `wrangler secret put` / `wrangler.toml`. |
 | `/admin/webhooks` | Outbound webhook endpoints: add/pause/delete, per-endpoint secret + event filter, adapter (`generic` / `slack` / `discord` / `telegram`), failure counts and retry status. |
 | `/admin/telegram` | **Admin-only.** Telegram operator bot: shows whether the bot token/webhook secret are set, links your personal Telegram account (one-time code or deep link), toggles the daily digest, and unlinks. See `docs/telegram.md`. |
-| `/admin/saved-replies` | Moderator saved replies: create/edit canned responses, private or shared scope, postable onto a comment from the queue. |
+| `/admin/saved-replies` | Moderator saved replies: create/edit canned responses, private or shared scope. Presets are a *prefill* for the reply composer, not the only way to reply — see **Replying from the admin panel** below. |
 | `/admin/usage` | Cloudflare analytics (requests, comments by domain). Requires `CF_API_TOKEN` + `CF_ACCOUNT_ID`; renders setup instructions when unset. |
 
 State-changing endpoints (all under `/admin/api/...`, all require admin
@@ -931,6 +931,7 @@ responding):
 - `POST /admin/api/comments/:id` — `{action: approve|spam|delete|restore, reason?}`
 - `POST /admin/api/comments/bulk` — `{ids: string[], action}` (cap 100)
 - `POST /admin/api/comments/:id/reports/resolve` — clears open reader reports on a comment (audited `report.resolve`)
+- `POST /admin/api/comments/:id/reply` — `{body_md, saved_reply_id?, notify?}` posts a moderator reply nested under `:id` (audited `comment.reply`; `notify` defaults to true and fans out to the post's confirmed subscribers; `saved_reply_id` is audit provenance only and must be a preset this mod can see)
 - `POST /admin/api/posts/close` — `{slug, closed: boolean}` (per-post close/open; audited `post.close` / `post.open`; busts the cached first page)
 - `POST /admin/api/users/:id` — `{banned: boolean, reason?, from_comment?}` (one-click ban-author records the originating comment in audit meta; admin-only)
 - `POST /admin/api/users/:id/role` — `{role: user|mod|admin, reason?}` (admin-only; refuses self-change and the last-admin demotion)
@@ -940,6 +941,13 @@ responding):
 - `POST /admin/api/ops/seed-demo` — disabled when `ENV=production`
 - `POST /admin/api/ops/ip-retention` — manual drain of the IP-hash sweep; no body. `400 retention_disabled` when `IP_HASH_RETENTION_DAYS` is `0` or below the 7-day floor. Audits `ip_retention.sweep` only when it actually cleared something.
 - `POST /admin/api/ops/audit-retention` — same shape for the audit-log sweep, gated on `AUDIT_LOG_RETENTION_DAYS` and a 30-day floor, audited `audit_retention.sweep`.
+
+One POST is unaudited, because it neither changes nor stores anything:
+
+- `POST /admin/api/preview` — `{body_md}` → `{html}`, the reply composer's
+  markdown preview. Renders through the same allowlist sanitizer as a real
+  comment and persists nothing. Separate from the widget's
+  `/api/v1/preview`, which is anonymous and IP-rate-limited.
 
 One admin read is listed here too, because of what it returns:
 
@@ -1061,11 +1069,39 @@ bodies over 64 KB skip the retry queue (logged, inline attempt still
 made). An endpoint that fails 10 consecutive times auto-disables —
 re-enable it from the admin page after fixing the receiver.
 
+**Replying from the admin panel.** A mod can answer a comment without
+leaving the admin UI, from either the queue's **Reply** modal or the
+single-comment view (`/admin/comments/:id`, which is the better surface
+for a considered reply — the thread, the spam verdicts and any reader
+reports are all on screen). The composer is free text: type the reply,
+optionally **Preview** the rendered markdown, then post. It inserts a
+regular comment nested under the target, authored by the signed-in
+moderator, `status='approved'` — no Turnstile, no spam check, and no
+`ip_hash`/`user_agent` stored. The moderator's name is shown above the
+box, because a shared admin login otherwise puts the wrong face on
+every reply. Audited as `comment.reply`.
+
+**Notify thread subscribers** is a checkbox on the composer, **default
+on**: the reply fans out to every confirmed, still-subscribed email
+subscriber on that post — the same fan-out a reader's reply uses, and
+the same batched digest drains it, with no moderator/reader distinction
+in the email. Uncheck it for a housekeeping note ("dupe, see above")
+that shouldn't email the thread. The mod's own address is always
+skipped. Subscriptions are per *post*, not per comment, so this notifies
+thread followers rather than only the person being replied to.
+
 **Saved replies.** Canned moderator responses, managed on
 `/admin/saved-replies`. Each reply is owned by its author and scoped
 `private` (only the owner sees it) or `shared` (every mod/admin sees
-it). The queue's reply box offers a picker; posting one inserts it as a
-regular comment from the moderator's identity.
+it). In the composer they sit behind a collapsed **Insert a saved
+reply** picker and only prefill the textarea — edit freely afterwards.
+The reverse works too: **Save for reuse** turns whatever is in the box
+into a new preset (title + scope). Presets cap at 8 000 characters
+while a comment allows 10 000, so a long reply can be postable and
+still too long to save; the button says so rather than failing. When a
+preset prefilled the body its id is recorded in the audit row's
+`saved_reply_id`, and it is cleared if the text is edited away from the
+preset — provenance is never claimed for text the mod actually wrote.
 
 **Disqus import.** Two entry points, both idempotent (deduplicated by
 Disqus comment ID, tracked in `0009_import_tracking.sql`; re-running

--- a/src/admin-ui/components/reply-composer.ts
+++ b/src/admin-ui/components/reply-composer.ts
@@ -1,0 +1,223 @@
+/**
+ * Free-text moderator reply composer.
+ *
+ * Shared by the queue's reply modal and the single-comment view so the two
+ * can't drift. Free text is the primary input; saved replies are offered as an
+ * optional *prefill* behind a collapsed picker, which is the inverse of how
+ * this worked when the only way to reply was to pick a preset first.
+ *
+ * The component owns its own Alpine scope (body, notify, preview, save-for-
+ * reuse). The target comment id comes from the caller as a JS *expression*
+ * evaluated in the enclosing Alpine scope: a literal on the comment-detail
+ * page, and the modal's `commentId` state in the queue, where the same
+ * composer serves whichever row was clicked.
+ */
+import { escapeHtml, jsLiteral } from "../escape";
+import { MAX_BODY_CHARS } from "../../lib/markdown";
+
+// Mirrors SAVED_REPLY_BODY_MAX in routes/admin.ts. Not imported: admin-ui is
+// downstream of that module (it imports these renderers), so reaching back for
+// the constant would close an import cycle. The same literal is already
+// hard-coded in pages/saved-replies.ts for the same reason.
+//
+// It is *lower* than MAX_BODY_CHARS, so a reply can be perfectly postable and
+// still too long to save as a preset. The UI has to say so rather than let the
+// save 400 with body_too_long.
+const SAVED_REPLY_BODY_MAX = 8000;
+
+export type ReplyComposerOptions = {
+	/**
+	 * JS expression, evaluated in the enclosing Alpine scope, yielding the id of
+	 * the comment being replied to. Callers pass either a quoted literal or the
+	 * name of a state property; either way it must already be safe to embed.
+	 */
+	commentIdExpr: string;
+	/** Display name of the signed-in moderator, shown as the posting identity. */
+	modName: string;
+	/** Statements to run after a successful post (close a modal, reload, …). */
+	onPosted?: string;
+	/** Offer the saved-reply picker as a prefill source. */
+	offerSavedReplies?: boolean;
+};
+
+export const replyComposer = (o: ReplyComposerOptions): string => {
+	const onPosted = o.onPosted ?? "";
+	const offer = o.offerSavedReplies !== false;
+	return `<div class="reply-composer" x-data="{
+  body: '',
+  notify: true,
+  busy: false,
+  previewing: false,
+  previewHtml: '',
+  savedReplyId: null,
+  pickedBody: '',
+  pickerOpen: false,
+  replies: [],
+  loadedReplies: false,
+  saveOpen: false,
+  saveTitle: '',
+  saveScope: 'private',
+  saving: false,
+  get tooLongToSave() { return this.body.length > ${SAVED_REPLY_BODY_MAX}; },
+  onEdit(v) {
+    this.body = v;
+    // Editing away from the preset drops the provenance claim, so the audit row
+    // never credits a saved reply for text the mod actually wrote.
+    if (this.savedReplyId && v !== this.pickedBody) this.savedReplyId = null;
+    if (this.previewing) this.previewing = false;
+  },
+  async loadReplies() {
+    if (this.loadedReplies) return;
+    try {
+      const r = await fetch('/admin/api/saved-replies', { headers: { accept: 'application/json' } });
+      if (!r.ok) throw new Error('Could not load saved replies');
+      const j = await r.json();
+      this.replies = Array.isArray(j.replies) ? j.replies : [];
+      this.loadedReplies = true;
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Load failed', kind: 'bad' });
+    }
+  },
+  pick(r) {
+    this.body = r.body_md;
+    this.pickedBody = r.body_md;
+    this.savedReplyId = r.id;
+    this.pickerOpen = false;
+    this.previewing = false;
+  },
+  async togglePreview() {
+    if (this.previewing) { this.previewing = false; return; }
+    if (!this.body.trim()) return;
+    this.busy = true;
+    try {
+      const r = await fetch('/admin/api/preview', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ body_md: this.body }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.error || ('Preview failed: ' + r.status));
+      }
+      const j = await r.json();
+      this.previewHtml = j.html || '';
+      this.previewing = true;
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Preview failed', kind: 'bad' });
+    } finally { this.busy = false; }
+  },
+  async send() {
+    if (this.busy || !this.body.trim()) return;
+    this.busy = true;
+    try {
+      const r = await fetch('/admin/api/comments/' + ${o.commentIdExpr} + '/reply', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ body_md: this.body, saved_reply_id: this.savedReplyId, notify: this.notify }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.error || ('Post failed: ' + r.status));
+      }
+      this.$dispatch('toast', { text: this.notify ? 'Reply posted — subscribers notified' : 'Reply posted' });
+      this.body = ''; this.savedReplyId = null; this.previewing = false;
+      ${onPosted}
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Post failed', kind: 'bad' });
+    } finally { this.busy = false; }
+  },
+  async saveForReuse() {
+    if (this.saving || !this.saveTitle.trim() || !this.body.trim() || this.tooLongToSave) return;
+    this.saving = true;
+    try {
+      const r = await fetch('/admin/api/saved-replies', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: this.saveTitle, body_md: this.body, scope: this.saveScope }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.error || ('Save failed: ' + r.status));
+      }
+      this.$dispatch('toast', { text: 'Saved for reuse' });
+      this.saveOpen = false; this.saveTitle = '';
+      this.loadedReplies = false; this.replies = [];
+    } catch (e) {
+      this.$dispatch('toast', { text: e.message || 'Save failed', kind: 'bad' });
+    } finally { this.saving = false; }
+  }
+}">
+  <p class="muted" style="margin:0 0 0.5rem">Posting as <strong>${escapeHtml(o.modName)}</strong> — published immediately, no spam check.</p>
+${
+	offer
+		? `  <p style="margin:0 0 0.5rem">
+    <button type="button" class="btn" @click="pickerOpen = !pickerOpen; loadReplies()"
+            x-text="pickerOpen ? 'Hide saved replies' : 'Insert a saved reply'"></button>
+  </p>
+  <div x-show="pickerOpen" x-cloak style="margin-bottom:0.5rem">
+    <ul class="reply-list" x-show="replies.length">
+      <template x-for="r in replies" :key="r.id">
+        <li>
+          <button type="button"
+                  :class="savedReplyId === r.id ? 'reply-pick active' : 'reply-pick'"
+                  @click="pick(r)">
+            <strong x-text="r.title"></strong>
+            <span class="muted" x-text="r.scope"></span>
+          </button>
+        </li>
+      </template>
+    </ul>
+    <p class="muted" x-show="loadedReplies && !replies.length">
+      No saved replies yet. Write the reply below — you can save it for reuse afterwards.
+    </p>
+  </div>
+`
+		: ""
+}  <label>Reply (markdown)<br>
+    <textarea :value="body" @input="onEdit($event.target.value)" rows="8" maxlength="${MAX_BODY_CHARS}"
+              placeholder="Write a reply…"
+              style="width:100%;min-height:160px;font-family:ui-monospace,monospace"></textarea>
+  </label>
+  <div x-show="previewing" x-cloak class="reply-preview" style="margin:0.5rem 0">
+    <p class="muted" style="margin:0 0 0.25rem">Preview</p>
+    <div x-html="previewHtml"></div>
+  </div>
+  <p style="margin:0.5rem 0">
+    <label><input type="checkbox" x-model="notify"> Notify thread subscribers by email</label>
+  </p>
+  <p>
+    <button :disabled="busy || !body.trim()" @click="send()">Post reply</button>
+    <button :disabled="busy || !body.trim()" class="btn" @click="togglePreview()"
+            x-text="previewing ? 'Hide preview' : 'Preview'"></button>
+    <button :disabled="!body.trim()" class="btn" @click="saveOpen = !saveOpen">Save for reuse</button>
+  </p>
+  <div x-show="saveOpen" x-cloak style="margin-top:0.5rem">
+    <p class="muted" x-show="tooLongToSave" style="margin:0 0 0.25rem">
+      Too long to save as a preset (over ${SAVED_REPLY_BODY_MAX} characters). It can still be posted.
+    </p>
+    <label>Title<br>
+      <input type="text" x-model="saveTitle" maxlength="120" style="width:100%">
+    </label>
+    <label style="display:block;margin-top:0.25rem">Scope<br>
+      <select x-model="saveScope">
+        <option value="private">private</option>
+        <option value="shared">shared</option>
+      </select>
+    </label>
+    <p style="margin-top:0.5rem">
+      <button :disabled="saving || !saveTitle.trim() || tooLongToSave" @click="saveForReuse()">Save</button>
+      <button :disabled="saving" class="btn" @click="saveOpen = false">Cancel</button>
+    </p>
+  </div>
+</div>`;
+};
+
+/**
+ * Quote a known-at-render-time comment id for use as `commentIdExpr`.
+ *
+ * `jsLiteral`, not `jsLiteralRaw`: the composer writes its `x-data` blob raw
+ * rather than escaping it as a whole, so the literal's own double quotes have
+ * to become `&quot;` or they'd terminate the double-quoted attribute early.
+ * They decode back to quotes before Alpine parses the expression.
+ */
+export const commentIdLiteral = (id: string): string => jsLiteral(id);

--- a/src/admin-ui/components/reply-composer.ts
+++ b/src/admin-ui/components/reply-composer.ts
@@ -205,7 +205,7 @@ ${
       </select>
     </label>
     <p style="margin-top:0.5rem">
-      <button :disabled="saving || !saveTitle.trim() || tooLongToSave" @click="saveForReuse()">Save</button>
+      <button :disabled="saving || !saveTitle.trim() || !body.trim() || tooLongToSave" @click="saveForReuse()">Save</button>
       <button :disabled="saving" class="btn" @click="saveOpen = false">Cancel</button>
     </p>
   </div>

--- a/src/admin-ui/pages/comment-detail.ts
+++ b/src/admin-ui/pages/comment-detail.ts
@@ -8,6 +8,10 @@ import type {
 } from "../../db/queries";
 import { identiconSvg } from "../../lib/identicon";
 import { sanitizeForEmail as resanitizeBodyHtml } from "../../lib/markdown";
+import {
+	commentIdLiteral,
+	replyComposer,
+} from "../components/reply-composer";
 import { escapeHtml, jsLiteral } from "../escape";
 
 const formatTs = (ts: number): string =>
@@ -213,6 +217,8 @@ const actionsFor = (status: CommentStatus): string => {
 export const renderCommentDetail = (
 	d: AdminCommentDetail,
 	isAdmin = false,
+	/** Signed-in moderator's display name, shown as the reply composer's identity. */
+	modName = "",
 ): string => {
 	const { comment, parent, replies, ip_siblings, user_recent, verdicts, reports, audit } = d;
 	const parentSection = parent
@@ -241,6 +247,21 @@ export const renderCommentDetail = (
 		     ${user_recent.map((s) => commentCard(s, `Recent`)).join("")}
 		   </div>`
 		: "";
+	// Same gate the action buttons use: there is nothing to answer on a deleted
+	// comment. Unlike the queue's modal this composer is always mounted — this
+	// page is where a considered reply gets written, with the thread, the spam
+	// verdicts and any reader reports all on screen.
+	const replySection =
+		comment.status === "deleted"
+			? ""
+			: `<div class="card">
+	     <h3>Reply</h3>
+	     ${replyComposer({
+				commentIdExpr: commentIdLiteral(comment.id),
+				modName,
+				onPosted: "setTimeout(() => location.reload(), 600);",
+			})}
+	   </div>`;
 
 	return `
 <a href="/admin/queue" class="muted">← back to queue</a>
@@ -272,6 +293,7 @@ export const renderCommentDetail = (
   <pre style="white-space:pre-wrap;font-size:0.85rem">${escapeHtml(comment.body_md)}</pre>
 </div>
 
+${replySection}
 ${reportsSection(comment.id, reports)}
 ${verdictsSection(verdicts)}
 ${parentSection}

--- a/src/admin-ui/pages/queue.ts
+++ b/src/admin-ui/pages/queue.ts
@@ -6,6 +6,7 @@ import type {
 import { identiconSvg } from "../../lib/identicon";
 import { sanitizeForEmail as resanitizeBodyHtml } from "../../lib/markdown";
 import { renderHostFilter } from "../components/host-filter";
+import { replyComposer } from "../components/reply-composer";
 import { escapeHtml, jsLiteral } from "../escape";
 
 const relTime = (ts: number, now: number = Date.now()): string => {
@@ -145,7 +146,7 @@ const actionButtons = (id: string, status: CommentStatus): string => {
 			`<button :disabled="busy" class="bad" @click="${rowAct(id, "delete", "Deleted")}">Delete</button>`,
 		);
 	}
-	// Reply opens the saved-replies picker — mods only see it on
+	// Reply opens the free-text composer — mods only see it on
 	// approved/pending comments. No point replying to deleted/spam.
 	if (status !== "deleted" && status !== "spam") {
 		parts.push(
@@ -169,6 +170,8 @@ export const renderQueue = (
 	hosts: string[] = [],
 	post: PostLifecycle | null = null,
 	reportCounts: Record<string, number> = {},
+	/** Signed-in moderator's display name, shown as the reply composer's identity. */
+	modName = "",
 ): string => {
 	const statusTabs = ["all", "approved", "pending", "spam", "deleted"]
 		.map((s) => {
@@ -285,57 +288,10 @@ export const renderQueue = (
 <div class="filter-bar"><span class="muted">filter:</span> ${tabs}</div>
 ${filterBar}
 ${lifecycleBar}
-<div x-data="{
-  open: false,
-  commentId: null,
-  replies: [],
-  selected: null,
-  busy: false,
-  body: '',
-  loaded: false,
-  async load() {
-    if (this.loaded) return;
-    this.busy = true;
-    try {
-      const r = await fetch('/admin/api/saved-replies', { headers: { accept: 'application/json' } });
-      if (!r.ok) throw new Error('Could not load saved replies');
-      const j = await r.json();
-      this.replies = Array.isArray(j.replies) ? j.replies : [];
-      this.loaded = true;
-    } catch (e) {
-      this.$dispatch('toast', { text: e.message || 'Load failed', kind: 'bad' });
-    } finally {
-      this.busy = false;
-    }
-  },
-  pick(r) {
-    this.selected = r;
-    this.body = r.body_md;
-  },
-  async send() {
-    if (!this.selected || !this.commentId) return;
-    this.busy = true;
-    try {
-      const r = await fetch('/admin/api/saved-replies/' + this.selected.id + '/post', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ comment_id: this.commentId, body_md: this.body }),
-      });
-      if (!r.ok) {
-        const j = await r.json().catch(() => ({}));
-        throw new Error(j.error || ('Post failed: ' + r.status));
-      }
-      this.$dispatch('toast', { text: 'Reply posted' });
-      this.open = false;
-    } catch (e) {
-      this.$dispatch('toast', { text: e.message || 'Post failed', kind: 'bad' });
-    } finally {
-      this.busy = false;
-    }
-  }
-}"
-@open-reply.window="open=true; commentId=$event.detail.id; selected=null; body=''; load();"
-@keydown.escape.window="open=false">
+<div x-data="{ open: false, commentId: null }"
+@open-reply.window="open = true; commentId = $event.detail.id;"
+@reply-posted="open = false"
+@keydown.escape.window="open = false">
 <div class="card" x-data="{
   selected: [],
   bulkBusy: false,
@@ -391,36 +347,24 @@ ${lifecycleBar}
     <button :disabled="bulkBusy" @click="selected = []">Clear</button>
   </div>
 </div>
-<div class="reply-modal" x-show="open" x-cloak role="dialog" aria-label="Reply with a saved reply"
+<div class="reply-modal" x-show="open" x-cloak role="dialog" aria-label="Reply to this comment"
      @click.self="open=false">
   <div class="reply-modal-inner">
-    <h3 style="margin-top:0">Reply with a saved reply</h3>
-    <p class="muted" x-show="!replies.length && loaded">
-      No saved replies yet — <a href="/admin/saved-replies/new">create one</a>.
-    </p>
-    <ul class="reply-list" x-show="replies.length">
-      <template x-for="r in replies" :key="r.id">
-        <li>
-          <button type="button"
-                  :class="selected && selected.id === r.id ? 'reply-pick active' : 'reply-pick'"
-                  @click="pick(r)">
-            <strong x-text="r.title"></strong>
-            <span class="muted" x-text="r.scope"></span>
-          </button>
-        </li>
-      </template>
-    </ul>
-    <div x-show="selected">
-      <label>Body (markdown)<br>
-        <textarea x-model="body" rows="8" maxlength="8000"
-                  style="width:100%;min-height:160px;font-family:ui-monospace,monospace"></textarea>
-      </label>
-      <p>
-        <button :disabled="busy || !body.trim()" @click="send()">Post reply</button>
-        <button :disabled="busy" @click="open=false" class="btn">Cancel</button>
-      </p>
-    </div>
-    <p x-show="!selected && replies.length" class="muted">Pick a reply above to preview and post.</p>
+    <h3 style="margin-top:0">Reply to this comment</h3>
+    <!-- x-if rather than x-show so each open mounts a fresh composer: closing
+         the modal must not leave last time's draft, preview or notify choice
+         sitting in the next reply. -->
+    <template x-if="open">
+${replyComposer({
+	commentIdExpr: "commentId",
+	modName,
+	// The composer has its own Alpine scope, so assigning `open` there would
+	// create a new property on the child instead of closing the modal. Bubble an
+	// event to the wrapper's @reply-posted handler instead.
+	onPosted: "this.$dispatch('reply-posted');",
+})}
+    </template>
+    <p><button class="btn" @click="open=false">Cancel</button></p>
   </div>
 </div>
 </div>`;

--- a/src/admin-ui/styles.ts
+++ b/src/admin-ui/styles.ts
@@ -247,6 +247,12 @@ button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .reply-pick:hover { background: var(--surface-2); }
 .reply-pick.active { background: var(--accent); color: var(--accent-fg); }
 .reply-pick.active .muted { color: var(--accent-fg); opacity: 0.85; }
+/* Preview renders the same allowlisted HTML a posted comment would store, so it
+   is boxed to read as output rather than as more of the form. */
+.reply-preview { border: 1px solid var(--border); border-radius: 6px;
+                 padding: 0.5rem 0.75rem; background: var(--surface-2); }
+.reply-preview > div > :first-child { margin-top: 0; }
+.reply-preview > div > :last-child { margin-bottom: 0; }
 .comment-card { border: 1px solid var(--border); border-radius: 6px;
                 padding: 0.75rem; margin: 0.5rem 0; }
 .comment-card-head { display: flex; justify-content: space-between;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2425,7 +2425,15 @@ export const ADMIN_ACTIONS = [
 	"saved_reply.create",
 	"saved_reply.update",
 	"saved_reply.delete",
+	// Retired in favour of `comment.reply` when the moderator reply path stopped
+	// being keyed on a saved reply. Nothing writes it any more, but this array is
+	// the allowlist both the audit dropdown and the `?action=` query validate
+	// against (see `ip_retention.sweep` above for what dropping an entry costs),
+	// so removing it would make every historical row unfilterable.
 	"saved_reply.post",
+	// A moderator reply posted from the admin panel. Free text, optionally
+	// prefilled from a saved reply — `meta.saved_reply_id` records which.
+	"comment.reply",
 	"import.disqus",
 	"settings.update",
 	"post.close",

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -47,6 +47,7 @@ import {
 	deleteSettings,
 	deleteTelegramLinkByUser,
 	deleteWebhookEndpoint,
+	enqueueNotification,
 	exportUserData,
 	getComment,
 	getTelegramLinkByUser,
@@ -60,6 +61,7 @@ import {
 	isSavedReplyScope,
 	isUserRole,
 	isWebhookAdapter,
+	listActiveSubscriptionsForPost,
 	listSavedRepliesForUser,
 	listWebhookEndpoints,
 	markSubscriptionUnsubscribed,
@@ -145,7 +147,11 @@ import {
 	renderSubscriptions,
 	type SubscriptionsFilters,
 } from "../admin-ui/pages/subscriptions";
-import { CURRENT_RENDERER_VERSION, renderMarkdown } from "../lib/markdown";
+import {
+	CURRENT_RENDERER_VERSION,
+	renderMarkdown,
+	validateBody,
+} from "../lib/markdown";
 import { MAX_XML_BYTES, runDisqusImport } from "../lib/disqus-import";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
 import {
@@ -1600,6 +1606,145 @@ admin.post("/api/saved-replies/:id/post", async (c) => {
 		ts: Date.now(),
 	});
 	return c.json({ ok: true, id: inserted.id });
+});
+
+// --------------------------- Moderator replies -----------------------------
+//
+// POST /admin/api/comments/:id/reply
+//   { body_md, saved_reply_id?, notify? }
+//
+// The canonical way a moderator answers a comment from the admin panel. Free
+// text is the general case; a saved reply is only a *prefill* of it, which is
+// why this route is keyed on the comment being answered rather than on a saved
+// reply. `saved_reply_id` is provenance for the audit row and nothing else.
+//
+// The reply is a child of the target (not a top-level comment), authored by the
+// moderator's own user, status=approved — Turnstile and the spam pipeline are
+// bypassed because a mod posting under their own name has already vouched for
+// the content. Body is always re-rendered through renderMarkdown at post time;
+// we never trust stored HTML.
+//
+// Length is bounded by the *comment* cap (MAX_BODY_CHARS, via validateBody),
+// not SAVED_REPLY_BODY_MAX. What we insert here is a comment, so it gets the
+// comment's rules; a saved reply's 8k body always fits inside that.
+admin.post("/api/comments/:id/reply", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const body = await c.req
+		.json<{
+			body_md?: unknown;
+			saved_reply_id?: unknown;
+			notify?: unknown;
+		}>()
+		.catch(() => null);
+	if (!body) return c.json({ error: "invalid_body" }, 400);
+
+	const valid = validateBody(
+		typeof body.body_md === "string" ? body.body_md : "",
+	);
+	if (!valid.ok) {
+		return c.json(
+			valid.key === "err.body.too_long"
+				? { error: "body_too_long", max: valid.max }
+				: { error: "body_required" },
+			400,
+		);
+	}
+
+	// Provenance is optional, but when claimed it has to be a reply this mod can
+	// actually see — otherwise the audit row could name someone else's private
+	// saved reply. A 400 rather than a 404: the reply body is fine, the claim
+	// about where it came from is not.
+	let savedReplyId: string | null = null;
+	if (body.saved_reply_id != null) {
+		if (typeof body.saved_reply_id !== "string") {
+			return c.json({ error: "invalid_body" }, 400);
+		}
+		const source = await getSavedReply(c.env.DB, body.saved_reply_id);
+		if (!source || (source.owner_id !== user.id && source.scope !== "shared")) {
+			return c.json({ error: "saved_reply_not_visible" }, 400);
+		}
+		savedReplyId = source.id;
+	}
+
+	const target = await getComment(c.env.DB, c.req.param("id"));
+	if (!target) return c.json({ error: "comment_not_found" }, 404);
+	if (target.status === "deleted") {
+		return c.json({ error: "comment_deleted" }, 400);
+	}
+	// The nesting cap applies to moderators too: the O(N^2) tree-assembly cost
+	// it guards doesn't care who created the chain. Reply higher up instead.
+	const depth = target.depth + 1;
+	if (depth > MAX_REPLY_DEPTH) {
+		return c.json({ error: "thread_too_deep" }, 400);
+	}
+
+	const inserted = await insertComment(c.env.DB, {
+		post_slug: target.post_slug,
+		parent_id: target.id,
+		user_id: user.id,
+		body_md: valid.body,
+		body_html: renderMarkdown(valid.body),
+		renderer_version: CURRENT_RENDERER_VERSION,
+		status: "approved",
+		ip_hash: null,
+		user_agent: null,
+		depth,
+	});
+
+	// Default on: this is a real comment on a real thread, so the people
+	// following that thread should hear about it the same way they hear about a
+	// reader's reply. The composer's checkbox exists so a housekeeping note
+	// ("dupe, see above") doesn't have to email everyone.
+	const notify = body.notify !== false;
+	await adminInsertAudit(c.env.DB, {
+		admin_id: user.id,
+		action: "comment.reply",
+		target_kind: "comment",
+		target_id: inserted.id,
+		meta: {
+			from_saved_reply: savedReplyId != null,
+			saved_reply_id: savedReplyId,
+			parent_id: target.id,
+			post_slug: target.post_slug,
+			// The operator's choice, not a delivery count — the fan-out below is
+			// deferred, and a number here would be a guess at what it will write.
+			notify_subscribers: notify,
+		},
+	});
+	// Bust the post's tree caches so the new reply is visible immediately.
+	await bustTreeCache(c.env, c.req.url, target.post_slug);
+	fireWebhook(c.env, c.executionCtx, {
+		event: "comment.posted",
+		comment_id: inserted.id,
+		post_slug: target.post_slug,
+		user_id: user.id,
+		ts: inserted.created_at,
+	});
+
+	if (notify) {
+		const fanout = (async () => {
+			const subs = await listActiveSubscriptionsForPost(
+				c.env.DB,
+				target.post_slug,
+			);
+			// Skip our own address for the same reason the widget path does: being
+			// emailed about your own comment reads as a bug.
+			const selfEmail = user.email?.toLowerCase() ?? null;
+			for (const sub of subs) {
+				if (selfEmail && sub.email === selfEmail) continue;
+				await enqueueNotification(c.env.DB, sub.id, inserted.id);
+			}
+		})();
+		// Always wait for the enqueue to finish — same reasoning as the widget
+		// fan-out in routes/api.comments.ts: without an executionCtx the runtime
+		// can cancel the orphan promise once the response settles, and a lost row
+		// here is a notification nobody ever gets.
+		if (c.executionCtx) c.executionCtx.waitUntil(fanout);
+		else await fanout;
+	}
+
+	return c.json({ ok: true, id: inserted.id, notified: notify });
 });
 
 admin.post("/api/comments/:id", async (c) => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1576,6 +1576,14 @@ admin.post("/api/comments/:id/reply", async (c) => {
 		);
 	}
 
+	// Optional, but not coercible: `"false"` and `0` are what a buggy client sends
+	// when it means "don't email anyone", and silently reading either as true
+	// mails the whole thread. Absent stays absent; anything present must be a
+	// real boolean.
+	if (body.notify != null && typeof body.notify !== "boolean") {
+		return c.json({ error: "invalid_body" }, 400);
+	}
+
 	// Provenance is optional, but when claimed it has to be a reply this mod can
 	// actually see — otherwise the audit row could name someone else's private
 	// saved reply. A 400 rather than a 404: the reply body is fine, the claim
@@ -1621,7 +1629,7 @@ admin.post("/api/comments/:id/reply", async (c) => {
 	// following that thread should hear about it the same way they hear about a
 	// reader's reply. The composer's checkbox exists so a housekeeping note
 	// ("dupe, see above") doesn't have to email everyone.
-	const notify = body.notify !== false;
+	const notify = body.notify ?? true;
 	await adminInsertAudit(c.env.DB, {
 		admin_id: user.id,
 		action: "comment.reply",

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -432,6 +432,7 @@ admin.get("/queue", async (c) => {
 				hosts,
 				postState,
 				reportCounts,
+				user.name,
 			),
 			user,
 			updateInfo,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1322,12 +1322,12 @@ admin.delete("/api/webhooks/:id", async (c) => {
 //     Even an admin can't modify another mod's reply through the API — they
 //     can sign in as that user via OAuth if they really need to.
 //
-// Post-as-reply:
-//   - POST /admin/api/saved-replies/:id/post with { comment_id } posts a
-//     top-level reply on the same post as the target comment, authored by
-//     the mod's own user, status=approved (bypassing Turnstile/spam — the
-//     mod has already vouched for the content). Body is the saved reply's
-//     markdown, optionally edited.
+// Posting one is not a saved-reply operation any more: a mod posts through
+// POST /admin/api/comments/:id/reply (see "Moderator replies" below) with the
+// preset's markdown as the request body, and an optional `saved_reply_id` for
+// audit provenance only. Saved replies are a *prefill* source, not a posting
+// path — the dedicated `saved-replies/:id/post` endpoint was removed when free
+// text became the canonical reply input.
 
 // Exported so tests can assert the parser against the real values
 // instead of pinning literal numbers that would silently drift.
@@ -1531,82 +1531,6 @@ admin.delete("/api/saved-replies/:id", async (c) => {
 		meta: { title: existing.title, scope: existing.scope },
 	});
 	return c.json({ ok: true, id });
-});
-
-// Post a saved reply as a top-level reply on a comment. Body is the
-// saved reply's markdown by default; the mod can override (`body_md`) to
-// tweak before sending. Always re-rendered through renderMarkdown — we
-// never trust stored HTML.
-admin.post("/api/saved-replies/:id/post", async (c) => {
-	const user = await requireMod(c);
-	if (user instanceof Response) return user;
-	const id = c.req.param("id");
-	const reply = await getSavedReply(c.env.DB, id);
-	if (!reply) return c.json({ error: "not_found" }, 404);
-	// Visibility check mirrors the GET — only the owner or shared replies.
-	if (reply.owner_id !== user.id && reply.scope !== "shared") {
-		return c.json({ error: "not_found" }, 404);
-	}
-	const body = await c.req
-		.json<{ comment_id?: unknown; body_md?: unknown }>()
-		.catch(() => null);
-	if (!body || typeof body.comment_id !== "string") {
-		return c.json({ error: "invalid_body" }, 400);
-	}
-	const target = await getComment(c.env.DB, body.comment_id);
-	if (!target) return c.json({ error: "comment_not_found" }, 404);
-	if (target.status === "deleted") {
-		return c.json({ error: "comment_deleted" }, 400);
-	}
-	// Allow the mod to override the body before posting.
-	const rawBody =
-		typeof body.body_md === "string" && body.body_md.trim().length > 0
-			? body.body_md
-			: reply.body_md;
-	if (rawBody.length > SAVED_REPLY_BODY_MAX) {
-		return c.json({ error: "body_too_long" }, 400);
-	}
-	// The nesting cap applies to moderators too: the O(N^2) tree-assembly cost
-	// it guards doesn't care who created the chain. Reply higher up instead.
-	const depth = target.depth + 1;
-	if (depth > MAX_REPLY_DEPTH) {
-		return c.json({ error: "thread_too_deep" }, 400);
-	}
-	const body_html = renderMarkdown(rawBody);
-	const inserted = await insertComment(c.env.DB, {
-		post_slug: target.post_slug,
-		parent_id: target.id,
-		user_id: user.id,
-		body_md: rawBody,
-		body_html,
-		renderer_version: CURRENT_RENDERER_VERSION,
-		status: "approved",
-		ip_hash: null,
-		user_agent: null,
-		depth,
-	});
-	await adminInsertAudit(c.env.DB, {
-		admin_id: user.id,
-		action: "saved_reply.post",
-		target_kind: "comment",
-		target_id: inserted.id,
-		meta: {
-			from_saved_reply: true,
-			saved_reply_id: reply.id,
-			parent_id: target.id,
-			post_slug: target.post_slug,
-		},
-	});
-	// Bust the post's tree caches so the new reply is visible immediately.
-	await bustTreeCache(c.env, c.req.url, target.post_slug);
-	fireWebhook(c.env, c.executionCtx, {
-		event: "comment.posted",
-		comment_id: inserted.id,
-		post_slug: target.post_slug,
-		user_id: user.id,
-		ts: Date.now(),
-	});
-	return c.json({ ok: true, id: inserted.id });
 });
 
 // --------------------------- Moderator replies -----------------------------

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -453,7 +453,7 @@ admin.get("/comments/:id", async (c) => {
 		renderPage(
 			c,
 			`Comment ${id.slice(0, 8)}`,
-			renderCommentDetail(detail, user.role === "admin"),
+			renderCommentDetail(detail, user.role === "admin", user.name),
 			user,
 			updateInfo,
 		),

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1747,6 +1747,39 @@ admin.post("/api/comments/:id/reply", async (c) => {
 	return c.json({ ok: true, id: inserted.id, notified: notify });
 });
 
+// POST /admin/api/preview  { body_md } -> { html }
+//
+// Render markdown for the reply composer without persisting. A saved reply was
+// vetted when it was written; ad hoc text is not, and it posts publicly under
+// the moderator's own name, so seeing it first matters.
+//
+// Deliberately not a call to POST /api/v1/preview: that route is anonymous and
+// rate-limited to 5 requests / 10s per IP on a shared bucket, which is the
+// wrong shape for an authenticated moderator editing a reply. Here requireMod
+// is the gate, and the admin middleware's same-origin check comes for free.
+//
+// Returning HTML for the page to inject is safe for exactly the reason the
+// widget's preview is: renderMarkdown is the strict-allowlist sanitizer, and it
+// is the same function that produces the stored body_html.
+admin.post("/api/preview", async (c) => {
+	const user = await requireMod(c);
+	if (user instanceof Response) return user;
+	const body = await c.req.json<{ body_md?: unknown }>().catch(() => null);
+	if (!body) return c.json({ error: "invalid_body" }, 400);
+	const valid = validateBody(
+		typeof body.body_md === "string" ? body.body_md : "",
+	);
+	if (!valid.ok) {
+		return c.json(
+			valid.key === "err.body.too_long"
+				? { error: "body_too_long", max: valid.max }
+				: { error: "body_required" },
+			400,
+		);
+	}
+	return c.json({ html: renderMarkdown(valid.body) });
+});
+
 admin.post("/api/comments/:id", async (c) => {
 	const user = await requireMod(c);
 	if (user instanceof Response) return user;

--- a/tests/admin-js-context-escaping.test.ts
+++ b/tests/admin-js-context-escaping.test.ts
@@ -24,6 +24,10 @@ import {
 	renderWebhookForm,
 } from "../src/admin-ui/pages/webhooks";
 import { renderSavedReplyForm } from "../src/admin-ui/pages/saved-replies";
+import {
+	commentIdLiteral,
+	replyComposer,
+} from "../src/admin-ui/components/reply-composer";
 import { accessDeniedHtml } from "../src/admin-ui/layout";
 
 // A single quote closes the JS literal, `<` opens a tag once the attribute is
@@ -142,6 +146,45 @@ describe("the escaped literal survives the browser's decode", () => {
 		// JSON.parse accepts the same escapes JS string literals do, including
 		// the / / < that jsLiteral adds.
 		expect(JSON.parse(decodeEntities(literal ?? ""))).toBe(HOSTILE);
+	});
+});
+
+describe("replyComposer", () => {
+	// The composer is the one component whose Alpine blob is assembled from two
+	// different kinds of value: a comment id that ends up inside a JS string
+	// literal (jsLiteral), and the moderator's display name that ends up as HTML
+	// text (escapeHtml). Getting either helper backwards is invisible until the
+	// value is hostile.
+	it("embeds a hostile comment id as a JS literal in the fetch URL", () => {
+		const html = replyComposer({
+			commentIdExpr: commentIdLiteral(HOSTILE),
+			modName: "Mod",
+		});
+		expectNoBreakout(html);
+		expect(html).toContain("'/admin/api/comments/' + &quot;");
+	});
+
+	it("HTML-escapes the moderator name", () => {
+		const html = replyComposer({
+			commentIdExpr: "commentId",
+			modName: '<img src=x onerror=alert(1)>',
+		});
+		expect(html).not.toContain("<img src=x");
+		expect(html).toContain("&lt;img src=x");
+	});
+
+	it("keeps the x-data attribute intact — the id cannot close it", () => {
+		// The blob is written raw into a double-quoted attribute, so a raw `"`
+		// anywhere in the interpolated literal would truncate the expression and
+		// silently break the composer (the failure mode the section above records).
+		const html = replyComposer({
+			commentIdExpr: commentIdLiteral(HOSTILE),
+			modName: "Mod",
+		});
+		const attr = /x-data="([\s\S]*?)"\s*>/.exec(html)?.[1];
+		expect(attr).toBeDefined();
+		expect(attr).toContain("send()");
+		expect(attr).toContain("saveForReuse()");
 	});
 });
 

--- a/tests/admin-reply.test.ts
+++ b/tests/admin-reply.test.ts
@@ -1,0 +1,624 @@
+/**
+ * Ad hoc moderator replies — POST /admin/api/comments/:id/reply.
+ *
+ * The endpoint that replaced `POST /admin/api/saved-replies/:id/post`, which was
+ * keyed on a preset the mod had to invent first. Free text is now the canonical
+ * input and a saved reply is an optional *prefill* whose id survives only as
+ * audit provenance. Driven end-to-end against REAL SQLite with every migration
+ * applied, so the subscription filtering and the audit write are the production
+ * SQL, not a re-implementation.
+ *
+ * Covered:
+ *
+ *   - insert shape: nested under the target (parent_id/depth), authored by the
+ *     mod, status=approved, no ip_hash/user_agent, current renderer version;
+ *   - body is re-rendered through the sanitizer at post time — a <script> or
+ *     <img onerror> in body_md never reaches body_html;
+ *   - validation: empty body, body over MAX_BODY_CHARS, MAX_REPLY_DEPTH;
+ *   - notification fan-out: on by default, one row per *confirmed, subscribed*
+ *     subscriber, skipping the replying mod's own address; `notify: false`
+ *     writes none but still posts;
+ *   - audit provenance: `comment.reply` with saved_reply_id in the prefilled
+ *     case and null in the ad hoc case, and a claim on a saved reply the mod
+ *     can't see is refused;
+ *   - guards: no session → 401, non-mod → 403, cross-origin → 403, unknown or
+ *     deleted target → 404/400.
+ *
+ * `waitUntil` collects the fan-out promise so assertions can await it — a no-op
+ * waitUntil would race the enqueue.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ADMIN_ACTIONS, insertComment } from "../src/db/queries";
+import type { Bindings } from "../src/index";
+import { CURRENT_RENDERER_VERSION, MAX_BODY_CHARS } from "../src/lib/markdown";
+import { MAX_REPLY_DEPTH } from "../src/lib/tree";
+import { admin } from "../src/routes/admin";
+
+const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
+
+const makeD1 = (db: DatabaseSync): any => ({
+	prepare(sql: string) {
+		const stmt = db.prepare(sql);
+		let bound: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				bound = args;
+				return this;
+			},
+			async run() {
+				const r = stmt.run(...(bound as never[]));
+				return { success: true, meta: { changes: r.changes } };
+			},
+			async first() {
+				return stmt.get(...(bound as never[])) ?? null;
+			},
+			async all() {
+				return { results: stmt.all(...(bound as never[])) };
+			},
+		};
+	},
+});
+
+const SID = "a".repeat(64);
+const MOD_ID = "01HMOD00000000000000000AB";
+const USER_ID = "01HPLAIN000000000000000AB";
+const AUTHOR_ID = "01HAUTHOR000000000000000AB";
+const MOD_EMAIL = "mod@example.com";
+const TS = 1_700_000_000_000;
+
+const freshDb = () => {
+	const sqlite = new DatabaseSync(":memory:");
+	for (const file of readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+	}
+	return { sqlite, db: makeD1(sqlite) };
+};
+
+/** Session KV: SID maps to the mod by default, or to whichever id is set. */
+let sessionUserId = MOD_ID;
+const makeSessions = () => ({
+	async get(key: string) {
+		if (key !== `sess:${SID}`) return null;
+		return JSON.stringify({
+			user_id: sessionUserId,
+			expires_at: 4_102_444_800_000,
+		});
+	},
+	async put() {},
+	async delete() {},
+});
+
+const makeKv = () => {
+	const store = new Map<string, string>([
+		["meta:latest-release", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+		["meta:recent-releases", JSON.stringify({ kind: "null", fetchedAt: 1 })],
+	]);
+	return {
+		async get(key: string, type?: "json") {
+			const raw = store.get(key);
+			if (raw == null) return null;
+			return type === "json" ? JSON.parse(raw) : raw;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list({ prefix }: { prefix: string }) {
+			return {
+				keys: [...store.keys()]
+					.filter((k) => k.startsWith(prefix))
+					.map((name) => ({ name })),
+			};
+		},
+	};
+};
+
+let sqlite: DatabaseSync;
+let db: any;
+let env: Bindings;
+let deferred: Promise<unknown>[];
+
+const execCtx = () =>
+	({
+		waitUntil(p: Promise<unknown>) {
+			deferred.push(p);
+		},
+		passThroughOnException() {},
+	}) as unknown as ExecutionContext;
+
+const settle = async (): Promise<void> => {
+	await Promise.all(deferred);
+	deferred = [];
+};
+
+const seedComment = async (
+	opts: { depth?: number; status?: string; parent?: string | null } = {},
+): Promise<string> => {
+	const c = await insertComment(db, {
+		post_slug: "hello",
+		parent_id: opts.parent ?? null,
+		user_id: AUTHOR_ID,
+		body_md: "a comment",
+		body_html: "<p>a comment</p>",
+		renderer_version: CURRENT_RENDERER_VERSION,
+		status: (opts.status ?? "approved") as never,
+		ip_hash: null,
+		user_agent: null,
+		depth: opts.depth ?? 1,
+	});
+	return c.id;
+};
+
+const seedSubscription = (opts: {
+	id: string;
+	email: string;
+	confirmed?: boolean;
+	unsubscribed?: boolean;
+}): void => {
+	sqlite
+		.prepare(
+			`INSERT INTO subscriptions
+			   (id, post_slug, email, token, created_at, confirmed_at, unsubscribed_at)
+			 VALUES (?, 'hello', ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			opts.id,
+			opts.email,
+			`tok_${opts.id}`,
+			TS,
+			opts.confirmed === false ? null : TS,
+			opts.unsubscribed ? TS : null,
+		);
+};
+
+const seedSavedReply = (opts: {
+	id: string;
+	owner: string;
+	scope: "private" | "shared";
+	body?: string;
+}): void => {
+	sqlite
+		.prepare(
+			`INSERT INTO saved_replies
+			   (id, owner_id, title, body_md, scope, created_at, updated_at)
+			 VALUES (?, ?, 'Preset', ?, ?, ?, ?)`,
+		)
+		.run(opts.id, opts.owner, opts.body ?? "Preset body", opts.scope, TS, TS);
+};
+
+const commentRow = (id: string): Record<string, unknown> =>
+	sqlite.prepare("SELECT * FROM comments WHERE id = ?").get(id) as Record<
+		string,
+		unknown
+	>;
+
+const replies = (): Record<string, unknown>[] =>
+	sqlite
+		.prepare("SELECT * FROM comments WHERE user_id = ? ORDER BY created_at")
+		.all(MOD_ID) as Record<string, unknown>[];
+
+/** Subscription ids that have a queued notification for `commentId`. */
+const notifiedSubs = (commentId: string): string[] =>
+	(
+		sqlite
+			.prepare(
+				"SELECT subscription_id FROM notifications WHERE comment_id = ? ORDER BY subscription_id",
+			)
+			.all(commentId) as { subscription_id: string }[]
+	).map((r) => r.subscription_id);
+
+const lastReplyAudit = (): { meta: string | null } | undefined =>
+	sqlite
+		.prepare(
+			"SELECT meta FROM audit_log WHERE action = 'comment.reply' ORDER BY created_at DESC, id DESC LIMIT 1",
+		)
+		.get() as { meta: string | null } | undefined;
+
+beforeEach(() => {
+	const fresh = freshDb();
+	sqlite = fresh.sqlite;
+	db = fresh.db;
+	deferred = [];
+	sessionUserId = MOD_ID;
+	sqlite
+		.prepare(
+			`INSERT INTO users (id, provider, provider_id, name, email, is_admin, role, created_at)
+			 VALUES (?, 'github', '1', 'Mod', ?, 0, 'mod', ?)`,
+		)
+		.run(MOD_ID, MOD_EMAIL, TS);
+	sqlite
+		.prepare(
+			`INSERT INTO users (id, provider, provider_id, name, email, is_admin, role, created_at)
+			 VALUES (?, 'github', '2', 'Reader', 'reader@example.com', 0, 'user', ?)`,
+		)
+		.run(USER_ID, TS);
+	sqlite
+		.prepare(
+			"INSERT INTO users (id, provider, provider_id, name, created_at) VALUES (?, 'anon', NULL, 'Author', ?)",
+		)
+		.run(AUTHOR_ID, TS);
+	sqlite
+		.prepare("INSERT INTO posts (slug, created_at) VALUES ('hello', ?)")
+		.run(TS);
+	env = {
+		DB: db,
+		TREE_CACHE: makeKv(),
+		SESSIONS: makeSessions(),
+	} as unknown as Bindings;
+});
+
+const app = () => new Hono<{ Bindings: Bindings }>().route("/admin", admin);
+
+const reply = (
+	id: string,
+	payload: Record<string, unknown>,
+	opts: { cookie?: boolean; origin?: string | null } = {},
+) => {
+	const { cookie = true, origin = "http://localhost" } = opts;
+	const headers: Record<string, string> = {
+		"content-type": "application/json",
+	};
+	if (cookie) headers.cookie = `__Host-garrul_sess=${SID}`;
+	if (origin) headers.origin = origin;
+	return app().request(
+		`/admin/api/comments/${id}/reply`,
+		{ method: "POST", headers, body: JSON.stringify(payload) },
+		env as unknown as Record<string, unknown>,
+		execCtx(),
+	);
+};
+
+/** Post a reply that is expected to succeed, returning the new comment's id. */
+const replyId = async (
+	id: string,
+	payload: Record<string, unknown>,
+): Promise<string> => {
+	const res = await reply(id, payload);
+	expect(res.status).toBe(200);
+	return ((await res.json()) as { id: string }).id;
+};
+
+describe("POST /admin/api/comments/:id/reply — insert shape", () => {
+	it("posts ad hoc free text nested under the target, authored by the mod", async () => {
+		const target = await seedComment({ depth: 2 });
+		const res = await reply(target, { body_md: "**thanks** for the report" });
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { ok: boolean; id: string };
+		expect(json.ok).toBe(true);
+		await settle();
+
+		const row = commentRow(json.id);
+		expect(row.parent_id).toBe(target);
+		expect(row.depth).toBe(3);
+		expect(row.user_id).toBe(MOD_ID);
+		expect(row.post_slug).toBe("hello");
+		expect(row.status).toBe("approved");
+		expect(row.renderer_version).toBe(CURRENT_RENDERER_VERSION);
+		// Posted by a signed-in mod through the admin panel: there is no reader
+		// request to fingerprint, and storing the mod's own would be new PII.
+		expect(row.ip_hash).toBeNull();
+		expect(row.user_agent).toBeNull();
+		expect(row.body_md).toBe("**thanks** for the report");
+		expect(row.body_html).toContain("<strong>thanks</strong>");
+	});
+
+	it("works with no saved reply in the database at all", async () => {
+		// The whole point of the feature: replying must not require inventing a
+		// preset first.
+		const target = await seedComment();
+		const res = await reply(target, { body_md: "one-off answer" });
+		expect(res.status).toBe(200);
+		await settle();
+		expect(replies()).toHaveLength(1);
+	});
+});
+
+describe("POST /admin/api/comments/:id/reply — sanitization", () => {
+	it("strips a <script> from the stored html", async () => {
+		const target = await seedComment();
+		const res = await reply(target, {
+			body_md: "Hi <script>alert(1)</script> there",
+		});
+		const { id } = (await res.json()) as { id: string };
+		await settle();
+		const html = commentRow(id).body_html as string;
+		expect(html).not.toContain("<script>");
+		expect(html).not.toContain("</script>");
+	});
+
+	it("strips <img onerror=..> from the stored html", async () => {
+		const target = await seedComment();
+		const res = await reply(target, { body_md: '<img src=x onerror="x()">' });
+		const { id } = (await res.json()) as { id: string };
+		await settle();
+		const html = commentRow(id).body_html as string;
+		expect(html).not.toContain("onerror");
+		expect(html).not.toContain("<img");
+	});
+});
+
+describe("POST /admin/api/comments/:id/reply — validation", () => {
+	it("rejects an empty body", async () => {
+		const target = await seedComment();
+		const res = await reply(target, { body_md: "   " });
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "body_required" });
+		expect(replies()).toHaveLength(0);
+	});
+
+	it("rejects a missing body_md", async () => {
+		const target = await seedComment();
+		const res = await reply(target, {});
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "body_required" });
+	});
+
+	it("accepts a body at MAX_BODY_CHARS and rejects one char more", async () => {
+		const target = await seedComment();
+		const ok = await reply(target, { body_md: "x".repeat(MAX_BODY_CHARS) });
+		expect(ok.status).toBe(200);
+
+		const tooLong = await reply(target, {
+			body_md: "x".repeat(MAX_BODY_CHARS + 1),
+		});
+		expect(tooLong.status).toBe(400);
+		expect(await tooLong.json()).toEqual({
+			error: "body_too_long",
+			max: MAX_BODY_CHARS,
+		});
+		await settle();
+		expect(replies()).toHaveLength(1);
+	});
+
+	it("refuses to exceed MAX_REPLY_DEPTH", async () => {
+		const target = await seedComment({ depth: MAX_REPLY_DEPTH });
+		const res = await reply(target, { body_md: "too deep" });
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "thread_too_deep" });
+		expect(replies()).toHaveLength(0);
+	});
+
+	it("404s an unknown target and 400s a deleted one", async () => {
+		const missing = await reply("01HNOPE0000000000000000000", {
+			body_md: "hi",
+		});
+		expect(missing.status).toBe(404);
+
+		const gone = await seedComment({ status: "deleted" });
+		const res = await reply(gone, { body_md: "hi" });
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "comment_deleted" });
+		expect(replies()).toHaveLength(0);
+	});
+});
+
+describe("POST /admin/api/comments/:id/reply — notification fan-out", () => {
+	it("notifies confirmed subscribers by default and skips the mod's own address", async () => {
+		seedSubscription({ id: "sub_a", email: "a@example.com" });
+		seedSubscription({ id: "sub_b", email: "b@example.com" });
+		seedSubscription({ id: "sub_self", email: MOD_EMAIL });
+		const target = await seedComment();
+
+		const res = await reply(target, { body_md: "answered" });
+		expect(await res.json()).toMatchObject({ ok: true, notified: true });
+		const id = await replyId(target, { body_md: "again" });
+		await settle();
+
+		expect(notifiedSubs(id)).toEqual(["sub_a", "sub_b"]);
+	});
+
+	it("writes no notifications when notify is false, but still posts", async () => {
+		seedSubscription({ id: "sub_a", email: "a@example.com" });
+		const target = await seedComment();
+
+		const res = await reply(target, { body_md: "quiet note", notify: false });
+		expect(await res.json()).toMatchObject({ notified: false });
+		await settle();
+
+		expect(replies()).toHaveLength(1);
+		expect(
+			sqlite.prepare("SELECT COUNT(*) AS n FROM notifications").get(),
+		).toEqual({ n: 0 });
+	});
+
+	it("skips unconfirmed and unsubscribed subscriptions", async () => {
+		// Asserts we inherited listActiveSubscriptionsForPost's filtering rather
+		// than re-rolling the WHERE clause in the admin route.
+		seedSubscription({ id: "sub_live", email: "live@example.com" });
+		seedSubscription({
+			id: "sub_pending",
+			email: "pending@example.com",
+			confirmed: false,
+		});
+		seedSubscription({
+			id: "sub_gone",
+			email: "gone@example.com",
+			unsubscribed: true,
+		});
+		const target = await seedComment();
+
+		const id = await replyId(target, { body_md: "hello" });
+		await settle();
+
+		expect(notifiedSubs(id)).toEqual(["sub_live"]);
+	});
+
+	it("does not notify subscribers of a different post", async () => {
+		sqlite
+			.prepare("INSERT INTO posts (slug, created_at) VALUES ('other', ?)")
+			.run(TS);
+		sqlite
+			.prepare(
+				`INSERT INTO subscriptions (id, post_slug, email, token, created_at, confirmed_at)
+				 VALUES ('sub_other', 'other', 'other@example.com', 'tok_other', ?, ?)`,
+			)
+			.run(TS, TS);
+		const target = await seedComment();
+
+		const id = await replyId(target, { body_md: "hello" });
+		await settle();
+
+		expect(notifiedSubs(id)).toEqual([]);
+	});
+});
+
+describe("POST /admin/api/comments/:id/reply — audit provenance", () => {
+	it("records comment.reply with no saved reply for ad hoc text", async () => {
+		const target = await seedComment();
+		const id = await replyId(target, { body_md: "ad hoc" });
+		await settle();
+
+		const meta = JSON.parse(lastReplyAudit()?.meta ?? "{}");
+		expect(meta.from_saved_reply).toBe(false);
+		expect(meta.saved_reply_id).toBeNull();
+		expect(meta.parent_id).toBe(target);
+		expect(meta.post_slug).toBe("hello");
+		expect(meta.notify_subscribers).toBe(true);
+		expect(
+			sqlite
+				.prepare(
+					"SELECT target_id FROM audit_log WHERE action = 'comment.reply'",
+				)
+				.get(),
+		).toEqual({ target_id: id });
+	});
+
+	it("records the saved reply that prefilled the body", async () => {
+		seedSavedReply({ id: "sr_own", owner: MOD_ID, scope: "private" });
+		const target = await seedComment();
+		const res = await reply(target, {
+			body_md: "Preset body",
+			saved_reply_id: "sr_own",
+		});
+		expect(res.status).toBe(200);
+		await settle();
+
+		const meta = JSON.parse(lastReplyAudit()?.meta ?? "{}");
+		expect(meta.from_saved_reply).toBe(true);
+		expect(meta.saved_reply_id).toBe("sr_own");
+	});
+
+	it("accepts a shared saved reply owned by someone else", async () => {
+		seedSavedReply({ id: "sr_shared", owner: AUTHOR_ID, scope: "shared" });
+		const target = await seedComment();
+		const res = await reply(target, {
+			body_md: "Preset body",
+			saved_reply_id: "sr_shared",
+		});
+		expect(res.status).toBe(200);
+		await settle();
+		expect(JSON.parse(lastReplyAudit()?.meta ?? "{}").saved_reply_id).toBe(
+			"sr_shared",
+		);
+	});
+
+	it("refuses to credit a saved reply the mod cannot see", async () => {
+		seedSavedReply({ id: "sr_private", owner: AUTHOR_ID, scope: "private" });
+		const target = await seedComment();
+		const res = await reply(target, {
+			body_md: "borrowed",
+			saved_reply_id: "sr_private",
+		});
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "saved_reply_not_visible" });
+		expect(replies()).toHaveLength(0);
+	});
+
+	it("refuses an unknown saved reply id, and a non-string one", async () => {
+		const target = await seedComment();
+		const missing = await reply(target, {
+			body_md: "x",
+			saved_reply_id: "sr_nope",
+		});
+		expect(missing.status).toBe(400);
+		expect(await missing.json()).toEqual({ error: "saved_reply_not_visible" });
+
+		const wrongType = await reply(target, { body_md: "x", saved_reply_id: 7 });
+		expect(wrongType.status).toBe(400);
+		expect(await wrongType.json()).toEqual({ error: "invalid_body" });
+		expect(replies()).toHaveLength(0);
+	});
+});
+
+describe("POST /admin/api/comments/:id/reply — guards", () => {
+	it("rejects an unauthenticated request", async () => {
+		const target = await seedComment();
+		const res = await reply(target, { body_md: "hi" }, { cookie: false });
+		expect(res.status).toBe(401);
+		expect(replies()).toHaveLength(0);
+	});
+
+	it("rejects a plain (non-mod) user", async () => {
+		sessionUserId = USER_ID;
+		const target = await seedComment();
+		const res = await reply(target, { body_md: "hi" });
+		expect(res.status).toBe(403);
+		expect(replies()).toHaveLength(0);
+	});
+
+	it("rejects a cross-origin request (CSRF)", async () => {
+		const target = await seedComment();
+		const res = await reply(
+			target,
+			{ body_md: "hi" },
+			{ origin: "https://evil.example" },
+		);
+		expect(res.status).toBe(403);
+		expect(replies()).toHaveLength(0);
+	});
+});
+
+describe("POST /admin/api/preview", () => {
+	const preview = (payload: Record<string, unknown>, cookie = true) => {
+		const headers: Record<string, string> = {
+			"content-type": "application/json",
+			origin: "http://localhost",
+		};
+		if (cookie) headers.cookie = `__Host-garrul_sess=${SID}`;
+		return app().request(
+			"/admin/api/preview",
+			{ method: "POST", headers, body: JSON.stringify(payload) },
+			env as unknown as Record<string, unknown>,
+			execCtx(),
+		);
+	};
+
+	it("renders markdown through the same sanitizer, without persisting", async () => {
+		const res = await preview({
+			body_md: "**bold** <script>alert(1)</script>",
+		});
+		expect(res.status).toBe(200);
+		const { html } = (await res.json()) as { html: string };
+		expect(html).toContain("<strong>bold</strong>");
+		expect(html).not.toContain("<script>");
+		expect(
+			sqlite.prepare("SELECT COUNT(*) AS n FROM comments").get(),
+		).toEqual({ n: 0 });
+	});
+
+	it("rejects an empty body and an unauthenticated caller", async () => {
+		expect((await preview({ body_md: " " })).status).toBe(400);
+		expect((await preview({ body_md: "hi" }, false)).status).toBe(401);
+	});
+});
+
+describe("ADMIN_ACTIONS", () => {
+	it("offers comment.reply to the audit filter", async () => {
+		expect(ADMIN_ACTIONS).toContain("comment.reply");
+	});
+
+	it("keeps saved_reply.post so historical rows stay filterable", async () => {
+		// Nothing writes it since the saved-reply post endpoint was removed, but
+		// this array is the allowlist the audit dropdown and the `?action=` query
+		// validate against — dropping it would make old rows unfilterable.
+		expect(ADMIN_ACTIONS).toContain("saved_reply.post");
+	});
+});

--- a/tests/admin-reply.test.ts
+++ b/tests/admin-reply.test.ts
@@ -378,6 +378,18 @@ describe("POST /admin/api/comments/:id/reply — validation", () => {
 		expect(replies()).toHaveLength(1);
 	});
 
+	it("rejects a non-boolean notify instead of coercing it", async () => {
+		// The failure this guards is one-directional: a client meaning "don't
+		// email" that sends `"false"` or `0` would otherwise mail the thread.
+		const target = await seedComment();
+		for (const notify of ["false", 0, "true", {}]) {
+			const res = await reply(target, { body_md: "hi", notify });
+			expect(res.status).toBe(400);
+			expect(await res.json()).toEqual({ error: "invalid_body" });
+		}
+		expect(replies()).toHaveLength(0);
+	});
+
 	it("refuses to exceed MAX_REPLY_DEPTH", async () => {
 		const target = await seedComment({ depth: MAX_REPLY_DEPTH });
 		const res = await reply(target, { body_md: "too deep" });


### PR DESCRIPTION
**Why**

Replying to a comment from the admin panel required first inventing a **saved reply**. The queue's modal hid its textarea behind `x-show="selected"`, `send()` early-returned without a selection, and the endpoint itself was keyed on a saved-reply id (`POST /admin/api/saved-replies/:id/post`). An operator who wanted to type one sentence had to create a preset for something they would say once — the empty state literally read *"No saved replies yet — create one."*

The model was backwards. Free text is the general case; a saved reply is a *prefill* of it. This inverts that, and fixes the thing that was genuinely missing: **admin-panel replies notified nobody.** `src/routes/admin.ts` never imported `enqueueNotification`, so a moderator reply fired a webhook and busted cache while the thread's subscribers heard nothing.

**What changes**

- **New canonical endpoint** `POST /admin/api/comments/:id/reply` — `{body_md, saved_reply_id?, notify?}`. Validates against `MAX_BODY_CHARS` (10 000) because it inserts a *comment*, not a preset; nests under the target, authored by the signed-in mod, `status='approved'`, no `ip_hash`/`user_agent`, `MAX_REPLY_DEPTH` still enforced, tree cache busted, `comment.posted` webhook fired. `saved_reply_id` is **audit provenance only** and still passes the owner-or-shared visibility check, so an audit row can't name a preset the mod can't see.
- **Notification fan-out**, mirroring the widget path in `src/routes/api.comments.ts` — including the `waitUntil`-or-`await` shape, which exists because the runtime can cancel an orphan promise once the response settles and a lost row is a silently unsent email. `notify` defaults **on**; the mod's own address is always skipped. No schema or digest change: rows drain through the existing cron and render as a normal named author.
- **Shared composer** `src/admin-ui/components/reply-composer.ts`, rendered by both the queue modal and `/admin/comments/:id` so the two can't drift. Free-text textarea, markdown **Preview**, notify checkbox, collapsed "Insert a saved reply" picker, **Save for reuse** (title + scope, POSTing the existing saved-replies route with no server change), and a "posting as *name*" line — attribution matters more now that replying is routine, since a shared admin login otherwise puts the wrong face on every reply.
- **New** `POST /admin/api/preview` behind `requireMod`. Deliberately not reusing `/api/v1/preview`, which is anonymous and rate-limited to 5 req/10 s per IP on a shared bucket. Renders through the same allowlist sanitizer that produces stored `body_html`, which is why `x-html` injection is safe here.
- **Removed** `POST /admin/api/saved-replies/:id/post`. `"saved_reply.post"` stays in `ADMIN_ACTIONS` — that array is the allowlist both the audit dropdown and the `?action=` query validate against, so dropping it would make historical rows unfilterable.
- New audit action `"comment.reply"`, meta `{from_saved_reply, saved_reply_id, parent_id, post_slug, notify_subscribers}`.

**Worth knowing before merge**

Subscriptions are **thread-scoped, not comment-scoped** (`subscriptions` is `UNIQUE(post_slug, email)`), so "notify" emails every confirmed subscriber on the post rather than only the person replied to. There is no per-comment notify primitive anywhere in Garrul; adding one would be a schema change. `AGENTS-OPERATE.md` says this explicitly rather than letting an operator infer targeting that doesn't exist.

No new env var, no migration, no `src/lib/cors.ts` change — the admin router has its own strict same-origin guard, so every POST here is CSRF-covered already.

**Linked issue**

none

**Checks**

- [x] `npm run lint` — unchanged (1 pre-existing CSS descending-specificity warning)
- [x] `npm run typecheck`
- [x] `npm test` — 1797 tests / 114 files
- [x] Updated tests for changed behavior — new `tests/admin-reply.test.ts` (25 cases) drives both endpoints against **real SQLite with every migration applied**: insert shape, sanitizer re-render, empty/over-cap body, `thread_too_deep`, fan-out (default on, skips the mod's own address, inherits `listActiveSubscriptionsForPost`'s confirmed/unsubscribed filtering), `notify: false` writing zero rows, audit provenance in both directions, and the 401/403/404 guards. `waitUntil` collects the fan-out promise so assertions await it — a no-op `waitUntil` would race the enqueue and pass for the wrong reason. `tests/admin-js-context-escaping.test.ts` gains the composer, the one component mixing a `jsLiteral` id with an `escapeHtml` display name.
- [x] Updated docs — `AGENTS-OPERATE.md` gains a **Replying from the admin panel** section, a rewritten **Saved replies** paragraph, and both new endpoints. Neither `docs-sync.yml` gate fires for these paths and there is no new env var; updated anyway because the guide described the old behavior.

**Not verified**

The composer's fetch round trip has never run in a real browser — the server side is test-covered, the Alpine layer is not. Worth one manual pass through `/admin/queue` and `/admin/comments/:id` under `npx wrangler dev --local-upstream localhost` before this ships.
