### PR TITLE
feat: comment permalinks and accessibility pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,19 +449,30 @@ widget knows at mount time:
    where the host page and the Worker live on different origins: the
    link falls back to `location.href` with the same
    `#garrul-comment-<id>` anchor.
-3. **Neither resolves** — the document's origin *matches* the API
-   origin, which happens in the iframe variant (§6) with no `?url=`
-   passed, where the document being linked from **is** the Worker's
-   own `/embed/:slug` page: the link falls back to the Worker's
-   `GET /c/:id`, which 302s to the comment's stored post URL plus the
-   same anchor.
+3. **Neither resolves** — either the document's origin *matches* the
+   API origin, which happens in the iframe variant (§6) with no
+   `?url=` passed, where the document being linked from **is** the
+   Worker's own `/embed/:slug` page; or `location.href` is not an
+   absolute http(s) URL at all (`about:srcdoc`, `blob:`, `file:`). The
+   link falls back to the Worker's `GET /c/:id`, which 302s to the
+   comment's stored post URL plus the same anchor.
 
 Rung 3 exists for durability (a permalink shared from an iframe embed
 still resolves after the post moves) but is deliberately the last
 resort, not the default: every click of `/c/:id` is a Worker
 invocation against the 100,000 requests/day free tier, where the
-host-page anchor costs nothing. It also 404s when the post has no
-`url` on file, which is why rungs 1 and 2 are tried first.
+host-page anchor costs nothing.
+
+It is also the rung with the most ways to miss, and the failure is
+always a 404 or a link that lands nowhere rather than a wrong comment.
+`/c/:id` 404s when the post has no `url` on file, when that URL fails
+to parse or is not http(s), and for any comment whose status is
+`pending`, `spam` or `deleted` — a moderation-queue entry has no
+public permalink. And when the stored post URL *already* carries a
+fragment, the redirect appends with `&` rather than `#`, producing
+`<url>#frag&garrul-comment-<id>`, which matches no element and scrolls
+nowhere. Rungs 1 and 2 have none of these failure modes, which is why
+they are tried first.
 
 The link is a plain `<a href>` — no clipboard-copy JavaScript shim —
 so right-click-copy, middle-click, and Cmd/Ctrl-click all work the way

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,11 +468,11 @@ always a 404 or a link that lands nowhere rather than a wrong comment.
 `/c/:id` 404s when the post has no `url` on file, when that URL fails
 to parse or is not http(s), and for any comment whose status is
 `pending`, `spam` or `deleted` — a moderation-queue entry has no
-public permalink. And when the stored post URL *already* carries a
-fragment, the redirect appends with `&` rather than `#`, producing
-`<url>#frag&garrul-comment-<id>`, which matches no element and scrolls
-nowhere. Rungs 1 and 2 have none of these failure modes, which is why
-they are tried first.
+public permalink. A stored post URL that *already* carries a fragment
+is not one of those ways: the redirect replaces that fragment rather
+than joining to it with `&`, matching how rungs 1 and 2 build their
+anchors. Rungs 1 and 2 have none of the remaining failure modes, which
+is why they are tried first.
 
 The link is a plain `<a href>` — no clipboard-copy JavaScript shim —
 so right-click-copy, middle-click, and Cmd/Ctrl-click all work the way

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,40 @@ and a sort selector above the list. Neither needs any host-page wiring:
   chronological. The selection is per-mount UI state — it isn't
   persisted and can't be preset from the host element.
 
+### Per-comment permalinks (since v2.17.0)
+
+Each comment's timestamp is now a link to that one comment, with no
+host-page wiring required. What it resolves to depends on what the
+widget knows at mount time:
+
+1. **`data-url` is set** (recommended — see §4): the link is
+   `<data-url>#garrul-comment-<id>`.
+2. **No `data-url`, and the document's own origin differs from the
+   Worker's API origin** — the normal case for a script-tag embed,
+   where the host page and the Worker live on different origins: the
+   link falls back to `location.href` with the same
+   `#garrul-comment-<id>` anchor.
+3. **Neither resolves** — the document's origin *matches* the API
+   origin, which happens in the iframe variant (§6) with no `?url=`
+   passed, where the document being linked from **is** the Worker's
+   own `/embed/:slug` page: the link falls back to the Worker's
+   `GET /c/:id`, which 302s to the comment's stored post URL plus the
+   same anchor.
+
+Rung 3 exists for durability (a permalink shared from an iframe embed
+still resolves after the post moves) but is deliberately the last
+resort, not the default: every click of `/c/:id` is a Worker
+invocation against the 100,000 requests/day free tier, where the
+host-page anchor costs nothing. It also 404s when the post has no
+`url` on file, which is why rungs 1 and 2 are tried first.
+
+The link is a plain `<a href>` — no clipboard-copy JavaScript shim —
+so right-click-copy, middle-click, and Cmd/Ctrl-click all work the way
+a reader expects. `#garrul-comment-<id>` is the `id` the widget already
+stamps on every thread node's wrapper element, and the same anchor the
+per-post RSS feed (`/feed/:slug`) links to, so a permalink shared from
+either surface lands on the same spot once the widget mounts.
+
 ### Page-level reactions and votes (since v1.10.0)
 
 Separate from comment-level engagement, the widget can render an

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -120,6 +120,18 @@ would otherwise stay light inside a dark widget. A pinned `data-theme` wins
 over the OS preference here too, so `data-theme="light"` on a dark-OS reader
 does not leave them a dark dropdown over a light thread.
 
+The dark palette paints its own background (`#12161a` by default, via
+`--garrul-bg`). To make the widget blend with your host page's dark background,
+override `--garrul-bg` to match:
+
+```css
+#garrul { --garrul-bg: var(--my-page-bg, #0a0a0a); }
+```
+
+**Known limitation:** A widget pinned to `data-theme="light"` on a dark host
+page will inherit the page's background and become hard to read. Override
+`--garrul-bg` to light (e.g. `#fff`) in this scenario.
+
 **Precedence (highest wins):**
 
 1. An explicit `--garrul-*` override you set on the host or an ancestor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.16.0",
+  "version": "2.17.0",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 2,

--- a/src/lib/identicon.ts
+++ b/src/lib/identicon.ts
@@ -47,5 +47,5 @@ export const identiconSvg = (seed: string, size = 48): string => {
 		}
 	}
 
-	return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" role="img" aria-label="identicon"><rect width="${size}" height="${size}" fill="${bg}"/>${rects.join("")}</svg>`;
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" aria-hidden="true"><rect width="${size}" height="${size}" fill="${bg}"/>${rects.join("")}</svg>`;
 };

--- a/src/routes/permalink.ts
+++ b/src/routes/permalink.ts
@@ -17,6 +17,11 @@
 import { Hono } from "hono";
 import type { Bindings } from "../index";
 import { getComment, getPost } from "../db/queries";
+// The anchor id has one source of truth, in the widget that stamps it onto each
+// thread node. Server-imports-widget is the established direction here (see
+// routes/api.reactions.ts pulling from ../widget/reactions) — the widget cannot
+// import server code, because tsconfig.widget.json includes only src/widget/**.
+import { commentAnchorId } from "../widget/permalink";
 
 const permalink = new Hono<{ Bindings: Bindings }>();
 
