### PR TITLE
feat(widget): render a posted comment from its 201 echo instead of reloading

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1229,11 +1229,14 @@ Two consequences worth planning around:
   until the comments section scrolls into view still takes a bouncer
   to zero, so it is still worth doing on a high-traffic blog — but the
   saving is 2 requests per bounce, not 4 to 6.
-- **Posting a comment costs one request, not two** (since v2.20.0).
-  The widget renders the new comment from the `201` echo instead of
-  re-fetching the thread's first page. That also fixed the case where a
-  reader's own comment was missing after posting on a thread past
-  `comments_per_page` under the oldest-first sort.
+- **Posting a comment normally costs one request, not two** (since
+  v2.20.0). The widget renders the new comment from the `201` echo
+  instead of re-fetching the thread's first page. That also fixed the
+  case where a reader's own comment was missing after posting on a
+  thread past `comments_per_page` under the oldest-first sort. It still
+  spends the old second request when the echo cannot be placed — a
+  Worker older than the bundle, or a reply whose spot on the page is not
+  determined yet — so budget one per comment, occasionally two.
 
 Nothing was removed. Every endpoint the old mount called still exists
 and still behaves identically, and a widget bundle newer than the

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1229,6 +1229,11 @@ Two consequences worth planning around:
   until the comments section scrolls into view still takes a bouncer
   to zero, so it is still worth doing on a high-traffic blog — but the
   saving is 2 requests per bounce, not 4 to 6.
+- **Posting a comment costs one request, not two** (since v2.20.0).
+  The widget renders the new comment from the `201` echo instead of
+  re-fetching the thread's first page. That also fixed the case where a
+  reader's own comment was missing after posting on a thread past
+  `comments_per_page` under the oldest-first sort.
 
 Nothing was removed. Every endpoint the old mount called still exists
 and still behaves identically, and a widget bundle newer than the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,10 @@ When the endpoint answers a 404 — what a Worker without the route
 returns — the widget silently falls back to exactly the pre-v2.15.0
 call sequence. So does a 200 whose body carries no comment tree, and a
 request that never lands. The 404 is remembered per API base, so a
-reader on such a Worker probes once and every later reload — posting,
-editing, deleting, changing sort — goes straight to the legacy calls.
+reader on such a Worker probes once and every later reload — editing,
+deleting, changing sort — goes straight to the legacy calls. Posting is
+not in that list any more: since v2.20.0 a successful post reloads
+nothing on either path.
 
 Any **other** non-2xx does not fall back: it surfaces as an error, the
 same one a failed `/api/v1/comments` would render. The fallback is only
@@ -568,6 +570,45 @@ other threads, with per-row buttons and an unsubscribe-from-all.
 
 **Embedders need no wiring for any of this.** It is all inside the widget
 and the emails; there are no new `data-*` attributes and no new env vars.
+
+### Posting a comment (since v2.20.0)
+
+A successful post renders straight from the `201` the server already
+returns, and fetches nothing back.
+
+`POST /api/v1/comments` echoes the new comment in full, so the widget
+builds the node from that echo and inserts it into the page it is
+already showing. Before v2.20.0 it discarded the echo and re-fetched the
+first page of the thread instead, which had two costs an embedder can
+see:
+
+- **A second request per comment.** Posting now costs one.
+- **On a thread longer than one page, your own comment could land
+  nowhere.** A reload fetches page *one*, and under the oldest-first
+  sort a new top-level comment belongs on the *last* page — so it
+  simply was not in the response that replaced the page.
+
+The reader's own comment carries a subtle accent (`.gr-thread`
+`[data-posted]`, styleable like everything else in §5) for as long as it
+is on screen. That is deliberate rather than decorative: under
+oldest-first and top-first its **position is provisional**. It is
+inserted where the reader is looking — last under `old`, first under
+`new` and `top`, nested under its parent for a reply — and the next real
+load puts it where the sort actually places it. Marking it keeps that
+from reading as a claim about thread order.
+
+Nothing about this is optimistic. The comment is only drawn after the
+server accepts it, and it is drawn with the status the server assigned —
+a post held by moderation renders with its "Pending approval" badge, not
+as approved-then-corrected. Whether a comment is held is a server
+verdict (muted words, Akismet, Workers AI, first-comment hold), so it is
+not something the widget could have guessed.
+
+Because the page is no longer replaced, **scroll position and every open
+form survive a post**. If the echo is missing a field the renderer needs
+— a widget bundle newer than the Worker it talks to — the widget falls
+back to the pre-v2.20.0 reload, the same way the mount falls back on a
+404 (§3).
 
 ### Markdown preview (since v1.10.0)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,9 +181,13 @@ returns — the widget silently falls back to exactly the pre-v2.15.0
 call sequence. So does a 200 whose body carries no comment tree, and a
 request that never lands. The 404 is remembered per API base, so a
 reader on such a Worker probes once and every later reload — editing,
-deleting, changing sort — goes straight to the legacy calls. Posting is
-not in that list any more: since v2.20.0 a successful post reloads
-nothing on either path.
+deleting, changing sort — goes straight to the legacy calls. Posting has
+left that list in the normal case: since v2.20.0 a successful post
+renders from its own `201` and reloads nothing on either path. It still
+falls back to a reload when that echo cannot be rendered where it
+belongs — an old or malformed payload, or a parent no longer on screen
+(§4, *Posting a comment*) — so budget one request per comment and a
+second only on those paths.
 
 Any **other** non-2xx does not fall back: it surfaces as an error, the
 same one a failed `/api/v1/comments` would render. The fallback is only
@@ -593,9 +597,11 @@ The reader's own comment carries a subtle accent (`.gr-thread`
 is on screen. That is deliberate rather than decorative: under
 oldest-first and top-first its **position is provisional**. It is
 inserted where the reader is looking — last under `old`, first under
-`new` and `top`, nested under its parent for a reply — and the next real
-load puts it where the sort actually places it. Marking it keeps that
-from reading as a claim about thread order.
+`new` and `top`, nested under its parent for a reply — and the next
+response that has an opinion puts it where the sort actually places it:
+a reload, or a Load More page that turns out to contain it, moves the
+node into the server's order rather than leaving the guess standing.
+Marking it keeps that from reading as a claim about thread order.
 
 Nothing about this is optimistic. The comment is only drawn after the
 server accepts it, and it is drawn with the status the server assigned —
@@ -605,10 +611,19 @@ verdict (muted words, Akismet, Workers AI, first-comment hold), so it is
 not something the widget could have guessed.
 
 Because the page is no longer replaced, **scroll position and every open
-form survive a post**. If the echo is missing a field the renderer needs
-— a widget bundle newer than the Worker it talks to — the widget falls
-back to the pre-v2.20.0 reload, the same way the mount falls back on a
-404 (§3).
+form survive a post**. The widget falls back to the pre-v2.20.0 reload —
+the same way the mount falls back on a 404 (§3), and costing the same
+second request it always did — whenever it cannot place the comment
+honestly:
+
+- the echo is missing a field the renderer needs (a widget bundle newer
+  than the Worker it talks to);
+- the comment was a reply and its parent is not on the rendered page;
+- the reply flattens onto a tier whose remaining replies are still
+  behind a "Show N more replies" button, so where it belongs in that
+  tier is not known yet.
+
+So posting costs one request in the ordinary case and two in those.
 
 ### Markdown preview (since v1.10.0)
 

