### PR TITLE
fix(embed): let the iframe route frame its own Turnstile gate

### DIFF
--- a/src/routes/embed-iframe.ts
+++ b/src/routes/embed-iframe.ts
@@ -404,7 +404,18 @@ iframe.get("/:slug", (c) => {
 		"default-src 'none'",
 		`script-src ${apiOrigin} ${TURNSTILE_ORIGIN} 'unsafe-inline'`,
 		`connect-src ${apiOrigin} ${TURNSTILE_ORIGIN}`,
-		`frame-src ${TURNSTILE_ORIGIN}`,
+		// `apiOrigin` as well as Turnstile's own: the widget does not frame
+		// challenges.cloudflare.com directly, it frames `${apiBase}/embed/
+		// turnstile-frame` and *that* page hosts CF's script (see the route above
+		// — the indirection is what keeps the parent origin out of CF's referrer
+		// and lets the frame carry its own CSP). Listing only Turnstile here
+		// blocked the gate on this route, which anonymous posting cannot survive:
+		// the API requires a Turnstile token from an anonymous author whether or
+		// not the operator configured Turnstile, so the post came back 400 with
+		// nothing on screen explaining why. Not a new grant — `apiOrigin` is
+		// already trusted for script and connect two lines up, and is either this
+		// Worker or an ALLOWED_ORIGINS entry.
+		`frame-src ${apiOrigin} ${TURNSTILE_ORIGIN}`,
 		"style-src 'unsafe-inline'",
 		"img-src data: https:",
 		"font-src data:",

--- a/tests/embed-iframe.test.ts
+++ b/tests/embed-iframe.test.ts
@@ -142,6 +142,27 @@ describe("GET /embed/:slug", () => {
 		});
 	});
 
+	describe("frame-src", () => {
+		it("names the api origin, which is what hosts the Turnstile gate", async () => {
+			// Regression guard. The widget frames `${apiBase}/embed/turnstile-frame`,
+			// not challenges.cloudflare.com directly, so a frame-src naming only
+			// Turnstile blocks the gate here — and an anonymous post needs a token
+			// whether or not the operator configured Turnstile, so the whole
+			// anonymous path on this route 400s with nothing explaining why.
+			const res = await fetchPage("/embed/hello");
+			const fs = directive(res, "frame-src") ?? "";
+			expect(fs).toContain(SELF);
+			expect(fs).toContain("https://challenges.cloudflare.com");
+		});
+
+		it("does not name an unlisted ?api= override", async () => {
+			const res = await fetchPage("/embed/hello?api=https%3A%2F%2Fevil.example");
+			const fs = directive(res, "frame-src") ?? "";
+			expect(fs).not.toContain("evil.example");
+			expect(fs).toContain(SELF);
+		});
+	});
+
 	describe("?lang=", () => {
 		it("lands on both <html lang> and data-lang", async () => {
 			// Two consumers, not one: <html lang> is what assistive tech and the


### PR DESCRIPTION
## What

`GET /embed/:slug` — the iframe-variant comment page — sent
`frame-src https://challenges.cloudflare.com`. The widget never frames
Cloudflare directly: it frames `${apiBase}/embed/turnstile-frame`, and that
same-origin page is what hosts CF's script. So Chromium blocked the gate:

```
Framing 'http://localhost:8787/embed/turnstile-frame?parent_origin=…' violates
the following Content Security Policy directive:
"frame-src https://challenges.cloudflare.com".
```

## Why it matters

`POST /api/v1/comments` requires a Turnstile token from an anonymous author
whether or not the operator configured Turnstile (`src/routes/api.comments.ts`).
With no gate able to mount, **every anonymous post from an iframe embed returned
400 "Spam check failed. Refresh and try again."** — advice that cannot work,
because a refresh rebuilds the same blocked frame. Signed-in posting was fine
(it skips the challenge unless `turnstile_always`), and script-tag embeds were
unaffected: their CSP belongs to the host page, which already has to allow the
Worker origin.

## The fix

`frame-src ${apiOrigin} ${TURNSTILE_ORIGIN}`.

`apiOrigin` rather than `'self'`, because the frame is loaded from whatever
`?api=` resolved to. It is not a new grant — the same value is already trusted
for `script-src` and `connect-src` on the line above, and an unlisted `?api=`
override is dropped before the CSP is built (existing test covers that).

The turnstile-frame route's own `frame-src` is left Turnstile-only: that page
frames CF and nothing else.

## Tests

New `frame-src` block in `tests/embed-iframe.test.ts`: one test that the api
origin is named, one that an unlisted `?api=` override never reaches the
directive. Both fail against the old header (verified by reverting the fix).

Found while verifying #100 in a headless browser; unrelated to that PR.