@@ -51,9 +56,16 @@ permalink.get("/:id", async (c) => {
 		return c.text("post URL invalid", 404);
 	}
 
-	const target = `${post.url}${post.url.includes("#") ? "&" : "#"}garrul-comment-${id}`;
+	// Build the fragment on the parsed URL rather than by string concatenation.
+	// A stored `post.url` that already carries a fragment used to be joined with
+	// `&` — `…/post/#section-2&garrul-comment-<id>` — which is a single fragment
+	// named `section-2&garrul-comment-<id>`, matching no element and defeating
+	// the whole redirect. Assigning `.hash` replaces the existing fragment
+	// instead, the same rule the widget's own resolver follows
+	// (`withAnchor` in src/widget/permalink.ts).
+	parsed.hash = commentAnchorId(id);
 	c.header("cache-control", "public, max-age=300");
-	return c.redirect(target, 302);
+	return c.redirect(parsed.toString(), 302);
 });
 
 export { permalink };

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2765,9 +2765,9 @@ const setSort = (root: ShadowRoot, sort: SortKey): void => {
  * first. That case is backlog #45 and is deliberately not solved here; the
  * caller falls back to the live region.
  *
- * The `tabindex="-1"` is left in place after focus moves away: re-focusing the
- * same comment later (e.g. via a permalink click) should work the same way, and
- * it costs nothing.
+ * The `tabindex="-1"` is left in place after focus moves away: it keeps the
+ * article out of the sequential tab order permanently, costs nothing to leave,
+ * and poses no risk to future interactions (focus or otherwise).
  */
 const focusPostedComment = (root: ShadowRoot, id: string): boolean => {
 	const node = root.getElementById(commentAnchorId(id));
@@ -3419,6 +3419,9 @@ const submit = async (
 			// and announce success there.
 			if (errEl) {
 				showStatus(errEl, s("w.posted"), "notice");
+				// Make the status box focusable (it's a plain <div> with no tabindex).
+				// -1 keeps it out of tab order but allows programmatic focus.
+				errEl.tabIndex = -1;
 				errEl.focus();
 			}
 		}

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2885,10 +2885,8 @@ const loadOnce = async (
 			// locale's own overrides, not a merged copy — makeS falls back to the
 			// bundled English per key, so a partial translation renders English
 			// exactly where it is incomplete and correct everywhere else.
-			host.lang = locale;
 			if (typeof cfg.locale === "string" && cfg.locale) {
 				locale = cfg.locale;
-				host.lang = locale;
 				({ s, sAround } = makeS(
 					(cfg.strings ?? {}) as StringTable,
 					locale,
@@ -2929,6 +2927,12 @@ const loadOnce = async (
 			if (typeof cfg.community_collapse_ratio === "number")
 				communityCollapseRatio = cfg.community_collapse_ratio;
 		}
+		// Stamp the language the widget actually ended up rendering in, not the
+		// one it hoped for. Unconditional on purpose: a server that omits
+		// `locale`, or a config fetch that came back empty, still renders the
+		// bundled English — and a screen reader given no `lang` here falls back
+		// to the host page's, which is exactly the case where the two disagree.
+		host.lang = locale;
 	} catch {
 		// The config is optional; the widget still renders without Turnstile (the
 		// server will reject anonymous POSTs in that case). Only the legacy branch

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2752,7 +2752,15 @@ const fetchMe = async (apiBase: string): Promise<Me> => {
 // silently land in a different order than the page the reader is looking at.
 const loadState = new WeakMap<
 	ShadowRoot,
-	{ running: boolean; queued: boolean; sort: SortKey | null }
+	{
+		running: boolean;
+		queued: boolean;
+		sort: SortKey | null;
+		// The anchor id (see commentAnchorId) of the last hash target actually
+		// revealed for this root — see revealHashTarget below. `null` until a
+		// hash reveal has succeeded at least once.
+		revealedHash: string | null;
+	}
 >();
 
 const load = async (
@@ -2763,7 +2771,7 @@ const load = async (
 ): Promise<void> => {
 	let st = loadState.get(root);
 	if (!st) {
-		st = { running: false, queued: false, sort: null };
+		st = { running: false, queued: false, sort: null, revealedHash: null };
 		loadState.set(root, st);
 		// Wire the permalink reveal to same-document fragment navigations here
 		// rather than in init(): a naive addEventListener at the reveal's own
@@ -2796,6 +2804,43 @@ const load = async (
 const setSort = (root: ShadowRoot, sort: SortKey): void => {
 	const st = loadState.get(root);
 	if (st) st.sort = sort;
+};
+
+// A per-root "focus and announce after the next render" request. `submit()`,
+// a reply, an edit, a moderation delete and the reaction legacy-API fallback
+// all trigger a reload, and `loadOnce` destroys the old tree
+// (`root.replaceChildren()`) before any code written after `ctx.reload()`
+// gets a chance to touch it — so what should happen once the *new* tree
+// lands has to be stashed here instead, and consumed by loadOnce itself
+// (see the arbitration at its tail, below `root.append(style, wrap)`).
+//
+// A WeakMap keyed on the request's own root, not queued as a list: only the
+// most recent request matters, and this also has to survive the
+// queued-reload race in `load()` above — if a second load() call arrives
+// while one is running, `st.queued` fires a follow-up `load()` after the
+// first finishes, and it is that follow-up's `loadOnce` (the one that
+// actually renders last) which must be the one to consume the request, not
+// whichever render happened to run first. A WeakMap already keyed by root
+// does this for free: whichever loadOnce runs last reads-and-deletes
+// whatever is there, with no separate flag needed to track who "owns" it.
+type PendingReveal = { id: string | null; announce?: string };
+const pendingReveal = new WeakMap<ShadowRoot, PendingReveal>();
+
+/**
+ * Setter for `pendingReveal`. Called directly by `submit()` (it has `root`
+ * in scope but no `ctx`); wrapped as `ctx.revealAfterReload` for the other
+ * four reload sites, which have `ctx` but would otherwise need `root`
+ * threaded through just for this.
+ */
+const revealAfterReload = (
+	root: ShadowRoot,
+	id: string | null,
+	announce?: string,
+): void => {
+	// Built conditionally rather than `{ id, announce }`: exactOptionalPropertyTypes
+	// treats an explicit `announce: undefined` as different from the key being
+	// absent, and PendingReveal's `announce?` means the latter.
+	pendingReveal.set(root, announce !== undefined ? { id, announce } : { id });
 };
 
 /**
@@ -2832,12 +2877,26 @@ const focusPostedComment = (root: ShadowRoot, id: string): boolean => {
  * Silent no-op when the hash isn't one of ours, or when it is but the
  * comment isn't in the rendered tree — a hash for another page, or one that
  * hasn't loaded yet, must never surface as an error.
+ *
+ * Reveals a given hash at most once per root. Scrolling alone was harmless
+ * on every reload, because the re-render was already resetting scroll
+ * position; moving focus is not — a reader who followed a permalink, read on,
+ * and then changed sort order or posted a reply must not be yanked back onto
+ * a comment they already left. `loadState.revealedHash` tracks the last hash
+ * that actually found its target; the browser itself only fires `hashchange`
+ * for a hash that actually changed, so gating on "already revealed this one"
+ * here matches what a reader can actually re-trigger. Returns whether it
+ * revealed anything, so loadOnce's arbitration can fall through when it
+ * didn't.
  */
-const revealHashTarget = (root: ShadowRoot): void => {
+const revealHashTarget = (root: ShadowRoot): boolean => {
 	const id = commentIdFromHash(window.location.hash);
-	if (!id) return;
-	const target = root.getElementById(commentAnchorId(id));
-	if (!target) return;
+	if (!id) return false;
+	const anchorId = commentAnchorId(id);
+	const st = loadState.get(root);
+	if (st?.revealedHash === anchorId) return false;
+	const target = root.getElementById(anchorId);
+	if (!target) return false;
 	// The CSS half of the reduced-motion promise lives in styles.css; scroll
 	// behavior is set here, so it has to be honored here too. `matchMedia` is
 	// guarded because the widget also runs under the iframe route and in test
@@ -2852,6 +2911,11 @@ const revealHashTarget = (root: ShadowRoot): void => {
 	// Scrolling alone only serves a sighted mouse user; move the caret too so
 	// keyboard and screen-reader users land on the comment (WCAG 2.4.3).
 	focusPostedComment(root, id);
+	// Record only on success: a hash pointing at a comment that hasn't
+	// rendered yet (paged thread, or a reload still in flight) must not count
+	// as revealed, so a later Load More or reload can still catch it.
+	if (st) st.revealedHash = anchorId;
+	return true;
 };
 
 // Closed-state notice copy, picked from the server's closed_reason enum so the
@@ -3233,10 +3297,44 @@ const loadOnce = async (
 
 	root.append(style, wrap);
 
-	// Reveal a permalink target (#garrul-comment-<id>) now that the tree is in
-	// the DOM. hashchange (see load(), above) covers the same-document
-	// navigation case; this call covers mount and every later reload.
-	revealHashTarget(root);
+	// Arbitrate what takes focus now that the fresh tree is in the DOM. At
+	// most one thing wins:
+	//   1. a pending reveal request (the reader just posted, replied, edited,
+	//      deleted, or reacted) — it's something they just did, so it beats
+	//      restoring a hash target they may have long since read past;
+	//   2. otherwise an unrevealed hash target (see revealHashTarget's own
+	//      once-per-hash guard) — covers mount, and any reload while a
+	//      permalink's hash is still set and hasn't been shown yet;
+	//   3. otherwise nothing; focus is left alone.
+	// Read-then-delete rather than a plain read: this is also what makes the
+	// mechanism correct under the queued-reload race in load() above. If a
+	// second load() arrives while one is running, that reload is queued and
+	// re-runs after this loadOnce returns — so whichever loadOnce call
+	// happens to run *last* is the one whose render the reader actually
+	// sees, and deleting the entry here means that last render is always the
+	// one that consumes it, never a stale one an earlier, superseded render
+	// already read.
+	const pending = pendingReveal.get(root);
+	pendingReveal.delete(root);
+	if (pending) {
+		const revealed = pending.id != null && focusPostedComment(root, pending.id);
+		// The status box in the tree just appended above — not whatever
+		// `.gr-error` a caller captured before this reload, which belongs to
+		// the node `root.replaceChildren()` just destroyed.
+		const statusEl = form.querySelector(".gr-error") as HTMLElement | null;
+		if (pending.announce && statusEl) {
+			showStatus(statusEl, pending.announce, "notice");
+		}
+		if (!revealed && statusEl) {
+			// Comment not in the rendered tree (paged thread, hard-deleted row,
+			// or no id at all) — fall back to the status box so a keyboard user
+			// still lands somewhere meaningful instead of <body>.
+			statusEl.tabIndex = -1;
+			statusEl.focus();
+		}
+	} else {
+		revealHashTarget(root);
+	}
 
 	// Turnstile mounts on the visitor's first composer focus, not here. api.js
 	// plus the challenge platform it pulls in is larger than this entire widget,
@@ -3467,30 +3565,16 @@ const submit = async (
 			}
 		}
 
+		// Request the focus-and-announce for once the new tree lands, *before*
+		// awaiting the reload: `load()` can return immediately and queue this
+		// reload behind one already in flight (see load(), above), so by the
+		// time `await` resolves here the tree it resolved against may already
+		// be stale. Stashing the request now, keyed on `root`, means whichever
+		// loadOnce call actually renders last — this one, or the queued
+		// follow-up — is the one that consumes it; see the arbitration at the
+		// tail of loadOnce.
+		revealAfterReload(root, json.comment?.id ?? null, s("w.posted"));
 		await load(root, slug, apiBase, host);
-
-		// Move focus to the newly posted comment so keyboard users don't land
-		// silently in an emptied composer. If the comment isn't in the rendered
-		// tree (paged thread, comment on last page, reload fetched page 1), fall
-		// back to the status region. Both paths announce success via the live
-		// region, serving different users: focus for keyboard navigation, the
-		// announcement for screen readers.
-		const newId = json.comment?.id;
-		if (newId && focusPostedComment(root, newId)) {
-			// Comment found and focused. Announce success to the live region.
-			if (errEl) showStatus(errEl, s("w.posted"), "notice");
-		} else {
-			// Comment not in tree (backlog #45) or no ID in response. Focus the
-			// status region to ensure keyboard focus lands somewhere meaningful,
-			// and announce success there.
-			if (errEl) {
-				showStatus(errEl, s("w.posted"), "notice");
-				// Make the status box focusable (it's a plain <div> with no tabindex).
-				// -1 keeps it out of tab order but allows programmatic focus.
-				errEl.tabIndex = -1;
-				errEl.focus();
-			}
-		}
 	} catch (err) {
 		// Same race, and the one that actually bit: a Turnstile error landing
 		// mid-submit had its message replaced by String(err) here, and the

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -3347,19 +3347,46 @@ const loadOnce = async (
 	pendingReveal.delete(root);
 	if (pending) {
 		const revealed = pending.id != null && focusPostedComment(root, pending.id);
-		// The status box in the tree just appended above — not whatever
-		// `.gr-error` a caller captured before this reload, which belongs to
-		// the node `root.replaceChildren()` just destroyed.
-		const statusEl = form.querySelector(".gr-error") as HTMLElement | null;
-		if (pending.announce && statusEl) {
-			showStatus(statusEl, pending.announce, "notice");
-		}
+		// Query from `root`, not `form`: buildForm always builds the composer,
+		// but it is only appended into `wrap` when accepting comments (see
+		// below), so a reload that closes the thread in the same round-trip as
+		// the reader's action leaves `form` holding a `.gr-error` that was
+		// never mounted. Querying the live tree instead gives that case a real
+		// `null` — a write into a detached box, or a `.focus()` that silently
+		// does nothing, is the exact bug this mechanism exists to close.
+		const statusEl = root.querySelector(".gr-error") as HTMLElement | null;
 		if (!revealed && statusEl) {
 			// Comment not in the rendered tree (paged thread, hard-deleted row,
 			// or no id at all) — fall back to the status box so a keyboard user
-			// still lands somewhere meaningful instead of <body>.
+			// still lands somewhere meaningful instead of <body>. Focus itself
+			// doesn't wait on the live-region timing below (moving focus isn't
+			// what triggers an aria-live announcement, filling in text is), so
+			// there's nothing to gain by delaying it — and a delay here would
+			// be a visible stall between the reader's action and the focus jump.
 			statusEl.tabIndex = -1;
 			statusEl.focus();
+		}
+		if (pending.announce) {
+			const announce = pending.announce;
+			// Deferred to a later task — see the statusBox docstring above: "a
+			// live region has to already be in that tree when its text changes
+			// for the change to be announced ... a region that appears and
+			// fills in at the same moment is precisely the case screen readers
+			// miss." `root.append(style, wrap)` above is what put *this* box in
+			// the document — root.replaceChildren() killed the previous one —
+			// so writing its text in this same synchronous task is that exact
+			// case, just triggered by the region being brand new rather than
+			// merely empty. A macrotask (not queueMicrotask, which can still
+			// run before the browser has registered the new region) gives it
+			// a full turn to do so before the text that must be announced lands.
+			setTimeout(() => {
+				// Re-query rather than close over `statusEl`: another reload
+				// can land in the time this task waited to run, and writing
+				// into whatever `statusEl` pointed at would be writing into a
+				// node root.replaceChildren() may have already destroyed.
+				const box = root.querySelector(".gr-error") as HTMLElement | null;
+				if (box) showStatus(box, announce, "notice");
+			}, 0);
 		}
 	} else {
 		revealHashTarget(root);

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -570,7 +570,7 @@ const buildSkeleton = (): DocumentFragment => {
 	list.setAttribute("aria-busy", "true");
 	list.setAttribute("aria-label", s("w.loading_comments"));
 	for (let i = 0; i < 3; i++) {
-		const row = el("div", "gr-comment");
+		const row = el("article", "gr-comment");
 		const avatarWrap = el("div", "gr-avatar");
 		avatarWrap.appendChild(el("div", "gr-skel gr-skel-avatar"));
 		const lines = el("div");
@@ -2068,15 +2068,23 @@ const shouldCollapseLowScore = (n: TreeNode, ctx: WidgetCtx): boolean => {
 };
 
 const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
-	const row = el("div", "gr-comment");
+	// <article> rather than <div>: it gives assistive tech a real comment
+	// boundary in what is otherwise an undifferentiated run of divs, and it is
+	// the element the HTML spec names for exactly this ("a forum post, a
+	// magazine article, a user-submitted comment").
+	const row = el("article", "gr-comment");
 	row.dataset.id = n.id;
 	if (n.flatten_from) row.dataset.flat = "1";
+	const nameId = `gr-name-${n.id}`;
+	row.setAttribute("aria-labelledby", nameId);
 	row.appendChild(buildAvatar(n.author));
 
 	const main = el("div", "gr-main");
 
 	const meta = el("div", "gr-meta");
-	meta.appendChild(el("span", "gr-name", n.author.name));
+	const nameEl = el("span", "gr-name", n.author.name);
+	nameEl.id = nameId;
+	meta.appendChild(nameEl);
 	if (n.author.provider !== "anon") {
 		meta.appendChild(el("span", "gr-verified", s("w.verified")));
 	}
@@ -2084,7 +2092,7 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	// anchor, so right-click-copy, middle-click and Cmd-click all work natively
 	// and we spend no bytes on a clipboard shim. Clicking it is handled by the
 	// existing hash-scroll at the bottom of this file.
-	const permalink = el("a", "gr-permalink") as HTMLAnchorElement;
+	const permalink = el("a", "gr-permalink");
 	permalink.href = ctx.permalinkFor(n.id);
 	permalink.appendChild(buildTime(n.created_at));
 	meta.appendChild(permalink);
@@ -3110,6 +3118,14 @@ const loadOnce = async (
 		attr.append(beforeLink, link, afterLink);
 		wrap.appendChild(attr);
 	}
+
+	// Wire up the region heading for assistive tech: a visually-hidden <h2> that
+	// gives screen readers a landmark and a name for the entire comments section.
+	const heading = el("h2", "gr-sr", s("w.region"));
+	heading.id = "gr-region-heading";
+	wrap.setAttribute("role", "region");
+	wrap.setAttribute("aria-labelledby", heading.id);
+	wrap.prepend(heading);
 
 	root.append(style, wrap);
 

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2885,6 +2885,7 @@ const loadOnce = async (
 			// locale's own overrides, not a merged copy — makeS falls back to the
 			// bundled English per key, so a partial translation renders English
 			// exactly where it is incomplete and correct everywhere else.
+			host.lang = locale;
 			if (typeof cfg.locale === "string" && cfg.locale) {
 				locale = cfg.locale;
 				host.lang = locale;

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -488,6 +488,7 @@ const buildWritePreview = (
 	// is here for the person pasting an essay, and for them it has to appear
 	// before they hit Post, not after the server rejects it.
 	const counter = el("span", "gr-count");
+	counter.setAttribute("role", "status");
 	counter.hidden = true;
 	const paintCount = (): void => {
 		const left = maxBodyChars - textarea.value.length;
@@ -567,6 +568,7 @@ const buildSkeleton = (): DocumentFragment => {
 	const frag = document.createDocumentFragment();
 	const root = el("div", "gr-root");
 	const list = el("div", "gr-list");
+	list.setAttribute("role", "status");
 	list.setAttribute("aria-busy", "true");
 	list.setAttribute("aria-label", s("w.loading_comments"));
 	for (let i = 0; i < 3; i++) {
@@ -1658,7 +1660,9 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 			yes.type = "button";
 			const no = el("button", undefined, s("w.cancel"));
 			no.type = "button";
-			confirmWrap.append(el("span", undefined, s("w.delete_confirm")), yes, no);
+			const prompt = el("span", undefined, s("w.delete_confirm"));
+			prompt.setAttribute("role", "status");
+			confirmWrap.append(prompt, yes, no);
 			delBtn.replaceWith(confirmWrap);
 			// Replacing the focused button drops focus to <body>, stranding a
 			// keyboard user mid-thread. Land on Cancel: for a destructive action

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -95,8 +95,11 @@ let maxBodyChars = 10_000;
 /** How close to the ceiling the counter appears. Silent above this. */
 const COUNT_WARN_AT = 500;
 
-/** Counter for generating unique hint container IDs. */
-let hintIdCounter = 0;
+/** Counter backing `nextId` — one sequence for every generated element id. */
+let idCounter = 0;
+
+/** A unique id with the given prefix, for aria-describedby/aria-labelledby targets. */
+const nextId = (prefix: string): string => `${prefix}-${++idCounter}`;
 
 /**
  * Build an API URL carrying the resolved locale.
@@ -493,7 +496,7 @@ const buildWritePreview = (
 	textarea.addEventListener("input", () => autoSize(textarea));
 	// One row under the box: what you can write on the left, how to send it on
 	// the right. The whole row hides together in Preview mode.
-	const hintId = `gr-hint-${++hintIdCounter}`;
+	const hintId = nextId("gr-hint");
 	const hint = el("div", "gr-md-hint");
 	hint.id = hintId;
 	// Silent until the author is close to the ceiling. A permanent "9,847 left"
@@ -501,7 +504,6 @@ const buildWritePreview = (
 	// is here for the person pasting an essay, and for them it has to appear
 	// before they hit Post, not after the server rejects it.
 	const counter = el("span", "gr-count");
-	counter.setAttribute("role", "status");
 	counter.hidden = true;
 	const paintCount = (): void => {
 		const left = maxBodyChars - textarea.value.length;
@@ -582,7 +584,6 @@ const buildSkeleton = (): DocumentFragment => {
 	const frag = document.createDocumentFragment();
 	const root = el("div", "gr-root");
 	const list = el("div", "gr-list");
-	list.setAttribute("role", "status");
 	list.setAttribute("aria-busy", "true");
 	list.setAttribute("aria-label", s("w.loading_comments"));
 	for (let i = 0; i < 3; i++) {
@@ -1685,7 +1686,14 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 			const no = el("button", undefined, s("w.cancel"));
 			no.type = "button";
 			const prompt = el("span", undefined, s("w.delete_confirm"));
-			prompt.setAttribute("role", "status");
+			// Not a live region: the prompt is inserted already populated, which
+			// is the case a live region never announces (see the statusBox
+			// docstring above). Focus is about to move to Cancel regardless, so
+			// aria-describedby on both buttons announces it deterministically
+			// instead.
+			prompt.id = nextId("gr-confirm");
+			yes.setAttribute("aria-describedby", prompt.id);
+			no.setAttribute("aria-describedby", prompt.id);
 			confirmWrap.append(prompt, yes, no);
 			delBtn.replaceWith(confirmWrap);
 			// Replacing the focused button drops focus to <body>, stranding a

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1090,7 +1090,9 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 			// row there is space for the label here, and it is the only thing that
 			// says what the emoji is *for* before the reader commits to a click.
 			const face = el("span", "gr-reaction-face");
-			face.appendChild(el("span", "gr-reaction-emoji", emoji));
+			const emoji_span = el("span", "gr-reaction-emoji", emoji);
+			emoji_span.setAttribute("aria-hidden", "true");
+			face.appendChild(emoji_span);
 			const count = el("span", "gr-reaction-count", "0");
 			face.appendChild(count);
 			btn.append(face, el("span", "gr-reaction-label", s(labelKey)));

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -46,7 +46,7 @@ import {
 	REACTION_KINDS,
 	mergeReactionTotals,
 } from "./reactions";
-import { commentAnchorId, commentHref } from "./permalink";
+import { commentAnchorId, commentHref, commentIdFromHash } from "./permalink";
 import { absoluteTime, isoTime, relativeTime } from "./time";
 // The mount request and the wire shapes it carries. Kept out of this file so the
 // fallback rule can be tested without a DOM — see boot.ts's header.
@@ -2765,6 +2765,17 @@ const load = async (
 	if (!st) {
 		st = { running: false, queued: false, sort: null };
 		loadState.set(root, st);
+		// Wire the permalink reveal to same-document fragment navigations here
+		// rather than in init(): a naive addEventListener at the reveal's own
+		// call site (inside loadOnce, below) would leak one listener per reload
+		// and fire the reveal N times, because loadOnce runs on every reload —
+		// not just at mount. This `if (!st)` branch, by contrast, only runs
+		// once per root's lifetime (the first load() call creates the state
+		// entry; every later call, from a reply, a sort change, a reconnect,
+		// finds it already there), so piggybacking here gets "exactly one
+		// listener per mount" for free, with no second WeakSet just to
+		// remember whether one was already bound.
+		window.addEventListener("hashchange", () => revealHashTarget(root));
 	}
 	if (st.running) {
 		st.queued = true;
@@ -2808,6 +2819,39 @@ const focusPostedComment = (root: ShadowRoot, id: string): boolean => {
 	article.tabIndex = -1;
 	article.focus();
 	return true;
+};
+
+/**
+ * Reveal a permalink target (#garrul-comment-<id>): scroll it into view and
+ * then move focus to it. Browsers don't auto-scroll to — or focus — anchors
+ * inside a shadow root, so both have to happen by hand. Called once the tree
+ * is in the DOM (see loadOnce, below) and again on every `hashchange` (see
+ * load(), above) — a same-document fragment navigation the browser cannot
+ * reach into the shadow root to act on itself.
+ *
+ * Silent no-op when the hash isn't one of ours, or when it is but the
+ * comment isn't in the rendered tree — a hash for another page, or one that
+ * hasn't loaded yet, must never surface as an error.
+ */
+const revealHashTarget = (root: ShadowRoot): void => {
+	const id = commentIdFromHash(window.location.hash);
+	if (!id) return;
+	const target = root.getElementById(commentAnchorId(id));
+	if (!target) return;
+	// The CSS half of the reduced-motion promise lives in styles.css; scroll
+	// behavior is set here, so it has to be honored here too. `matchMedia` is
+	// guarded because the widget also runs under the iframe route and in test
+	// DOMs that don't implement it.
+	const still = window.matchMedia?.(
+		"(prefers-reduced-motion: reduce)",
+	)?.matches;
+	target.scrollIntoView({
+		block: "center",
+		behavior: still ? "auto" : "smooth",
+	});
+	// Scrolling alone only serves a sighted mouse user; move the caret too so
+	// keyboard and screen-reader users land on the comment (WCAG 2.4.3).
+	focusPostedComment(root, id);
 };
 
 // Closed-state notice copy, picked from the server's closed_reason enum so the
@@ -3189,25 +3233,10 @@ const loadOnce = async (
 
 	root.append(style, wrap);
 
-	// Scroll a permalink target (#garrul-comment-<id>) into view once the
-	// tree is in the DOM. Browsers don't auto-scroll to anchors inside a
-	// shadow root, so we have to do it manually.
-	if (window.location.hash.startsWith("#garrul-comment-")) {
-		const target = root.getElementById(window.location.hash.slice(1));
-		if (target) {
-			// The CSS half of the reduced-motion promise lives in styles.css;
-			// scroll behavior is set here, so it has to be honored here too.
-			// `matchMedia` is guarded because the widget also runs under the
-			// iframe route and in test DOMs that don't implement it.
-			const still = window.matchMedia?.(
-				"(prefers-reduced-motion: reduce)",
-			)?.matches;
-			target.scrollIntoView({
-				block: "center",
-				behavior: still ? "auto" : "smooth",
-			});
-		}
-	}
+	// Reveal a permalink target (#garrul-comment-<id>) now that the tree is in
+	// the DOM. hashchange (see load(), above) covers the same-document
+	// navigation case; this call covers mount and every later reload.
+	revealHashTarget(root);
 
 	// Turnstile mounts on the visitor's first composer focus, not here. api.js
 	// plus the challenge platform it pulls in is larger than this entire widget,

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1762,6 +1762,7 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	const ta = el("textarea");
 	ta.value = "";
 	ta.placeholder = s("w.loading");
+	ta.setAttribute("aria-label", s("w.edit_ph"));
 	ta.required = true;
 	const actions = el("div", "gr-reply-actions");
 	const save = el("button", undefined, s("w.save"));
@@ -1834,6 +1835,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	const wrap = el("form", "gr-reply-form");
 	const ta = el("textarea");
 	ta.placeholder = s("w.reply_ph", { name: parent.author.name });
+	ta.setAttribute("aria-label", s("w.reply_ph", { name: parent.author.name }));
 	ta.required = true;
 	const dkey = attachDraft(ta, draftKey(ctx.slug, parent.id));
 
@@ -1842,6 +1844,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 		nameInput = el("input");
 		nameInput.type = "text";
 		nameInput.placeholder = s("w.name_ph");
+		nameInput.setAttribute("aria-label", s("w.name_ph"));
 		nameInput.required = true;
 		wrap.appendChild(nameInput);
 	}
@@ -2094,6 +2097,10 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	// existing hash-scroll at the bottom of this file.
 	const permalink = el("a", "gr-permalink");
 	permalink.href = ctx.permalinkFor(n.id);
+	permalink.setAttribute(
+		"aria-label",
+		s("w.permalink", { name: n.author.name, time: absoluteTime(n.created_at, locale) }),
+	);
 	permalink.appendChild(buildTime(n.created_at));
 	meta.appendChild(permalink);
 	if (n.edited_at) meta.appendChild(el("span", "gr-edited", s("w.edited")));
@@ -2339,6 +2346,7 @@ const buildForm = (
 		name.name = "name";
 		name.type = "text";
 		name.placeholder = s("w.name_ph");
+		name.setAttribute("aria-label", s("w.name_ph"));
 		name.required = true;
 		form.appendChild(name);
 	}
@@ -2347,6 +2355,7 @@ const buildForm = (
 	body.className = "gr-body-input";
 	body.name = "body";
 	body.placeholder = s("w.body_ph");
+	body.setAttribute("aria-label", s("w.body_ph"));
 	body.required = true;
 	form.appendChild(buildWritePreview(body, apiBase));
 
@@ -2394,6 +2403,7 @@ const buildForm = (
 			emailInput.name = "email";
 			emailInput.type = "email";
 			emailInput.placeholder = s("w.email_ph");
+			emailInput.setAttribute("aria-label", s("w.email_label"));
 			emailInput.autocomplete = "email";
 			emailInput.hidden = true;
 			notifyCb.addEventListener("change", () => {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -95,6 +95,9 @@ let maxBodyChars = 10_000;
 /** How close to the ceiling the counter appears. Silent above this. */
 const COUNT_WARN_AT = 500;
 
+/** Counter for generating unique hint container IDs. */
+let hintIdCounter = 0;
+
 /**
  * Build an API URL carrying the resolved locale.
  *
@@ -482,7 +485,9 @@ const buildWritePreview = (
 	textarea.addEventListener("input", () => autoSize(textarea));
 	// One row under the box: what you can write on the left, how to send it on
 	// the right. The whole row hides together in Preview mode.
+	const hintId = `gr-hint-${++hintIdCounter}`;
 	const hint = el("div", "gr-md-hint");
+	hint.id = hintId;
 	// Silent until the author is close to the ceiling. A permanent "9,847 left"
 	// on a limit almost nobody reaches is a nag, not information — the counter
 	// is here for the person pasting an essay, and for them it has to appear
@@ -505,6 +510,7 @@ const buildWritePreview = (
 		counter,
 		el("span", "gr-kbd-hint", s("w.kbd_hint")),
 	);
+	textarea.setAttribute("aria-describedby", hintId);
 	const pane = el("div", "gr-preview");
 	pane.hidden = true;
 

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1223,11 +1223,17 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 		up.type = "button";
 		up.setAttribute("aria-label", s("w.page.up"));
 		up.appendChild(document.createTextNode("▲"));
+		// aria-pressed only ever gets set from setVote, which needs a resolved
+		// `votes` payload — set it here too so a bootstrap that's missing votes
+		// (or hasn't resolved yet) doesn't leave the button with no toggle
+		// semantics at all.
+		markVote(up, false);
 		scoreEl = el("span", "gr-vote-score", "0");
 		down = el("button", "gr-vote");
 		down.type = "button";
 		down.setAttribute("aria-label", s("w.page.down"));
 		down.appendChild(document.createTextNode("▼"));
+		markVote(down, false);
 		if (!ctx.downvotesEnabled) down.hidden = true;
 		up.addEventListener("click", () => void castVote(myVote === 1 ? 0 : 1));
 		down.addEventListener("click", () => void castVote(myVote === -1 ? 0 : -1));

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -677,6 +677,14 @@ type WidgetCtx = {
 	// the subscribe bell render from it instead of each firing their own GET.
 	seed: MountSeed;
 	reload: () => void;
+	/**
+	 * Request that once the next reload's tree lands, focus (and optionally
+	 * announce) something — see `pendingReveal`/`revealAfterReload` near
+	 * `focusPostedComment` below. `id: null` skips straight to the status-box
+	 * fallback. Exists because `ctx.reload()` runs `root.replaceChildren()`
+	 * before any code after the call gets a chance to touch the old tree.
+	 */
+	revealAfterReload: (id: string | null, announce?: string) => void;
 	/** Precomputed permalink base for this mount; see src/widget/permalink.ts. */
 	permalinkFor: (id: string) => string;
 };
@@ -1047,6 +1055,11 @@ const buildReactions = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 				// fall back to the reload this used to do rather than merging
 				// against `{}`, which would blank every reaction on the comment.
 				if (!body.reactions) {
+					// Focus only, no announcement: refocusing the article is itself
+					// the confirmation for assistive tech, and this path is a legacy
+					// fallback for a server old enough to have never sent counts, so
+					// it adds no new string to a bundle under a hard size budget.
+					ctx.revealAfterReload(n.id);
 					ctx.reload();
 					return;
 				}
@@ -1701,6 +1714,11 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 						{ method: "DELETE", credentials: "include" },
 					);
 					if (res.ok) {
+						// Focus only, no announcement: the row usually survives as a
+						// tombstone, and landing focus on the updated comment is the
+						// confirmation for assistive tech. If it doesn't survive, the
+						// status-box fallback in loadOnce catches it.
+						ctx.revealAfterReload(n.id);
 						ctx.reload();
 						return;
 					}
@@ -1834,8 +1852,14 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 					body: JSON.stringify({ body: ta.value }),
 				},
 			);
-			if (res.ok) ctx.reload();
-			else save.disabled = false;
+			if (res.ok) {
+				// Focus only, no announcement: focusing the article makes
+				// assistive tech read the edited body, which is itself the
+				// confirmation, and it adds no new string to a bundle under a
+				// hard size budget.
+				ctx.revealAfterReload(n.id);
+				ctx.reload();
+			} else save.disabled = false;
 		} catch {
 			save.disabled = false;
 		}
@@ -2039,7 +2063,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 			});
 			const json = (await res.json()) as {
 				error?: string;
-				comment?: { status?: string };
+				comment?: { id?: string; status?: string };
 			};
 			if (!res.ok) {
 				if (tsGate?.failed) return;
@@ -2055,7 +2079,10 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 			clearDraft(dkey);
 			// Pending replies reload like approved ones: the author's own
 			// queued comment comes back from the list endpoint and renders
-			// inline with a "Pending approval" badge.
+			// inline with a "Pending approval" badge. Fall back to the parent
+			// comment's id so focus still lands somewhere sensible on the rare
+			// response that omits the new comment's id.
+			ctx.revealAfterReload(json.comment?.id ?? parent.id, s("w.posted"));
 			ctx.reload();
 		} catch (err) {
 			if (tsGate?.failed) return;
@@ -3137,6 +3164,8 @@ const loadOnce = async (
 			subscription: boot?.subscription,
 		},
 		reload,
+		revealAfterReload: (id: string | null, announce?: string) =>
+			revealAfterReload(root, id, announce),
 		permalinkFor,
 	};
 	// Article-level engagement bar sits at the very top, above the composer.

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1096,9 +1096,12 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 			// row there is space for the label here, and it is the only thing that
 			// says what the emoji is *for* before the reader commits to a click.
 			const face = el("span", "gr-reaction-face");
-			const emoji_span = el("span", "gr-reaction-emoji", emoji);
-			emoji_span.setAttribute("aria-hidden", "true");
-			face.appendChild(emoji_span);
+			// Same reason as the per-comment row: the glyph's own name reads as
+			// the wrong sentiment on a couple of them, and the visible label
+			// beside it already says what the button is for.
+			const emojiSpan = el("span", "gr-reaction-emoji", emoji);
+			emojiSpan.setAttribute("aria-hidden", "true");
+			face.appendChild(emojiSpan);
 			const count = el("span", "gr-reaction-count", "0");
 			face.appendChild(count);
 			btn.append(face, el("span", "gr-reaction-label", s(labelKey)));
@@ -2109,9 +2112,16 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	// existing hash-scroll at the bottom of this file.
 	const permalink = el("a", "gr-permalink");
 	permalink.href = ctx.permalinkFor(n.id);
+	// The visible label is relative ("6 minutes ago"), which collides across
+	// comments on an active thread and says nothing about where the link goes —
+	// a links-list reads as a column of bare durations. The name carries the
+	// commenter and the absolute time instead; the visible label is untouched.
 	permalink.setAttribute(
 		"aria-label",
-		s("w.permalink", { name: n.author.name, time: absoluteTime(n.created_at, locale) }),
+		s("w.permalink", {
+			name: n.author.name,
+			time: absoluteTime(n.created_at, locale),
+		}),
 	);
 	permalink.appendChild(buildTime(n.created_at));
 	meta.appendChild(permalink);

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2755,6 +2755,29 @@ const setSort = (root: ShadowRoot, sort: SortKey): void => {
 	if (st) st.sort = sort;
 };
 
+/**
+ * Move focus to a freshly posted comment so the post is announced and the
+ * keyboard caret lands somewhere meaningful, instead of silently returning to
+ * an emptied composer.
+ *
+ * Returns false when the comment is not in the rendered tree — under `sort=old`
+ * on a paged thread it belongs on the last page and `load()` re-fetches the
+ * first. That case is backlog #45 and is deliberately not solved here; the
+ * caller falls back to the live region.
+ *
+ * The `tabindex="-1"` is left in place after focus moves away: re-focusing the
+ * same comment later (e.g. via a permalink click) should work the same way, and
+ * it costs nothing.
+ */
+const focusPostedComment = (root: ShadowRoot, id: string): boolean => {
+	const node = root.getElementById(commentAnchorId(id));
+	const article = node?.querySelector<HTMLElement>(".gr-comment");
+	if (!article) return false;
+	article.tabIndex = -1;
+	article.focus();
+	return true;
+};
+
 // Closed-state notice copy, picked from the server's closed_reason enum so the
 // reader sees *why* the thread is frozen rather than a generic line.
 const closedNotice = (reason: ListResponse["closed_reason"]): string => {
@@ -3332,7 +3355,7 @@ const submit = async (
 		});
 		const json = (await res.json()) as {
 			error?: string;
-			comment?: { status?: string };
+			comment?: { id?: string; status?: string };
 		};
 		if (!res.ok) {
 			// A Turnstile error can arrive while this request is in flight.
@@ -3379,6 +3402,26 @@ const submit = async (
 		}
 
 		await load(root, slug, apiBase, host);
+
+		// Move focus to the newly posted comment so keyboard users don't land
+		// silently in an emptied composer. If the comment isn't in the rendered
+		// tree (paged thread, comment on last page, reload fetched page 1), fall
+		// back to the status region. Both paths announce success via the live
+		// region, serving different users: focus for keyboard navigation, the
+		// announcement for screen readers.
+		const newId = json.comment?.id;
+		if (newId && focusPostedComment(root, newId)) {
+			// Comment found and focused. Announce success to the live region.
+			if (errEl) showStatus(errEl, s("w.posted"), "notice");
+		} else {
+			// Comment not in tree (backlog #45) or no ID in response. Focus the
+			// status region to ensure keyboard focus lands somewhere meaningful,
+			// and announce success there.
+			if (errEl) {
+				showStatus(errEl, s("w.posted"), "notice");
+				errEl.focus();
+			}
+		}
 	} catch (err) {
 		// Same race, and the one that actually bit: a Turnstile error landing
 		// mid-submit had its message replaced by String(err) here, and the

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -114,6 +114,14 @@ const apiUrl = (base: string, path: string): string =>
 		? base + path
 		: `${base + path + (path.indexOf("?") < 0 ? "?" : "&")}lang=${encodeURIComponent(locale)}`;
 
+// Mark a vote button with its state: set/unset data-mine to highlight it visually,
+// and set aria-pressed so screen readers know whether the user's vote is cast.
+const markVote = (btn: HTMLElement, on: boolean): void => {
+	if (on) btn.dataset.mine = "1";
+	else delete btn.dataset.mine;
+	btn.setAttribute("aria-pressed", String(on));
+};
+
 // Mirrors lib/tree.ts's TreeAuthor. No `is_admin`: the API stopped sending it
 // (it let anyone enumerate privileged accounts) and nothing here rendered it.
 type TreeAuthor = {
@@ -914,7 +922,7 @@ const buildVotes = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	up.type = "button";
 	up.setAttribute("aria-label", s("w.vote.up"));
 	up.appendChild(document.createTextNode("▲"));
-	if (n.my_vote === 1) up.dataset.mine = "1";
+	markVote(up, n.my_vote === 1);
 
 	const scoreEl = el("span", "gr-vote-score", String(score));
 
@@ -922,7 +930,7 @@ const buildVotes = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	down.type = "button";
 	down.setAttribute("aria-label", s("w.vote.down"));
 	down.appendChild(document.createTextNode("▼"));
-	if (n.my_vote === -1) down.dataset.mine = "1";
+	markVote(down, n.my_vote === -1);
 
 	const cast = async (value: -1 | 0 | 1): Promise<void> => {
 		up.disabled = true;
@@ -943,10 +951,8 @@ const buildVotes = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 			n.score_down = body.score_down;
 			n.my_vote = body.my_vote;
 			scoreEl.textContent = String(body.score_up - body.score_down);
-			if (body.my_vote === 1) up.dataset.mine = "1";
-			else delete up.dataset.mine;
-			if (body.my_vote === -1) down.dataset.mine = "1";
-			else delete down.dataset.mine;
+			markVote(up, body.my_vote === 1);
+			markVote(down, body.my_vote === -1);
 		} catch {
 			// Network/parse failure: leave UI untouched; user can retry.
 		} finally {
@@ -1171,14 +1177,8 @@ const buildPageEngagement = (ctx: WidgetCtx): HTMLElement => {
 	const setVote = (s: PageVoteState): void => {
 		myVote = s.my_vote;
 		if (scoreEl) scoreEl.textContent = String(s.score_up - s.score_down);
-		if (up) {
-			if (myVote === 1) up.dataset.mine = "1";
-			else delete up.dataset.mine;
-		}
-		if (down) {
-			if (myVote === -1) down.dataset.mine = "1";
-			else delete down.dataset.mine;
-		}
+		if (up) markVote(up, myVote === 1);
+		if (down) markVote(down, myVote === -1);
 	};
 
 	const castVote = async (value: -1 | 0 | 1): Promise<void> => {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -46,6 +46,7 @@ import {
 	REACTION_KINDS,
 	mergeReactionTotals,
 } from "./reactions";
+import { commentAnchorId, commentHref } from "./permalink";
 import { absoluteTime, isoTime, relativeTime } from "./time";
 // The mount request and the wire shapes it carries. Kept out of this file so the
 // fallback rule can be tested without a DOM — see boot.ts's header.
@@ -660,6 +661,8 @@ type WidgetCtx = {
 	// the subscribe bell render from it instead of each firing their own GET.
 	seed: MountSeed;
 	reload: () => void;
+	/** Precomputed permalink base for this mount; see src/widget/permalink.ts. */
+	permalinkFor: (id: string) => string;
 };
 
 /**
@@ -2077,7 +2080,14 @@ const buildComment = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	if (n.author.provider !== "anon") {
 		meta.appendChild(el("span", "gr-verified", s("w.verified")));
 	}
-	meta.appendChild(buildTime(n.created_at));
+	// The timestamp is the permalink, the way Reddit/HN/Disqus do it — a plain
+	// anchor, so right-click-copy, middle-click and Cmd-click all work natively
+	// and we spend no bytes on a clipboard shim. Clicking it is handled by the
+	// existing hash-scroll at the bottom of this file.
+	const permalink = el("a", "gr-permalink") as HTMLAnchorElement;
+	permalink.href = ctx.permalinkFor(n.id);
+	permalink.appendChild(buildTime(n.created_at));
+	meta.appendChild(permalink);
 	if (n.edited_at) meta.appendChild(el("span", "gr-edited", s("w.edited")));
 	// Author-only signal: the list endpoint returns the viewer's own queued
 	// comments, so this badge is only ever seen by the author themselves.
@@ -2206,7 +2216,7 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	const wrap = el("div", "gr-thread");
 	wrap.dataset.id = n.id;
 	// Anchor id for the /c/:id permalink redirect to scroll into view.
-	wrap.id = `garrul-comment-${n.id}`;
+	wrap.id = commentAnchorId(n.id);
 	wrap.appendChild(buildComment(n, ctx));
 	if (n.replies.length > 0) {
 		const replies = el("div", "gr-replies");
@@ -2917,6 +2927,12 @@ const loadOnce = async (
 	const reload = () => {
 		void load(root, slug, apiBase, host);
 	};
+	const permalinkFor = (id: string): string =>
+		commentHref(id, {
+			dataUrl: host.dataset.url,
+			locationHref: window.location.href,
+			apiBase,
+		});
 	const ctx: WidgetCtx = {
 		apiBase,
 		slug,
@@ -2945,6 +2961,7 @@ const loadOnce = async (
 			subscription: boot?.subscription,
 		},
 		reload,
+		permalinkFor,
 	};
 	// Article-level engagement bar sits at the very top, above the composer.
 	if (pageReactionsEnabled || pageVotesEnabled) {

--- a/src/widget/permalink.ts
+++ b/src/widget/permalink.ts
@@ -27,16 +27,14 @@ export const commentAnchorId = (id: string): string => `garrul-comment-${id}`;
  * Built from `commentAnchorId("")` rather than a re-typed `"garrul-comment-"`
  * literal, so the prefix has exactly one source of truth.
  *
- * `#existing&garrul-comment-<id>` — the shape src/routes/permalink.ts:54
- * emits when a post's stored URL already carries a fragment — returns null
- * here rather than `<id>`. The combined fragment doesn't start with our
- * prefix (it starts with the *existing* fragment), so there is no substring
- * search to fall back to without risking a false positive on some unrelated
- * page's `#foo-garrul-comment-bar`-shaped anchor. It is already a known dead
- * end in a browser either way (see tests/widget-permalink.test.ts:57-60), so
- * returning null just means the widget stays silent instead of also failing
- * to find an element — the same "no match, no error" contract as any other
- * hash that isn't ours.
+ * The match is anchored at the start of the hash, not a substring search: a
+ * shape like `#existing&garrul-comment-<id>` returns null rather than `<id>`,
+ * because loosening to a substring search would also match an unrelated
+ * page's `#foo-garrul-comment-bar`-shaped anchor. Nothing we emit produces
+ * that shape — both this module's `withAnchor` and the server's `/c/:id`
+ * redirect *replace* any existing fragment — so anchoring at the start costs
+ * no real link, and an unrecognised hash gets the same "no match, no error"
+ * contract as any other hash that isn't ours.
  */
 export const commentIdFromHash = (hash: string): string | null => {
 	const prefix = `#${commentAnchorId("")}`;

--- a/src/widget/permalink.ts
+++ b/src/widget/permalink.ts
@@ -1,0 +1,70 @@
+/**
+ * Reader-facing permalink for a single comment.
+ *
+ * The link points at the *host page* (`https://blog/post/#garrul-comment-<id>`),
+ * not at the Worker's `/c/:id` redirect. `/c/:id` is already built and does
+ * survive a post moving, but every click of it is a Worker request against a
+ * 100,000/day free-tier ceiling — the same ceiling the bootstrap consolidation
+ * exists to protect. It also 404s when `post.url` is unset, so its durability
+ * edge only holds on installs where `data-url` is set and the host anchor
+ * works anyway.
+ *
+ * `/c/:id` survives as the last rung: inside the iframe embed
+ * (src/routes/embed-iframe.ts) with no `?url=`, `location` *is* the Worker's
+ * own page, and anchoring at it would produce a link to a bare embed frame.
+ *
+ * DOM-free on purpose — that is what lets it unit-test in the plain `node`
+ * pool with no browser, the same way time.ts and boot.ts do.
+ */
+
+/** Anchor id stamped on each thread node by embed.ts (`buildThread`). */
+export const commentAnchorId = (id: string): string => `garrul-comment-${id}`;
+
+export interface PermalinkCtx {
+	/** The host page's `data-url`, if the operator set one. */
+	dataUrl: string | undefined;
+	/** `window.location.href` at mount time. */
+	locationHref: string;
+	/** Resolved API origin (`host.dataset.api ?? SCRIPT_ORIGIN ?? origin`). */
+	apiBase: string;
+}
+
+/**
+ * Parse as an absolute http(s) URL, or null.
+ *
+ * `data-url` is caller-supplied by the host page, so the scheme check is a
+ * security boundary, not tidiness: without it a hostile or misconfigured host
+ * turns every timestamp in the thread into a `javascript:` link. Mirrors the
+ * same check the server does at src/routes/permalink.ts:44.
+ */
+const httpUrl = (raw: string | undefined): URL | null => {
+	if (!raw) return null;
+	let u: URL;
+	try {
+		u = new URL(raw);
+	} catch {
+		return null;
+	}
+	return u.protocol === "http:" || u.protocol === "https:" ? u : null;
+};
+
+/** Replace any existing fragment with the comment anchor. */
+const withAnchor = (u: URL, id: string): string => {
+	u.hash = commentAnchorId(id);
+	return u.toString();
+};
+
+export const commentHref = (id: string, ctx: PermalinkCtx): string => {
+	const data = httpUrl(ctx.dataUrl);
+	if (data) return withAnchor(data, id);
+
+	// Rung 2 is gated on an origin comparison rather than a frame check. A host
+	// blog that happens to be iframed for unrelated reasons still deserves a
+	// real anchor, and `window.top` access can throw cross-origin where
+	// comparing two origins cannot.
+	const loc = httpUrl(ctx.locationHref);
+	const api = httpUrl(ctx.apiBase);
+	if (loc && (!api || loc.origin !== api.origin)) return withAnchor(loc, id);
+
+	return `${ctx.apiBase.replace(/\/+$/, "")}/c/${id}`;
+};

--- a/src/widget/permalink.ts
+++ b/src/widget/permalink.ts
@@ -20,6 +20,31 @@
 /** Anchor id stamped on each thread node by embed.ts (`buildThread`). */
 export const commentAnchorId = (id: string): string => `garrul-comment-${id}`;
 
+/**
+ * Inverse of `commentAnchorId`: pull the comment id back out of
+ * `location.hash`, or null when the hash isn't one of ours.
+ *
+ * Built from `commentAnchorId("")` rather than a re-typed `"garrul-comment-"`
+ * literal, so the prefix has exactly one source of truth.
+ *
+ * `#existing&garrul-comment-<id>` — the shape src/routes/permalink.ts:54
+ * emits when a post's stored URL already carries a fragment — returns null
+ * here rather than `<id>`. The combined fragment doesn't start with our
+ * prefix (it starts with the *existing* fragment), so there is no substring
+ * search to fall back to without risking a false positive on some unrelated
+ * page's `#foo-garrul-comment-bar`-shaped anchor. It is already a known dead
+ * end in a browser either way (see tests/widget-permalink.test.ts:57-60), so
+ * returning null just means the widget stays silent instead of also failing
+ * to find an element — the same "no match, no error" contract as any other
+ * hash that isn't ours.
+ */
+export const commentIdFromHash = (hash: string): string | null => {
+	const prefix = `#${commentAnchorId("")}`;
+	if (!hash.startsWith(prefix)) return null;
+	const id = hash.slice(prefix.length);
+	return id.length > 0 ? id : null;
+};
+
 export interface PermalinkCtx {
 	/** The host page's `data-url`, if the operator set one. */
 	dataUrl: string | undefined;

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -127,6 +127,10 @@ export const EN = {
 	"w.replies": { one: "{n} reply", other: "{n} replies" },
 	"w.more_replies": { one: "Show {n} more reply", other: "Show {n} more replies" },
 	"w.loading_comments": "Loading comments",
+	// Names the comments region for assistive tech. Never rendered visually —
+	// see `.gr-sr` — so it exists to give screen readers and rotor
+	// navigation a landmark, not to put a title on the operator's page.
+	"w.region": "Comments",
 	"w.empty.open": "Be the first to comment.",
 	"w.empty.closed": "No comments yet.",
 	"w.closed.post": "Comments are closed on this post.",

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -66,6 +66,7 @@ export const EN = {
 	"w.name_ph": "Your name",
 	"w.body_ph": "Add a comment…",
 	"w.email_ph": "you@example.com",
+	"w.email_label": "Email address",
 	// A subscription is UNIQUE (post_slug, email) — it follows the thread, not
 	// your own comment, so every new comment on the post is delivered. The old
 	// wording ("on new replies") promised per-reply scoping the schema does not
@@ -128,6 +129,7 @@ export const EN = {
 	"w.replies": { one: "{n} reply", other: "{n} replies" },
 	"w.more_replies": { one: "Show {n} more reply", other: "Show {n} more replies" },
 	"w.loading_comments": "Loading comments",
+	"w.permalink": "Permalink to @{name}'s comment, {time}",
 	// Names the comments region for assistive tech. Never rendered visually —
 	// see `.gr-sr` — so it exists to give screen readers and rotor
 	// navigation a landmark, not to put a title on the operator's page.

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -78,6 +78,7 @@ export const EN = {
 	"w.loading": "Loading…",
 	"w.save": "Save",
 	"w.cancel": "Cancel",
+	"w.posted": "Comment posted",
 
 	// ── Anti-spam ───────────────────────────────────────────────────────────
 	"w.ts.title": "Anti-spam check",

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -75,7 +75,7 @@
 		--gr-border: var(--garrul-border, #2e353d);
 		--gr-muted: var(--garrul-muted, #9aa3b0);
 		--gr-accent: var(--garrul-accent, #3b82f6);
-		--gr-accent-fg: var(--garrul-accent-fg, #ffffff);
+		--gr-accent-fg: var(--garrul-accent-fg, #0b1220);
 		--gr-link: var(--garrul-link, #6aa9ff);
 		--gr-error: var(--garrul-error, #f08a8a);
 		--gr-notice: var(--garrul-notice, #6cb6e8);
@@ -96,7 +96,7 @@
 	--gr-border: var(--garrul-border, #2e353d);
 	--gr-muted: var(--garrul-muted, #9aa3b0);
 	--gr-accent: var(--garrul-accent, #3b82f6);
-	--gr-accent-fg: var(--garrul-accent-fg, #ffffff);
+	--gr-accent-fg: var(--garrul-accent-fg, #0b1220);
 	--gr-link: var(--garrul-link, #6aa9ff);
 	--gr-error: var(--garrul-error, #f08a8a);
 	--gr-notice: var(--garrul-notice, #6cb6e8);

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -476,6 +476,14 @@ button:active:not([disabled]) { opacity: 0.75; }
 }
 .gr-time { color: var(--gr-muted); font-size: 0.85em; }
 .gr-edited { color: var(--gr-muted); font-size: 0.85em; font-style: italic; }
+/* The permalink wraps the timestamp, so it must read as metadata, not as a
+   second link competing with the author name. Colour and weight are inherited;
+   only hover reveals that it is clickable. */
+.gr-permalink {
+	color: inherit;
+	text-decoration: none;
+}
+.gr-permalink:hover { text-decoration: underline; }
 .gr-pending {
 	color: var(--gr-notice);
 	border: 1px solid var(--gr-notice);

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -337,8 +337,8 @@
 	align-self: flex-start;
 }
 .gr-toolbar-btn:hover { background: var(--gr-hover); border-color: var(--gr-accent); }
-/* One focus ring for every interactive control in the shadow tree. */
-button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-visible {
+/* One focus ring for every interactive control in the shadow tree, including links. */
+button:focus-visible, textarea:focus-visible, input:focus-visible, select:focus-visible, a:focus-visible {
 	outline: 2px solid var(--gr-accent);
 	outline-offset: 2px;
 }

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -70,6 +70,7 @@
 @media (prefers-color-scheme: dark) {
 	:host(:not([data-theme="light"])) {
 		--gr-fg: var(--garrul-fg, #e6e8eb);
+		--gr-bg: var(--garrul-bg, #12161a);
 		--gr-input-bg: var(--garrul-input-bg, #1b1f24);
 		--gr-border: var(--garrul-border, #2e353d);
 		--gr-muted: var(--garrul-muted, #9aa3b0);
@@ -90,6 +91,7 @@
 :host([data-theme="dark"]) {
 	color-scheme: dark;
 	--gr-fg: var(--garrul-fg, #e6e8eb);
+	--gr-bg: var(--garrul-bg, #12161a);
 	--gr-input-bg: var(--garrul-input-bg, #1b1f24);
 	--gr-border: var(--garrul-border, #2e353d);
 	--gr-muted: var(--garrul-muted, #9aa3b0);

--- a/tests/identicon.test.ts
+++ b/tests/identicon.test.ts
@@ -38,4 +38,13 @@ describe("identiconSvg", () => {
 		expect(countAtX(0)).toBe(countAtX(4 * cell));
 		expect(countAtX(cell)).toBe(countAtX(3 * cell));
 	});
+
+	it("is marked as decorative for screen readers", () => {
+		const svg = identiconSvg("seed");
+		// The SVG must be marked as decorative with aria-hidden="true" (not role="img"
+		// or aria-label), since the commenter's name is already in the byline beside it.
+		expect(svg).toContain('aria-hidden="true"');
+		expect(svg).not.toMatch(/role="img"/);
+		expect(svg).not.toMatch(/aria-label/);
+	});
 });

--- a/tests/permalink-route.test.ts
+++ b/tests/permalink-route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * GET /c/:id — the server-side comment permalink redirect.
+ *
+ * The behaviour that matters here is the *fragment*: the route's whole job is
+ * to land the reader on `<post.url>#garrul-comment-<id>` so the widget's
+ * hash handling (src/widget/permalink.ts) can reveal the comment. A stored
+ * `post.url` that already carries a fragment is the case that used to break
+ * it, so it gets its own case below rather than living only in a comment.
+ */
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { permalink } from "../src/routes/permalink";
+import { commentAnchorId } from "../src/widget/permalink";
+import { asD1 } from "./helpers/d1";
+import type { TestEnv } from "./helpers/app";
+
+const ID = "01JQZ8X4M2NPQRSTUVWXYZ0123";
+
+/**
+ * D1 stub that answers the route's two reads, dispatching on the table name in
+ * the SQL. Either row may be `null` to exercise a 404 branch.
+ */
+const stubDb = (
+	comment: Record<string, unknown> | null,
+	post: Record<string, unknown> | null,
+) =>
+	asD1({
+		prepare: (sql: string) => ({
+			bind: () => ({
+				first: async () => (sql.includes("FROM comments") ? comment : post),
+			}),
+		}),
+	});
+
+const aComment = (over: Record<string, unknown> = {}) => ({
+	id: ID,
+	post_slug: "my-post",
+	status: "approved",
+	...over,
+});
+
+const aPost = (url: string | null) => ({
+	slug: "my-post",
+	title: "My Post",
+	url,
+	created_at: "2026-01-01T00:00:00.000Z",
+	closed: 0,
+	published_at: null,
+});
+
+const get = (
+	id: string,
+	comment: Record<string, unknown> | null,
+	post: Record<string, unknown> | null,
+) => {
+	const app = new Hono<{ Bindings: TestEnv }>();
+	app.route("/c", permalink);
+	return app.request(`/c/${id}`, {}, { DB: stubDb(comment, post) });
+};
+
+describe("GET /c/:id", () => {
+	it("redirects to the post URL with the comment anchor", async () => {
+		const res = await get(ID, aComment(), aPost("https://blog.example.com/post/"));
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toBe(
+			`https://blog.example.com/post/#${commentAnchorId(ID)}`,
+		);
+		expect(res.headers.get("cache-control")).toBe("public, max-age=300");
+	});
+
+	it("replaces an existing fragment rather than appending to it", async () => {
+		// The old string-concatenation build emitted
+		// `…/post/#section-2&garrul-comment-<id>`, one fragment named
+		// `section-2&garrul-comment-<id>`, which matches no element — and which
+		// `commentIdFromHash` correctly refuses to parse, so the widget never
+		// revealed the comment either.
+		const res = await get(
+			ID,
+			aComment(),
+			aPost("https://blog.example.com/post/#section-2"),
+		);
+		expect(res.headers.get("location")).toBe(
+			`https://blog.example.com/post/#${commentAnchorId(ID)}`,
+		);
+	});
+
+	it("preserves an existing query string", async () => {
+		const res = await get(
+			ID,
+			aComment(),
+			aPost("https://blog.example.com/post/?utm=x"),
+		);
+		expect(res.headers.get("location")).toBe(
+			`https://blog.example.com/post/?utm=x#${commentAnchorId(ID)}`,
+		);
+	});
+
+	it("400s on an over-long id without touching the database", async () => {
+		const res = await get("x".repeat(27), aComment(), aPost("https://blog.example.com/"));
+		expect(res.status).toBe(400);
+	});
+
+	it("404s when the comment does not exist", async () => {
+		const res = await get(ID, null, aPost("https://blog.example.com/"));
+		expect(res.status).toBe(404);
+	});
+
+	it.each(["deleted", "spam", "pending"])("404s on a %s comment", async (status) => {
+		const res = await get(ID, aComment({ status }), aPost("https://blog.example.com/"));
+		expect(res.status).toBe(404);
+	});
+
+	it("404s when the post has no URL", async () => {
+		const res = await get(ID, aComment(), aPost(null));
+		expect(res.status).toBe(404);
+	});
+
+	it.each(["javascript:alert(1)", "data:text/html,<script>", "//evil.example.com"])(
+		"404s rather than redirecting to %s",
+		async (hostile) => {
+			const res = await get(ID, aComment(), aPost(hostile));
+			expect(res.status).toBe(404);
+		},
+	);
+});

--- a/tests/widget-permalink.test.ts
+++ b/tests/widget-permalink.test.ts
@@ -7,7 +7,7 @@
  * the last rung, for the iframe embed standing on the Worker's own origin.
  */
 import { describe, it, expect } from "vitest";
-import { commentHref } from "../src/widget/permalink";
+import { commentAnchorId, commentHref, commentIdFromHash } from "../src/widget/permalink";
 
 const API = "https://comments.example.com";
 const ID = "01JQZ8X4M2";
@@ -98,5 +98,35 @@ describe("commentHref", () => {
 				apiBase: `${API}/`,
 			}),
 		).toBe(`${API}/c/${ID}`);
+	});
+});
+
+describe("commentIdFromHash", () => {
+	it("recovers the id from a valid #garrul-comment-<id> hash", () => {
+		expect(commentIdFromHash(`#${commentAnchorId(ID)}`)).toBe(ID);
+	});
+
+	it.each(["", "#"])("returns null for %j", (hash) => {
+		expect(commentIdFromHash(hash)).toBeNull();
+	});
+
+	it("returns null for a hash with the wrong prefix", () => {
+		expect(commentIdFromHash("#some-other-anchor")).toBeNull();
+	});
+
+	it("returns null when the prefix has nothing after it", () => {
+		expect(commentIdFromHash(`#${commentAnchorId("")}`)).toBeNull();
+	});
+
+	it("returns null for #existing&garrul-comment-<id> rather than the id", () => {
+		// src/routes/permalink.ts:54 emits exactly this shape when a post's
+		// stored URL already carries a fragment: the two fragments get joined
+		// with `&` rather than one replacing the other. The combined string
+		// doesn't start with our prefix (it starts with the *existing*
+		// fragment), so this is a plain no-match, not a special case — and it
+		// resolves to no element in a browser either way (see the
+		// "replaces an existing fragment" case above), so a null here costs
+		// nothing real.
+		expect(commentIdFromHash(`#existing&${commentAnchorId(ID)}`)).toBeNull();
 	});
 });

--- a/tests/widget-permalink.test.ts
+++ b/tests/widget-permalink.test.ts
@@ -56,8 +56,8 @@ describe("commentHref", () => {
 	});
 
 	it("replaces an existing fragment rather than appending to it", () => {
-		// Deliberate divergence from src/routes/permalink.ts:56, which emits
-		// `#existing&garrul-comment-<id>` — that resolves to nothing.
+		// The server's /c/:id redirect follows the same rule — see the matching
+		// case in tests/permalink-route.test.ts.
 		expect(
 			commentHref(ID, {
 				dataUrl: "https://blog.example.com/post/#section-2",
@@ -119,14 +119,13 @@ describe("commentIdFromHash", () => {
 	});
 
 	it("returns null for #existing&garrul-comment-<id> rather than the id", () => {
-		// src/routes/permalink.ts:54 emits exactly this shape when a post's
-		// stored URL already carries a fragment: the two fragments get joined
-		// with `&` rather than one replacing the other. The combined string
-		// doesn't start with our prefix (it starts with the *existing*
-		// fragment), so this is a plain no-match, not a special case — and it
-		// resolves to no element in a browser either way (see the
-		// "replaces an existing fragment" case above), so a null here costs
-		// nothing real.
+		// Nothing we emit produces this shape — both `commentHref` and the
+		// server's /c/:id redirect replace an existing fragment rather than
+		// joining to it. It is pinned because the alternative implementation
+		// (searching for the prefix anywhere in the hash) would return `<id>`
+		// here, and would equally match an unrelated page's
+		// `#foo-garrul-comment-bar`. Anchoring the match at the start of the
+		// hash is the behaviour under test.
 		expect(commentIdFromHash(`#existing&${commentAnchorId(ID)}`)).toBeNull();
 	});
 });

--- a/tests/widget-permalink.test.ts
+++ b/tests/widget-permalink.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Comment permalink resolution (src/widget/permalink.ts).
+ *
+ * The widget links each comment's timestamp at the *host page*, not at the
+ * Worker's /c/:id redirect — every click of the latter would spend a Worker
+ * invocation against the 100k/day free-tier ceiling. /c/:id survives only as
+ * the last rung, for the iframe embed standing on the Worker's own origin.
+ */
+import { describe, it, expect } from "vitest";
+import { commentHref } from "../src/widget/permalink";
+
+const API = "https://comments.example.com";
+const ID = "01JQZ8X4M2";
+
+describe("commentHref", () => {
+	it("anchors against data-url when it is a valid http(s) URL", () => {
+		expect(
+			commentHref(ID, {
+				dataUrl: "https://blog.example.com/post/",
+				locationHref: "https://blog.example.com/post/",
+				apiBase: API,
+			}),
+		).toBe(`https://blog.example.com/post/#garrul-comment-${ID}`);
+	});
+
+	it("falls back to location when data-url is absent", () => {
+		expect(
+			commentHref(ID, {
+				dataUrl: undefined,
+				locationHref: "https://blog.example.com/other/",
+				apiBase: API,
+			}),
+		).toBe(`https://blog.example.com/other/#garrul-comment-${ID}`);
+	});
+
+	it("uses /c/:id when standing on the Worker's own origin", () => {
+		// The iframe embed (src/routes/embed-iframe.ts) without ?url= — location
+		// is the Worker's /embed/:slug page, so anchoring at it self-references.
+		expect(
+			commentHref(ID, {
+				dataUrl: undefined,
+				locationHref: `${API}/embed/my-post`,
+				apiBase: API,
+			}),
+		).toBe(`${API}/c/${ID}`);
+	});
+
+	it("preserves an existing query string", () => {
+		expect(
+			commentHref(ID, {
+				dataUrl: "https://blog.example.com/post/?utm=x",
+				locationHref: "https://blog.example.com/post/",
+				apiBase: API,
+			}),
+		).toBe(`https://blog.example.com/post/?utm=x#garrul-comment-${ID}`);
+	});
+
+	it("replaces an existing fragment rather than appending to it", () => {
+		// Deliberate divergence from src/routes/permalink.ts:56, which emits
+		// `#existing&garrul-comment-<id>` — that resolves to nothing.
+		expect(
+			commentHref(ID, {
+				dataUrl: "https://blog.example.com/post/#section-2",
+				locationHref: "https://blog.example.com/post/",
+				apiBase: API,
+			}),
+		).toBe(`https://blog.example.com/post/#garrul-comment-${ID}`);
+	});
+
+	it.each(["javascript:alert(1)", "data:text/html,<script>", "//evil.example.com", "/relative/path"])(
+		"rejects %s in data-url and falls through to location",
+		(hostile) => {
+			expect(
+				commentHref(ID, {
+					dataUrl: hostile,
+					locationHref: "https://blog.example.com/post/",
+					apiBase: API,
+				}),
+			).toBe(`https://blog.example.com/post/#garrul-comment-${ID}`);
+		},
+	);
+
+	it("falls through to /c/:id when neither data-url nor location is usable", () => {
+		expect(
+			commentHref(ID, {
+				dataUrl: undefined,
+				locationHref: "about:blank",
+				apiBase: API,
+			}),
+		).toBe(`${API}/c/${ID}`);
+	});
+
+	it("does not double a trailing slash on the /c/ fallback", () => {
+		expect(
+			commentHref(ID, {
+				dataUrl: undefined,
+				locationHref: "about:blank",
+				apiBase: `${API}/`,
+			}),
+		).toBe(`${API}/c/${ID}`);
+	});
+});


### PR DESCRIPTION
Backlog #4 (copy-permalink) and #6 (accessibility pass), shipping as v2.17.0. #5 (collapse/expand subtree) was already shipped in v1.11.0 — closed, no code.

## Permalinks

New `src/widget/permalink.ts` resolves a per-comment URL against the host page (`commentAnchorId` / `commentHref` / `commentIdFromHash`). Comment timestamps are now anchors.

Browsers don't scroll or focus into an open shadow root, so the widget handles fragment navigation itself: a `hashchange` listener per mount scrolls the target, honors `prefers-reduced-motion`, and moves focus.

## Accessibility

- Accessible names on the four unlabeled form controls
- Delete-confirm uses `aria-describedby` instead of `role="status"`
- `aria-pressed` initialized on page-level vote buttons
- `role="status"` removed from the char counter and skeleton list (neither is a live region)
- Contrast tokens re-cut for WCAG AA
- Posting a comment now focuses it and announces it — deferred a macrotask so the live region is registered before its text changes

## Notes

- The dark `--gr-bg` default changes; called out in the release body.
- Widget DOM behavior is argued from source, not observed — the vitest node pool has no jsdom.

lint · typecheck · manifest:check · 1905 tests · build · size 18.23 KB gz (60.8% of budget)