--- a/src/widget/comment-node.ts
+++ b/src/widget/comment-node.ts
@@ -1,0 +1,248 @@
+/**
+ * The shape the comment renderer draws, and how to build one of those from the
+ * 201 echo of `POST /api/v1/comments` instead of from a second round trip.
+ *
+ * Lives outside embed.ts for the same reason boot.ts does: the interesting part
+ * is arithmetic — what depth a new reply renders at, whether it gets a flatten
+ * prefix, which list it belongs in — and embed.ts needs a DOM to load, so none
+ * of it would otherwise be reachable from the `node` test pool.
+ *
+ * Unlike boot.ts this module *does* know the renderer's node shape. That is not
+ * an inconsistency: boot.ts refuses to know it (see the comment on
+ * `BootstrapResponse.comments`) because it only has to recognize a tree well
+ * enough to decide whether to fall back, whereas this module has to *produce*
+ * one that the renderer will accept.
+ */
+import type { SortKey } from "./boot";
+import type { ReactionCount } from "./reactions";
+
+/**
+ * Mirrors lib/tree.ts's TreeAuthor. No `is_admin`: the API stopped sending it
+ * (it let anyone enumerate privileged accounts) and nothing here rendered it.
+ */
+export type TreeAuthor = {
+	id: string;
+	name: string;
+	provider: string;
+	avatar_svg: string | null;
+	avatar_url: string | null;
+};
+
+export type TreeNode = {
+	id: string;
+	parent_id: string | null;
+	body_html: string;
+	status: "approved" | "pending" | "spam" | "deleted";
+	edited_at: number | null;
+	deleted_at: number | null;
+	deleted_by: "author" | "moderator" | null;
+	created_at: number;
+	author: TreeAuthor;
+	depth: number;
+	flatten_from: string | null;
+	/** Optional on purpose: the list response is edge-cached, so payloads
+	 *  predating this field keep being served for up to TREE_CACHE_TTL after a
+	 *  deploy. Read it through the `n.depth < 4` fallback in embed.ts, never
+	 *  bare. `synthesizePosted` leans on that same fallback deliberately — see
+	 *  its note on why it omits the field rather than computing it. */
+	can_reply?: boolean;
+	reactions: ReactionCount[];
+	score_up: number;
+	score_down: number;
+	my_vote: -1 | 0 | 1;
+	replies: TreeNode[];
+};
+
+/**
+ * Display flatten threshold: anything nested deeper renders un-indented on this
+ * tier with an "@parent" prefix instead.
+ *
+ * Mirror of `MAX_DEPTH` in src/lib/tree.ts. Duplicated rather than imported
+ * because tsconfig.widget.json includes only `src/widget/**`, so the widget
+ * bundle cannot reach server modules — the same reason embed.ts keeps its own
+ * copy of the OAuth provider union.
+ */
+export const MAX_DEPTH = 4;
+
+/**
+ * The comment `POST /api/v1/comments` echoes back on 201 — the fields of
+ * `serializeComment` (src/routes/api.comments.ts) that the renderer needs.
+ *
+ * `post_slug` is in the real payload and deliberately absent here: nothing in
+ * the render path reads it.
+ */
+export type PostedEcho = {
+	id: string;
+	parent_id: string | null;
+	body_html: string;
+	status: TreeNode["status"];
+	edited_at: number | null;
+	deleted_at: number | null;
+	deleted_by: TreeNode["deleted_by"];
+	created_at: number;
+	author: TreeAuthor;
+};
+
+const STATUSES: ReadonlySet<string> = new Set([
+	"approved",
+	"pending",
+	"spam",
+	"deleted",
+]);
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null;
+
+const nullableNumber = (v: unknown): number | null =>
+	typeof v === "number" ? v : null;
+
+const nullableString = (v: unknown): string | null =>
+	typeof v === "string" ? v : null;
+
+/**
+ * Narrow a `{ comment: … }` body to something renderable, or `null`.
+ *
+ * `null` is not an error — it is the signal to take the old post-then-reload
+ * path. A widget bundle can outlive the Worker it talks to (the same premise
+ * behind boot.ts's bootstrap fallback), and a Worker whose echo predates a
+ * field the renderer needs would otherwise produce a comment with a blank body
+ * or a missing avatar. Validating here means the degraded case costs one extra
+ * request rather than one broken comment.
+ */
+export const readPostedEcho = (body: unknown): PostedEcho | null => {
+	if (!isRecord(body)) return null;
+	const author = body.author;
+	if (
+		typeof body.id !== "string" ||
+		typeof body.body_html !== "string" ||
+		typeof body.created_at !== "number" ||
+		typeof body.status !== "string" ||
+		!STATUSES.has(body.status) ||
+		!isRecord(author) ||
+		typeof author.id !== "string" ||
+		typeof author.name !== "string" ||
+		typeof author.provider !== "string"
+	) {
+		return null;
+	}
+	const deletedBy = body.deleted_by;
+	return {
+		id: body.id,
+		parent_id: nullableString(body.parent_id),
+		body_html: body.body_html,
+		status: body.status as TreeNode["status"],
+		edited_at: nullableNumber(body.edited_at),
+		deleted_at: nullableNumber(body.deleted_at),
+		deleted_by:
+			deletedBy === "author" || deletedBy === "moderator" ? deletedBy : null,
+		created_at: body.created_at,
+		author: {
+			id: author.id,
+			name: author.name,
+			provider: author.provider,
+			avatar_svg: nullableString(author.avatar_svg),
+			avatar_url: nullableString(author.avatar_url),
+		},
+	};
+};
+
+/**
+ * Which list a new reply joins, and how it renders once it is there.
+ *
+ * `into` distinguishes the two cases the server's tree builder produces: a
+ * normal reply is appended to its parent's own `replies`, but a reply to a node
+ * that has *already* been flattened is lifted to the parent's own tier and
+ * becomes its sibling, because that is where buildSubtree pushes descendants
+ * once past the threshold (it keeps chasing them into `frame.out`).
+ */
+export type ReplySlot = {
+	into: "replies" | "siblings";
+	depth: number;
+	flatten_from: string | null;
+};
+
+/**
+ * Mirror of the flatten rule in `buildSubtree` (src/lib/tree.ts), stated in
+ * terms of the parent node the widget already has on screen rather than the
+ * traversal frame the server has.
+ *
+ * The `flatten_from` label is the *immediate* parent's author name in both
+ * flattened cases, which is what makes them collapse into one branch here.
+ */
+export const replySlot = (parent: TreeNode): ReplySlot => {
+	const depth = parent.depth + 1;
+	if (depth < MAX_DEPTH) {
+		return { into: "replies", depth, flatten_from: null };
+	}
+	return {
+		into: parent.depth >= MAX_DEPTH ? "siblings" : "replies",
+		depth: MAX_DEPTH,
+		flatten_from: parent.author.name,
+	};
+};
+
+/**
+ * Where a brand-new *top-level* comment goes in the page already rendered.
+ *
+ * Replies need no such decision: the server orders every reply list
+ * `created_at ASC` regardless of `?sort=` (see `listCommentsForThreads` in
+ * src/db/queries.ts), so the newest reply is genuinely last in its parent's
+ * list and appending it is the truth.
+ *
+ * Top-level order is the sort key, and only `new` puts a fresh comment
+ * somewhere this page can honestly claim. Under `old` it belongs after every
+ * comment on every page, including pages not loaded yet; under `top` its
+ * position depends on scores it does not have. Both get the end and the start
+ * of the rendered page respectively — near where the reader is looking — and
+ * the caller marks the node as theirs so it reads as "here is what you posted"
+ * rather than as a claim about thread order. The next real load puts it where
+ * it actually belongs.
+ */
+export const topLevelPlacement = (sort: SortKey): "prepend" | "append" =>
+	sort === "old" ? "append" : "prepend";
+
+/**
+ * Build the node to render from the echo, given the parent it was a reply to
+ * (`null` for a top-level comment).
+ *
+ * Everything the echo does not carry is what a comment nobody has seen yet must
+ * be: no reactions, no votes, no replies.
+ *
+ * `can_reply` is deliberately left unset rather than computed. The server
+ * derives it from the *stored* depth against `MAX_REPLY_DEPTH` (8), and stored
+ * depth is not recoverable from a flattened node — every node on the threshold
+ * tier reports `depth === MAX_DEPTH` whatever its real nesting. Leaving the
+ * field absent hands the decision to embed.ts's documented `?? n.depth < 4`
+ * fallback, which is the same answer the widget already gives for an
+ * edge-cached payload that predates the field. The cost is that a reply to a
+ * freshly posted comment on the flattened tier is unavailable until the next
+ * load; the alternative is a second depth model in the widget that would be
+ * wrong in the other direction.
+ */
+export const synthesizePosted = (
+	echo: PostedEcho,
+	parent: TreeNode | null,
+): { node: TreeNode; slot: ReplySlot | null } => {
+	const slot = parent ? replySlot(parent) : null;
+	return {
+		node: {
+			id: echo.id,
+			parent_id: echo.parent_id,
+			body_html: echo.body_html,
+			status: echo.status,
+			edited_at: echo.edited_at,
+			deleted_at: echo.deleted_at,
+			deleted_by: echo.deleted_by,
+			created_at: echo.created_at,
+			author: echo.author,
+			depth: slot ? slot.depth : 0,
+			flatten_from: slot ? slot.flatten_from : null,
+			reactions: [],
+			score_up: 0,
+			score_down: 0,
+			my_vote: 0,
+			replies: [],
+		},
+		slot,
+	};
+};

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2388,7 +2388,22 @@ const renderReplyList = (
 		more.type = "button";
 		more.textContent = s("w.more_replies", { n: hidden.length });
 		more.addEventListener("click", () => {
+			// Same arbitration as `appendThreads`, on the reply side: this batch was
+			// captured when the list rendered, and `insertPostedNode` can have put
+			// one of these replies on screen live in the meantime — a load that
+			// raced a post puts the reply in `hidden` and the 201 then draws it
+			// after the button. Revealing the batch would then draw it twice. No
+			// repositioning needed, unlike top level: replies are ordered
+			// `created_at ASC`, this batch goes before the button and the live node
+			// is the newest, so last is already where it belongs.
+			const onScreen = new Set<string>();
+			for (const child of container.querySelectorAll<HTMLElement>(
+				":scope > .gr-thread",
+			)) {
+				if (child.dataset.id) onScreen.add(child.dataset.id);
+			}
 			for (const r of hidden) {
+				if (onScreen.has(r.id)) continue;
 				container.insertBefore(buildThread(r, ctx), more);
 			}
 			more.remove();
@@ -2860,29 +2875,51 @@ const fetchPage = async (
 };
 
 /**
- * Render top-level threads into the list, skipping any already on screen.
+ * Render top-level threads into the list, never drawing an id twice.
  *
- * The skip is load-more's guard against `insertPostedNode`. A comment rendered
- * from its own POST echo is on screen without the server having been asked
- * where it belongs, so a later page can legitimately contain it — under `old`
- * when the post landed on what was already the last page, and under `top` at
- * whatever rank a comment with no votes takes. Rendering it twice is the one
- * visible way that can go wrong, and comparing ids is the whole fix.
+ * The id check is load-more's arbitration with `insertPostedNode`. A comment
+ * rendered from its own POST echo is on screen without the server having been
+ * asked where it belongs, so a later page can legitimately contain it — under
+ * `old` when the post landed on what was already the last page, and under `top`
+ * at whatever rank a comment with no votes takes.
+ *
+ * Which is why a provisional node (`[data-posted]`) is *replaced* rather than
+ * skipped. Skipping keeps a guess that this very response disproves: under
+ * `old` the following page would render after a comment newer than all of it,
+ * and under `top` a score-0 post would sit above the ranks the server just
+ * sent. Rebuilding it here, in the order the page arrived in, is the server
+ * answering the question the echo path had to guess at — and it picks up the
+ * votes, reactions and replies the provisional node was drawn without. The
+ * accent carries over: the comment is still the reader's own.
+ *
+ * The cost is that a form left open under one's own just-posted comment does
+ * not survive that particular Load More. Every other node on screen is
+ * untouched, which is more than the pre-v2.20.0 post-then-reload kept.
+ *
+ * An id already on screen that is *not* provisional is left alone: it is a
+ * genuine overlap between pages, and the copy on screen is as authoritative as
+ * the one in this response.
  */
 const appendThreads = (
 	list: HTMLElement,
 	threads: TreeNode[],
 	ctx: WidgetCtx,
 ): void => {
-	const seen = new Set<string>();
+	const onScreen = new Map<string, HTMLElement>();
 	for (const child of list.querySelectorAll<HTMLElement>(":scope > .gr-thread")) {
 		const id = child.dataset.id;
-		if (id) seen.add(id);
+		if (id && !onScreen.has(id)) onScreen.set(id, child);
 	}
 	for (const t of threads) {
-		if (seen.has(t.id)) continue;
-		seen.add(t.id);
-		list.appendChild(buildThread(t, ctx));
+		const existing = onScreen.get(t.id);
+		if (existing && existing.dataset.posted !== "1") continue;
+		const built = buildThread(t, ctx);
+		if (existing) {
+			built.dataset.posted = "1";
+			existing.remove();
+		}
+		onScreen.set(t.id, built);
+		list.appendChild(built);
 	}
 };
 
@@ -3100,19 +3137,28 @@ const mountCtx = new WeakMap<ShadowRoot, WidgetCtx>();
  * `buildSubtree` emits a flattened subtree in DFS pre-order into the array its
  * nearest un-flattened ancestor sits in, so a comment's lifted descendants are
  * exactly the run of `[data-flat]` threads immediately following it. A new
- * reply to that comment joins the end of that run. `null` means the run reaches
- * the end of the list, which `insertBefore` reads as "append".
+ * reply to that comment joins the end of that run. `{ before: null }` means the
+ * run reaches the end of the list, which `insertBefore` reads as "append".
+ *
+ * `null` — no insertion point — is the case where the run runs into a "Show N
+ * more replies" button. Where it continues is then inside a batch that is not
+ * rendered yet, and that button inserts its batch immediately before itself
+ * when pressed, so anything placed here would end up above replies older than
+ * it the moment the reader expands the list. The caller falls back to a reload
+ * rather than guess, the same as for a parent that has been paged out.
  */
-const afterFlattenedRun = (thread: Element): Node | null => {
+const afterFlattenedRun = (thread: Element): { before: Node | null } | null => {
 	let last = thread;
 	for (let sib = thread.nextElementSibling; sib; sib = sib.nextElementSibling) {
 		const row = sib.querySelector(":scope > .gr-comment");
 		if (!sib.classList.contains("gr-thread") || !row?.hasAttribute("data-flat")) {
-			break;
+			return sib.classList.contains("gr-showmore")
+				? null
+				: { before: last.nextSibling };
 		}
 		last = sib;
 	}
-	return last.nextSibling;
+	return { before: last.nextSibling };
 };
 
 /**
@@ -3133,10 +3179,12 @@ const afterFlattenedRun = (thread: Element): Node | null => {
  * so the thing rendered here is the server's answer, arriving one request
  * earlier rather than being guessed and rolled back.
  *
- * Returns false when the tree cannot take the node — no rendered list, or a
- * reply whose parent has been paged out. Both mean "fall back to the old
- * post-then-reload path", exactly as `readPostedEcho` returning `null` does: a
- * comment in the wrong place is worse than a second request.
+ * Returns false when the tree cannot take the node — no rendered list, a reply
+ * whose parent has been paged out, or a flattened reply whose place on the tier
+ * is hidden behind a "Show N more replies" button (see `afterFlattenedRun`).
+ * All of them mean "fall back to the old post-then-reload path", exactly as
+ * `readPostedEcho` returning `null` does: a comment in the wrong place is worse
+ * than a second request.
  */
 const insertPostedNode = (
 	ctx: WidgetCtx,
@@ -3145,6 +3193,29 @@ const insertPostedNode = (
 ): boolean => {
 	const list = ctx.root.querySelector(".gr-list");
 	if (!list) return false;
+
+	// Announce and move focus, having established the comment is on screen. Two
+	// callers because "already there" is a success with nothing to draw.
+	const announcePosted = (): true => {
+		focusPostedComment(ctx.root, echo.id);
+		// No `setTimeout(0)` here, unlike loadOnce's arbitration. That delay exists
+		// because `root.replaceChildren()` had just built a brand-new live region,
+		// and a region has to be in the accessibility tree *before* its text
+		// changes. This path never destroys the tree, so the box has been sitting
+		// there all along and the write announces on the spot.
+		const statusEl = ctx.root.querySelector(".gr-error") as HTMLElement | null;
+		if (statusEl) showStatus(statusEl, s("w.posted"), "notice");
+		return true;
+	};
+
+	// A load that overlapped this POST can already have drawn the comment: the
+	// server commits before it answers, so any reload or Load More that fetched
+	// after the commit and landed before the 201 got back here includes it. The
+	// duplicate check in `appendThreads` cannot see that — it compares a page
+	// against the screen, and here it is the screen that is ahead. Inserting
+	// anyway would leave one comment rendered twice under a single anchor id.
+	if (ctx.root.getElementById(commentAnchorId(echo.id))) return announcePosted();
+
 	const { node, slot } = synthesizePosted(echo, parent);
 
 	// Resolve the destination before building anything, so a miss costs nothing.
@@ -3153,8 +3224,10 @@ const insertPostedNode = (
 	if (!slot) {
 		container = list;
 		// First comment on the thread: "no comments yet" is now false. The sort
-		// selector and the subscribe bell stay absent until the next real load —
-		// both render off `data.threads.length`, and neither is worth a request.
+		// selector stays absent until the next real load — it renders off
+		// `data.threads.length`, and one comment has no order to choose between.
+		// The subscribe bell is unaffected; it renders off the settings, not the
+		// thread, so it is already on screen wherever it belongs.
 		list.querySelector(".gr-empty")?.remove();
 		if (topLevelPlacement(activeSortFor(ctx.root)) === "prepend") {
 			before = list.firstChild;
@@ -3176,8 +3249,10 @@ const insertPostedNode = (
 			// own tier (see `replySlot`), not nested under it.
 			const tier = parentThread.parentElement;
 			if (!tier) return false;
+			const spot = afterFlattenedRun(parentThread);
+			if (!spot) return false;
 			container = tier;
-			before = afterFlattenedRun(parentThread);
+			before = spot.before;
 		}
 	}
 
@@ -3201,15 +3276,7 @@ const insertPostedNode = (
 		mount.reveal();
 	}
 
-	focusPostedComment(ctx.root, echo.id);
-	// No `setTimeout(0)` here, unlike loadOnce's arbitration. That delay exists
-	// because `root.replaceChildren()` had just built a brand-new live region,
-	// and a region has to be in the accessibility tree *before* its text
-	// changes. This path never destroys the tree, so the box has been sitting
-	// there all along and the write announces on the spot.
-	const statusEl = ctx.root.querySelector(".gr-error") as HTMLElement | null;
-	if (statusEl) showStatus(statusEl, s("w.posted"), "notice");
-	return true;
+	return announcePosted();
 };
 
 // Closed-state notice copy, picked from the server's closed_reason enum so the

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -2256,20 +2256,28 @@ const countDescendants = (n: TreeNode): number => {
  * Collapse/expand control for a node's replies. Hides/shows the replies
  * container in place (all replies are already in the DOM). `startCollapsed`
  * comes from the auto-collapse-depth setting.
+ *
+ * Returns handles rather than just the button because both the collapsed flag
+ * and the count are closure state, and neither survives contact with a reply
+ * that arrives after the toggle was built: the label would sit one short, and a
+ * container that auto-collapsed would swallow the new reply behind
+ * `display: none`. Every insert going through a full re-render is what has kept
+ * that unreachable, so the handles are what a caller needs in order not to.
  */
 const buildCollapseToggle = (
 	repliesEl: HTMLElement,
 	count: number,
 	startCollapsed: boolean,
-): HTMLButtonElement => {
+): { btn: HTMLButtonElement; reveal: () => void; countUp: () => void } => {
 	const btn = el("button", "gr-collapse") as HTMLButtonElement;
 	btn.type = "button";
 	let collapsed = startCollapsed;
+	let total = count;
 	const apply = () => {
 		repliesEl.style.display = collapsed ? "none" : "";
 		// The disclosure triangle is a glyph, not a word, so it stays outside the
 		// string — the count and its noun do not.
-		btn.textContent = `${collapsed ? "▸" : "▾"} ${s("w.replies", { n: count })}`;
+		btn.textContent = `${collapsed ? "▸" : "▾"} ${s("w.replies", { n: total })}`;
 		btn.setAttribute("aria-expanded", String(!collapsed));
 	};
 	btn.addEventListener("click", () => {
@@ -2277,7 +2285,70 @@ const buildCollapseToggle = (
 		apply();
 	});
 	apply();
-	return btn;
+	return {
+		btn,
+		reveal: () => {
+			if (!collapsed) return;
+			collapsed = false;
+			apply();
+		},
+		countUp: () => {
+			total += 1;
+			apply();
+		},
+	};
+};
+
+/**
+ * A node's mounted reply list: the container its direct replies render into,
+ * plus what an insert has to tell the toggle in front of it.
+ *
+ * Keyed on the `.gr-thread` wrap because that is the element the insert path
+ * can find from an id (`commentAnchorId`), and because the mount is created
+ * lazily — a node with no replies has no container and no toggle at all until
+ * someone replies to it.
+ */
+type ReplyMount = {
+	container: HTMLElement;
+	reveal: () => void;
+	countUp: () => void;
+};
+
+const replyMounts = new WeakMap<HTMLElement, ReplyMount>();
+
+/**
+ * The reply list for `n`, mounting the container and its toggle on first use.
+ *
+ * `startCollapsed` is computed here rather than passed so there is one rule for
+ * it. A caller that has just inserted the reader's own reply into a list that
+ * would auto-collapse calls `reveal()` afterwards; hiding a comment somebody
+ * made two seconds ago is never the right answer.
+ */
+const replyMountFor = (
+	threadEl: HTMLElement,
+	n: TreeNode,
+	ctx: WidgetCtx,
+): ReplyMount => {
+	const existing = replyMounts.get(threadEl);
+	if (existing) return existing;
+	const container = el("div", "gr-replies");
+	// Per-comment collapse toggle; auto-collapsed when this node is nested
+	// at/deeper than the configured depth (0 = never auto-collapse).
+	const startCollapsed =
+		ctx.autoCollapseDepth > 0 && n.depth >= ctx.autoCollapseDepth;
+	const toggle = buildCollapseToggle(
+		container,
+		countDescendants(n),
+		startCollapsed,
+	);
+	threadEl.append(toggle.btn, container);
+	const mount: ReplyMount = {
+		container,
+		reveal: toggle.reveal,
+		countUp: toggle.countUp,
+	};
+	replyMounts.set(threadEl, mount);
+	return mount;
 };
 
 /**
@@ -2317,18 +2388,7 @@ const buildThread = (n: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	wrap.id = commentAnchorId(n.id);
 	wrap.appendChild(buildComment(n, ctx));
 	if (n.replies.length > 0) {
-		const replies = el("div", "gr-replies");
-		renderReplyList(replies, n.replies, ctx);
-		// Per-comment collapse toggle; auto-collapsed when this node is nested
-		// at/deeper than the configured depth (0 = never auto-collapse).
-		const startCollapsed =
-			ctx.autoCollapseDepth > 0 && n.depth >= ctx.autoCollapseDepth;
-		const toggle = buildCollapseToggle(
-			replies,
-			countDescendants(n),
-			startCollapsed,
-		);
-		wrap.append(toggle, replies);
+		renderReplyList(replyMountFor(wrap, n, ctx).container, n.replies, ctx);
 	}
 	return wrap;
 };

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -49,7 +49,14 @@ import {
 // The node shape this file renders, plus the arithmetic that turns a POST echo
 // into one. Kept out of here so the depth/flatten/placement rules are reachable
 // from the DOM-free test pool — see the module header.
-import type { TreeAuthor, TreeNode } from "./comment-node";
+import {
+	type PostedEcho,
+	type TreeAuthor,
+	type TreeNode,
+	readPostedEcho,
+	synthesizePosted,
+	topLevelPlacement,
+} from "./comment-node";
 import { commentAnchorId, commentHref, commentIdFromHash } from "./permalink";
 import { absoluteTime, isoTime, relativeTime } from "./time";
 // The mount request and the wire shapes it carries. Kept out of this file so the
@@ -2110,11 +2117,20 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 			}
 			// Reply landed — drop the saved draft before the list re-renders.
 			clearDraft(dkey);
-			// Pending replies reload like approved ones: the author's own
-			// queued comment comes back from the list endpoint and renders
-			// inline with a "Pending approval" badge. Fall back to the parent
-			// comment's id so focus still lands somewhere sensible on the rare
-			// response that omits the new comment's id.
+			// The 201 carries the whole comment, so render it rather than paying a
+			// GET to read it back (see insertPostedNode). Pending replies take the
+			// same path as approved ones: `status` comes from the echo, so the
+			// "Pending approval" badge is drawn from the server's verdict either way.
+			const posted = readPostedEcho(json.comment);
+			if (posted && insertPostedNode(ctx, posted, parent)) {
+				// The reload used to take this form down with the rest of the tree,
+				// gate and all. Nothing does now, so it dismisses itself.
+				dismiss();
+				return;
+			}
+			// Echo unusable, or the parent is no longer on screen. Fall back to the
+			// reload, and to the parent comment's id so focus still lands somewhere
+			// sensible on a response that omits the new comment's own.
 			ctx.revealAfterReload(json.comment?.id ?? parent.id, s("w.posted"));
 			ctx.reload();
 		} catch (err) {
@@ -2843,12 +2859,31 @@ const fetchPage = async (
 	return (await res.json()) as ListResponse;
 };
 
+/**
+ * Render top-level threads into the list, skipping any already on screen.
+ *
+ * The skip is load-more's guard against `insertPostedNode`. A comment rendered
+ * from its own POST echo is on screen without the server having been asked
+ * where it belongs, so a later page can legitimately contain it — under `old`
+ * when the post landed on what was already the last page, and under `top` at
+ * whatever rank a comment with no votes takes. Rendering it twice is the one
+ * visible way that can go wrong, and comparing ids is the whole fix.
+ */
 const appendThreads = (
 	list: HTMLElement,
 	threads: TreeNode[],
 	ctx: WidgetCtx,
 ): void => {
-	for (const t of threads) list.appendChild(buildThread(t, ctx));
+	const seen = new Set<string>();
+	for (const child of list.querySelectorAll<HTMLElement>(":scope > .gr-thread")) {
+		const id = child.dataset.id;
+		if (id) seen.add(id);
+	}
+	for (const t of threads) {
+		if (seen.has(t.id)) continue;
+		seen.add(t.id);
+		list.appendChild(buildThread(t, ctx));
+	}
 };
 
 const fetchMe = async (apiBase: string): Promise<Me> => {
@@ -3039,6 +3074,141 @@ const revealHashTarget = (root: ShadowRoot): boolean => {
 	// rendered yet (paged thread, or a reload still in flight) must not count
 	// as revealed, so a later Load More or reload can still catch it.
 	if (st) st.revealedHash = anchorId;
+	return true;
+};
+
+/** The order the rendered page is actually in; see `loadState`'s `sort`. */
+const activeSortFor = (root: ShadowRoot): SortKey =>
+	loadState.get(root)?.sort ?? "new";
+
+/**
+ * The mount's live render context, so the top-level `submit()` can build a
+ * comment node without holding one.
+ *
+ * `submit()` is wired when the composer is constructed and has `root` but no
+ * `ctx` — `buildForm` runs before `loadOnce` has built one. Keyed on the root
+ * like `loadState` and `pendingReveal`, and overwritten by every render, so
+ * what is read out always belongs to the tree currently on screen. A miss (a
+ * submit racing the very first render) falls back to the reload path.
+ */
+const mountCtx = new WeakMap<ShadowRoot, WidgetCtx>();
+
+/**
+ * The insertion point directly after `thread` and after everything already
+ * flattened out of it.
+ *
+ * `buildSubtree` emits a flattened subtree in DFS pre-order into the array its
+ * nearest un-flattened ancestor sits in, so a comment's lifted descendants are
+ * exactly the run of `[data-flat]` threads immediately following it. A new
+ * reply to that comment joins the end of that run. `null` means the run reaches
+ * the end of the list, which `insertBefore` reads as "append".
+ */
+const afterFlattenedRun = (thread: Element): Node | null => {
+	let last = thread;
+	for (let sib = thread.nextElementSibling; sib; sib = sib.nextElementSibling) {
+		const row = sib.querySelector(":scope > .gr-comment");
+		if (!sib.classList.contains("gr-thread") || !row?.hasAttribute("data-flat")) {
+			break;
+		}
+		last = sib;
+	}
+	return last.nextSibling;
+};
+
+/**
+ * Put the comment the server just echoed straight into the rendered tree,
+ * instead of re-fetching the thread to find it.
+ *
+ * Backlog #9 and #45 are one bug seen from two sides. Posting used to
+ * `ctx.reload()`, which spent a second Worker request on the most expensive
+ * path the widget has — and re-fetched *page one*, so under `sort=old` on a
+ * thread past `comments_per_page` the reader's own comment came back on a page
+ * nobody was looking at (issue #94). Rendering the 201's own payload answers
+ * both: no request, and the node is placed relative to what is actually on
+ * screen. It also keeps scroll position and every other open form, which a
+ * `root.replaceChildren()` could not.
+ *
+ * Not optimistic, despite #9's title: whether a comment is held for moderation
+ * is a server verdict (muted words, Akismet, Workers AI, first-comment hold),
+ * so the thing rendered here is the server's answer, arriving one request
+ * earlier rather than being guessed and rolled back.
+ *
+ * Returns false when the tree cannot take the node — no rendered list, or a
+ * reply whose parent has been paged out. Both mean "fall back to the old
+ * post-then-reload path", exactly as `readPostedEcho` returning `null` does: a
+ * comment in the wrong place is worse than a second request.
+ */
+const insertPostedNode = (
+	ctx: WidgetCtx,
+	echo: PostedEcho,
+	parent: TreeNode | null,
+): boolean => {
+	const list = ctx.root.querySelector(".gr-list");
+	if (!list) return false;
+	const { node, slot } = synthesizePosted(echo, parent);
+
+	// Resolve the destination before building anything, so a miss costs nothing.
+	let container: Element;
+	let before: Node | null = null;
+	if (!slot) {
+		container = list;
+		// First comment on the thread: "no comments yet" is now false. The sort
+		// selector and the subscribe bell stay absent until the next real load —
+		// both render off `data.threads.length`, and neither is worth a request.
+		list.querySelector(".gr-empty")?.remove();
+		if (topLevelPlacement(activeSortFor(ctx.root)) === "prepend") {
+			before = list.firstChild;
+		}
+	} else if (!parent) {
+		return false;
+	} else {
+		const parentThread = ctx.root.getElementById(commentAnchorId(parent.id));
+		if (!parentThread) return false;
+		if (slot.into === "replies") {
+			// Plain append, even past a "Show N more replies" button. The hidden
+			// replies are the *newer* ones — renderReplyList slices from the end of
+			// an ascending list — so a comment posted seconds ago belongs after
+			// them, and the button reveals its batch by inserting before itself,
+			// which keeps the order right once it is pressed.
+			container = replyMountFor(parentThread, parent, ctx).container;
+		} else {
+			// A reply to an already-flattened comment is lifted onto that comment's
+			// own tier (see `replySlot`), not nested under it.
+			const tier = parentThread.parentElement;
+			if (!tier) return false;
+			container = tier;
+			before = afterFlattenedRun(parentThread);
+		}
+	}
+
+	const threadEl = buildThread(node, ctx);
+	// Marks it as the reader's own for this render. Under `old` and `top` its
+	// position is provisional (see `topLevelPlacement`), and "here is what you
+	// posted" is the one claim that stays true either way.
+	threadEl.dataset.posted = "1";
+	container.insertBefore(threadEl, before);
+
+	// Every list this node now sits inside shows one comment more — and none of
+	// them may be a collapsed list hiding a comment made two seconds ago.
+	for (
+		let a = threadEl.parentElement?.closest<HTMLElement>(".gr-thread") ?? null;
+		a;
+		a = a.parentElement?.closest<HTMLElement>(".gr-thread") ?? null
+	) {
+		const mount = replyMounts.get(a);
+		if (!mount) continue;
+		mount.countUp();
+		mount.reveal();
+	}
+
+	focusPostedComment(ctx.root, echo.id);
+	// No `setTimeout(0)` here, unlike loadOnce's arbitration. That delay exists
+	// because `root.replaceChildren()` had just built a brand-new live region,
+	// and a region has to be in the accessibility tree *before* its text
+	// changes. This path never destroys the tree, so the box has been sitting
+	// there all along and the write announces on the spot.
+	const statusEl = ctx.root.querySelector(".gr-error") as HTMLElement | null;
+	if (statusEl) showStatus(statusEl, s("w.posted"), "notice");
 	return true;
 };
 
@@ -3265,6 +3435,9 @@ const loadOnce = async (
 			revealAfterReload(root, id, announce),
 		permalinkFor,
 	};
+	// Publish it for `submit()`, which is wired to a composer built before this
+	// context existed. See `mountCtx`.
+	mountCtx.set(root, ctx);
 	// Article-level engagement bar sits at the very top, above the composer.
 	if (pageReactionsEnabled || pageVotesEnabled) {
 		wrap.appendChild(buildPageEngagement(ctx));
@@ -3694,11 +3867,6 @@ const submit = async (
 		// from a clean field.
 		clearDraft(draftKey(slug, null));
 
-		// Pending comments fall through to the same reload path as approved
-		// ones: the list endpoint returns the author's own queued comment, so
-		// `load()` re-renders it inline with a "Pending approval" badge — a
-		// visible, persistent confirmation rather than a transient notice.
-
 		// Fire-and-forget subscription — failure here doesn't roll back
 		// the comment. The widget already has both inputs handy.
 		const notifyCb = form.querySelector(".gr-notify-cb") as HTMLInputElement | null;
@@ -3722,8 +3890,38 @@ const submit = async (
 			}
 		}
 
-		// Request the focus-and-announce for once the new tree lands, *before*
-		// awaiting the reload: `load()` can return immediately and queue this
+		// The 201 carries the whole comment, so render it instead of spending a
+		// second request reading it back — and instead of re-fetching page one,
+		// where under `sort=old` the reader's own comment isn't (issue #94). See
+		// insertPostedNode. Pending comments take this path too: `status` comes
+		// from the echo, so the "Pending approval" badge is the server's verdict
+		// either way, and a persistent badge stays the confirmation rather than a
+		// transient notice.
+		const posted = readPostedEcho(json.comment);
+		const ctx = mountCtx.get(root);
+		if (posted && ctx && insertPostedNode(ctx, posted, null)) {
+			// The reload used to hand the composer back by rebuilding it. What is
+			// left to undo is what the post consumed: the text, the disabled
+			// button, and the Turnstile token — single-use once siteverify has seen
+			// it, so a composer holding a spent one can only produce a rejected post.
+			const bodyInput = form.querySelector(
+				".gr-body-input",
+			) as HTMLTextAreaElement | null;
+			if (bodyInput) {
+				bodyInput.value = "";
+				// Re-fires what buildWritePreview listens for: shrinks the box back
+				// to its resting height and clears the character counter.
+				bodyInput.dispatchEvent(new Event("input"));
+			}
+			if (submitBtn) submitBtn.disabled = false;
+			ts?.reset();
+			ts?.gate.clear();
+			return;
+		}
+
+		// Echo unusable, or no render context yet (a submit racing the very first
+		// load). Request the focus-and-announce for once the new tree lands,
+		// *before* awaiting the reload: `load()` can return immediately and queue this
 		// reload behind one already in flight (see load(), above), so by the
 		// time `await` resolves here the tree it resolved against may already
 		// be stale. Stashing the request now, keyed on `root`, means whichever

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -46,6 +46,10 @@ import {
 	REACTION_KINDS,
 	mergeReactionTotals,
 } from "./reactions";
+// The node shape this file renders, plus the arithmetic that turns a POST echo
+// into one. Kept out of here so the depth/flatten/placement rules are reachable
+// from the DOM-free test pool — see the module header.
+import type { TreeAuthor, TreeNode } from "./comment-node";
 import { commentAnchorId, commentHref, commentIdFromHash } from "./permalink";
 import { absoluteTime, isoTime, relativeTime } from "./time";
 // The mount request and the wire shapes it carries. Kept out of this file so the
@@ -123,39 +127,6 @@ const markVote = (btn: HTMLElement, on: boolean): void => {
 	if (on) btn.dataset.mine = "1";
 	else delete btn.dataset.mine;
 	btn.setAttribute("aria-pressed", String(on));
-};
-
-// Mirrors lib/tree.ts's TreeAuthor. No `is_admin`: the API stopped sending it
-// (it let anyone enumerate privileged accounts) and nothing here rendered it.
-type TreeAuthor = {
-	id: string;
-	name: string;
-	provider: string;
-	avatar_svg: string | null;
-	avatar_url: string | null;
-};
-
-type TreeNode = {
-	id: string;
-	parent_id: string | null;
-	body_html: string;
-	status: "approved" | "pending" | "spam" | "deleted";
-	edited_at: number | null;
-	deleted_at: number | null;
-	deleted_by: "author" | "moderator" | null;
-	created_at: number;
-	author: TreeAuthor;
-	depth: number;
-	flatten_from: string | null;
-	/** Optional on purpose: the list response is edge-cached, so payloads
-	 *  predating this field keep being served for up to TREE_CACHE_TTL after a
-	 *  deploy. Read it through the `n.depth < 4` fallback below, never bare. */
-	can_reply?: boolean;
-	reactions: ReactionCount[];
-	score_up: number;
-	score_down: number;
-	my_vote: -1 | 0 | 1;
-	replies: TreeNode[];
 };
 
 type VoteResponse = {

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -476,6 +476,18 @@ button:active:not([disabled]) { opacity: 0.75; }
    wrong side of the replies it indents on an RTL host page. */
 .gr-replies { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 0.5rem; padding-inline-start: 1.25rem; border-inline-start: 2px solid var(--gr-border); }
 .gr-comment { display: flex; gap: 0.75rem; }
+/* The reader's own comment, rendered from the POST echo rather than fetched
+   back (see insertPostedNode). It stays marked until the next real load
+   replaces the tree, because under `old` and `top` its position is provisional
+   — the accent is what makes the render read as "here is what you posted"
+   instead of as a claim about where it sits in the thread. Logical properties,
+   like the nesting rail above, so it lands on the right side on an RTL host.
+   Deliberately quiet: it sits next to a "Pending approval" badge often enough
+   that two loud signals would compete. */
+.gr-thread[data-posted] > .gr-comment {
+	border-inline-start: 2px solid var(--gr-accent);
+	padding-inline-start: 0.6rem;
+}
 .gr-comment[data-flat="1"] .gr-flatten { font-size: 0.85em; color: var(--gr-muted); margin-inline-end: 0.3em; }
 .gr-avatar { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 50%; overflow: hidden; background: var(--gr-surface); box-shadow: 0 0 0 1px var(--gr-border); }
 .gr-avatar svg, .gr-avatar img { width: 100%; height: 100%; display: block; }

--- a/tests/widget-comment-node.test.ts
+++ b/tests/widget-comment-node.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Building a renderable comment from the 201 echo of `POST /api/v1/comments`
+ * (src/widget/comment-node.ts).
+ *
+ * The point of the module is that a successful post no longer costs a second
+ * request, which means the widget now computes for itself three things the list
+ * endpoint used to hand it: what depth the new comment renders at, whether it
+ * carries a flatten prefix, and which list it joins. Those have to agree with
+ * `buildSubtree` in src/lib/tree.ts or a reply will render on the wrong tier
+ * until the next load — so the flatten cases here are checked against that
+ * function's rule, not against what looks plausible.
+ *
+ * `readPostedEcho` is covered for the same reason boot.ts's fallback is: the
+ * degraded answer has to be "take the old path", never "render a blank
+ * comment".
+ */
+import { describe, expect, it } from "vitest";
+import {
+	MAX_DEPTH,
+	type PostedEcho,
+	type TreeNode,
+	readPostedEcho,
+	replySlot,
+	synthesizePosted,
+	topLevelPlacement,
+} from "../src/widget/comment-node";
+
+const author = {
+	id: "u1",
+	name: "Ada",
+	provider: "github",
+	avatar_svg: null,
+	avatar_url: "https://example.com/a.png",
+};
+
+const echo = (over: Partial<PostedEcho> = {}): PostedEcho => ({
+	id: "c1",
+	parent_id: null,
+	body_html: "<p>hi</p>",
+	status: "approved",
+	edited_at: null,
+	deleted_at: null,
+	deleted_by: null,
+	created_at: 1_700_000_000_000,
+	author,
+	...over,
+});
+
+/** A rendered parent node, only the fields the slot rules read. */
+const parentAt = (depth: number, name = "Grace"): TreeNode => ({
+	id: `p${depth}`,
+	parent_id: null,
+	body_html: "",
+	status: "approved",
+	edited_at: null,
+	deleted_at: null,
+	deleted_by: null,
+	created_at: 0,
+	author: { ...author, id: "u2", name },
+	depth,
+	flatten_from: depth >= MAX_DEPTH ? "Someone" : null,
+	reactions: [],
+	score_up: 0,
+	score_down: 0,
+	my_vote: 0,
+	replies: [],
+});
+
+describe("synthesizePosted", () => {
+	it("renders a top-level comment at depth 0 with no flatten prefix", () => {
+		const { node, slot } = synthesizePosted(echo(), null);
+		expect(slot).toBeNull();
+		expect(node.depth).toBe(0);
+		expect(node.flatten_from).toBeNull();
+	});
+
+	it("carries the echo's own id, body, status and timestamp through", () => {
+		const { node } = synthesizePosted(
+			echo({ id: "abc", status: "pending", created_at: 42 }),
+			null,
+		);
+		expect(node.id).toBe("abc");
+		expect(node.body_html).toBe("<p>hi</p>");
+		// The badge the renderer draws off this is the whole reason the echo is
+		// used rather than a guess: whether a comment is held for moderation is a
+		// server verdict (muted words, Akismet, Workers AI, first-comment hold).
+		expect(node.status).toBe("pending");
+		expect(node.created_at).toBe(42);
+		expect(node.author).toEqual(author);
+	});
+
+	it("starts with no reactions, no votes and no replies", () => {
+		const { node } = synthesizePosted(echo(), null);
+		expect(node.reactions).toEqual([]);
+		expect(node.score_up).toBe(0);
+		expect(node.score_down).toBe(0);
+		expect(node.my_vote).toBe(0);
+		expect(node.replies).toEqual([]);
+	});
+
+	it("leaves can_reply unset so the renderer's depth fallback decides", () => {
+		// Not `false`, and not a computed guess: stored depth is unrecoverable
+		// from a flattened node, so the field's absence is the honest answer and
+		// embed.ts's `?? n.depth < 4` is the same rule it already applies to an
+		// edge-cached payload that predates the field.
+		const { node } = synthesizePosted(echo(), null);
+		expect("can_reply" in node).toBe(false);
+	});
+
+	it("nests a reply one level under its parent", () => {
+		const { node, slot } = synthesizePosted(
+			echo({ parent_id: "p1" }),
+			parentAt(1),
+		);
+		expect(node.depth).toBe(2);
+		expect(node.flatten_from).toBeNull();
+		expect(slot).toEqual({ into: "replies", depth: 2, flatten_from: null });
+	});
+});
+
+describe("replySlot", () => {
+	it("keeps replies nested while they stay under the flatten threshold", () => {
+		for (const depth of [0, 1, 2]) {
+			expect(replySlot(parentAt(depth))).toEqual({
+				into: "replies",
+				depth: depth + 1,
+				flatten_from: null,
+			});
+		}
+	});
+
+	it("flattens a reply that would cross the threshold, keeping it in the parent's list", () => {
+		// buildSubtree emits the child of a depth-(MAX_DEPTH-1) frame into that
+		// node's own `replies` — clamped to MAX_DEPTH and labelled — so the reply
+		// is still nested one level, it just renders un-indented.
+		expect(replySlot(parentAt(MAX_DEPTH - 1, "Grace"))).toEqual({
+			into: "replies",
+			depth: MAX_DEPTH,
+			flatten_from: "Grace",
+		});
+	});
+
+	it("makes a reply to an already-flattened comment its sibling", () => {
+		// Past the threshold buildSubtree pushes descendants into `frame.out` —
+		// the array the parent itself sits in — so the reply joins the same tier
+		// rather than nesting under a node that is already un-indented.
+		expect(replySlot(parentAt(MAX_DEPTH, "Grace"))).toEqual({
+			into: "siblings",
+			depth: MAX_DEPTH,
+			flatten_from: "Grace",
+		});
+	});
+
+	it("never renders deeper than the flatten threshold", () => {
+		// Imported threads (Disqus) can be nested past MAX_DEPTH, so the parent on
+		// screen can report the clamped depth with real nesting far below it.
+		for (const depth of [MAX_DEPTH, MAX_DEPTH + 3]) {
+			expect(replySlot(parentAt(depth)).depth).toBe(MAX_DEPTH);
+		}
+	});
+
+	it("labels the flatten prefix with the immediate parent, not an ancestor", () => {
+		expect(replySlot(parentAt(MAX_DEPTH, "Immediate")).flatten_from).toBe(
+			"Immediate",
+		);
+	});
+});
+
+describe("topLevelPlacement", () => {
+	it("puts a new comment first under the newest-first orders", () => {
+		expect(topLevelPlacement("new")).toBe("prepend");
+		// `top` ranks by score, which a comment nobody has voted on does not have.
+		// First is where the reader is looking, and the caller marks it as theirs.
+		expect(topLevelPlacement("top")).toBe("prepend");
+	});
+
+	it("puts a new comment last under oldest-first", () => {
+		// Where issue #94 bit: `ctx.reload()` re-fetched page 1, and under `old` a
+		// new top-level comment belongs on the *last* page, so on a thread past
+		// comments_per_page the reader's own comment was nowhere on screen.
+		expect(topLevelPlacement("old")).toBe("append");
+	});
+});
+
+describe("readPostedEcho", () => {
+	const body = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+		id: "c1",
+		post_slug: "hello",
+		parent_id: null,
+		body_html: "<p>hi</p>",
+		status: "approved",
+		edited_at: null,
+		deleted_at: null,
+		deleted_by: null,
+		created_at: 1_700_000_000_000,
+		author: { ...author },
+		...over,
+	});
+
+	it("accepts the real serializeComment payload", () => {
+		const read = readPostedEcho(body());
+		expect(read?.id).toBe("c1");
+		expect(read?.author.name).toBe("Ada");
+	});
+
+	it("ignores post_slug, which nothing in the render path reads", () => {
+		expect(readPostedEcho(body())).not.toHaveProperty("post_slug");
+	});
+
+	it("keeps a pending status rather than normalizing it", () => {
+		expect(readPostedEcho(body({ status: "pending" }))?.status).toBe("pending");
+	});
+
+	it("rejects a body missing any field the renderer needs", () => {
+		for (const missing of ["id", "body_html", "created_at", "status", "author"]) {
+			expect(readPostedEcho(body({ [missing]: undefined }))).toBeNull();
+		}
+	});
+
+	it("rejects a status it does not know how to render", () => {
+		expect(readPostedEcho(body({ status: "quarantined" }))).toBeNull();
+	});
+
+	it("rejects an author missing its identity fields", () => {
+		for (const missing of ["id", "name", "provider"]) {
+			const a: Record<string, unknown> = { ...author };
+			delete a[missing];
+			expect(readPostedEcho(body({ author: a }))).toBeNull();
+		}
+	});
+
+	it("rejects a non-object body, including the absent one", () => {
+		for (const v of [undefined, null, "c1", 7, []]) {
+			expect(readPostedEcho(v)).toBeNull();
+		}
+	});
+
+	it("tolerates an absent avatar on either side", () => {
+		const read = readPostedEcho(
+			body({ author: { ...author, avatar_svg: undefined, avatar_url: undefined } }),
+		);
+		expect(read?.author.avatar_svg).toBeNull();
+		expect(read?.author.avatar_url).toBeNull();
+	});
+
+	it("drops a deleted_by it does not recognize", () => {
+		expect(readPostedEcho(body({ deleted_by: "somebody" }))?.deleted_by).toBeNull();
+		expect(readPostedEcho(body({ deleted_by: "author" }))?.deleted_by).toBe("author");
+	});
+});


### PR DESCRIPTION
Backlog **#9** (optimistic post rendering) and **#45** / issue **#94** (your own comment invisible after posting on a paged thread) are the same bug seen from two sides, so they land together.

## What was wrong

A successful post scheduled a reveal and called `ctx.reload()`, which re-fetched page 1 of the thread and replaced the rendered page with it. Two costs:

- **A second Worker request on every comment.** Mount is two requests against a 100,000/day free tier; posting doubled up for a payload the server had already sent.
- **Under `old`, on a thread past `comments_per_page`, the reader's own comment landed nowhere.** A reload fetches page *one* — the oldest comments — and a new top-level comment belongs on the *last* page. It simply wasn't in the response that replaced the page. That's #94.

`POST /api/v1/comments` has always echoed the full comment on its `201`. Nothing server-side changes here: no migration, no new endpoint, no API version bump.

## What it does now

The widget builds the node from the echo and inserts it into the page it is already showing.

- **Placement** — prepend under `new` and `top`, append under `old`, nested under its parent for a reply, lifted to the parent's own tier when the parent is already flattened. `src/widget/comment-node.ts` mirrors the flatten rule in `buildSubtree` rather than guessing, because a reply that renders on the wrong tier stays wrong until the next load.
- **Ancestor bookkeeping** — every DOM-ancestor reply mount gets its count bumped and its collapsed list revealed; `.gr-empty` is cleared on a thread's first comment.
- **Marked as yours** — `.gr-thread[data-posted]` keeps a subtle accent while the node is on screen. Under `old` and `top` its position is **provisional**, so the mark is what makes the render read as "here is what you posted" rather than as a claim about thread order. Logical properties, so it lands correctly on an RTL host.
- **Not optimistic.** The comment is drawn only after the server accepts it, with the status the server assigned — a held post renders with its "Pending approval" badge rather than approved-then-corrected. Whether a comment is held is a server verdict (muted words, Akismet, Workers AI, first-comment hold), not something the widget could guess.
- **`can_reply` is deliberately left unset**, not computed. The server derives it from *stored* depth, which is unrecoverable from a flattened node, so the field's absence hands the decision to the documented `?? n.depth < 4` fallback embed.ts already applies to edge-cached payloads that predate the field.

Dropping the reload also means **scroll position and every open form survive a post**.

## Degrading

Both halves fail back to the old post-then-reload path rather than guessing:

- `readPostedEcho` returns `null` on an echo missing a field the renderer needs — the case where a widget bundle outlives the Worker it talks to, the same premise as boot.ts's bootstrap fallback.
- `insertPostedNode` returns `false` when the DOM it needs isn't there.

The degraded case costs one extra request; the alternative was one broken comment.

`appendThreads` grows an id guard for a hazard this creates: after an echo insert, a later "Load more" page can legitimately contain the same comment — under `old` when the post landed on what was already the last page, and under `top` at whatever rank a scoreless comment takes.

## Verification

Static gates on the final tree: typecheck clean, lint at baseline (1 warning / 2 infos, the pre-existing `noDescendingSpecificity`), 122 files / 1961 tests, bundle **19.57 KB gz of the 30 KB ceiling**. 21 new tests in `tests/widget-comment-node.test.ts` check the depth/flatten arithmetic against `buildSubtree`'s rule and every `readPostedEcho` accept/reject/tolerate case.

The insert path needs a DOM, so it was exercised in a real headless-Chromium mount against a local instance with `comments_per_page=3` and a 9-comment thread:

| case | result |
| --- | --- |
| top-level under `new` | prepended, marked, focused, composer reset, second post through the same composer works |
| top-level under `old`, paged (#94) | appended **last**, marked — the case that used to vanish |
| reply | nested under its parent, marked, collapse toggle appears reading "1 reply", reply form dismissed |

No `GET /api/v1/comments` followed any of the three posts — one request per comment, down from two.

Refs #9, #45 — closes #94.
