### PR TITLE
feat(widget): edit-window countdown

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -340,7 +340,8 @@ default, server-side clamped), edited from **Settings → Moderation**.
   **Since v2.21.0 the reader can see it**: inside the last hour the Edit button
   carries a countdown ("12m left"), the affordance disappears at expiry without
   a reload, and an editor left open disables itself and says so. Only the last
-  hour is shown, so raising this to days doesn't put a chip on every comment.
+  hour is shown, so raising this to days doesn't put a chip on every comment —
+  nor a background timer on the reader's device until that hour arrives.
   Nothing about the server-side gate changed — this is display only.
 - `SPAM_LINK_THRESHOLD` — clamped to `-1`–`50`. `-1` (the default, and where an
   unset or junk value lands) disables the check; `0` flags any comment carrying

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -337,6 +337,11 @@ default, server-side clamped), edited from **Settings → Moderation**.
   was unset, and an explicit `0` means "no editing" instead of silently meaning
   5. Installs that set the var explicitly are unaffected — the ceiling is a week
   precisely so a pre-existing longer window isn't silently shortened.
+  **Since v2.21.0 the reader can see it**: inside the last hour the Edit button
+  carries a countdown ("12m left"), the affordance disappears at expiry without
+  a reload, and an editor left open disables itself and says so. Only the last
+  hour is shown, so raising this to days doesn't put a chip on every comment.
+  Nothing about the server-side gate changed — this is display only.
 - `SPAM_LINK_THRESHOLD` — clamped to `-1`–`50`. `-1` (the default, and where an
   unset or junk value lands) disables the check; `0` flags any comment carrying
   a link. The sentinel exists because this signal has always had three states —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -639,6 +639,38 @@ what you preview is byte-identical to what gets posted, with no
 client-side markdown library and no XSS divergence. The endpoint is
 public but rate-limited; no auth required.
 
+### Editing your own comment (since v2.21.0)
+
+A signed-in author gets an **Edit** button on their own comment for
+`edit_window_minutes` after posting (default 15; `0` disables editing
+entirely and the button never appears). `/api/v1/config` reports the
+resolved value as `edit_window_minutes`.
+
+Inside the **last hour** of that window the button is followed by a muted
+countdown — "12m left", then "less than a minute left" under sixty seconds.
+It re-reads the clock every 15 seconds. On the default 15-minute window the
+countdown is therefore visible for the whole window; on a window configured
+in days it stays quiet until the last hour, so a long window doesn't paint a
+"6 days left" chip on every comment. The chip is not a live region — it is
+wired to the button with `aria-describedby`, so a screen reader announces the
+remaining time when the button takes focus rather than every fifteen seconds.
+
+At expiry the Edit button and its countdown are **removed from the row**
+without a reload. An editor already open is disabled in place: the field and
+Save go inert, "Your edit window has closed." appears in a polite live region,
+and Cancel stays enabled so the box can still be dismissed. This is a display
+of the server rule, not a second copy of it — `PATCH /api/v1/comments/:id`
+and `GET /api/v1/comments/:id/source` both still 403 past the window.
+
+Two caveats worth knowing:
+
+- The countdown is computed against the **reader's** clock. A badly skewed
+  clock mis-states the time left, exactly as it has always mis-gated the
+  button; nothing on the wire carries a server `now`.
+- Any other refusal from `PATCH` — a rate limit, a validation failure, a spam
+  verdict — now renders in that same box. Before v2.21.0 the editor had no
+  status surface at all and those failures silently re-enabled Save.
+
 ### Deleting your own comment (since v2.9.0)
 
 Delete asks for confirmation **in place**: the button becomes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,7 +651,8 @@ countdown — "12m left", then "less than a minute left" under sixty seconds.
 It re-reads the clock every 15 seconds. On the default 15-minute window the
 countdown is therefore visible for the whole window; on a window configured
 in days it stays quiet until the last hour, so a long window doesn't paint a
-"6 days left" chip on every comment. The chip is not a live region — it is
+"6 days left" chip on every comment — and no timer runs before then either,
+so the quiet is real rather than just visual. The chip is not a live region — it is
 wired to the button with `aria-describedby`, so a screen reader announces the
 remaining time when the button takes focus rather than every fifteen seconds.
 
@@ -667,6 +668,10 @@ Two caveats worth knowing:
 - The countdown is computed against the **reader's** clock. A badly skewed
   clock mis-states the time left, exactly as it has always mis-gated the
   button; nothing on the wire carries a server `now`.
+- The 15-second tick is how the *display* keeps up, not how expiry is decided.
+  An editor asks the clock again when its prefill lands and again on submit, so
+  a click that arrives in the gap between the window closing and the next tick
+  gets the same "Your edit window has closed." notice rather than a bare 403.
 - Any other refusal from `PATCH` — a rate limit, a validation failure, a spam
   verdict — now renders in that same box. Before v2.21.0 the editor had no
   status surface at all and those failures silently re-enabled Save.

--- a/src/i18n/widget/de.ts
+++ b/src/i18n/widget/de.ts
@@ -73,6 +73,9 @@ export const de = {
 	"w.lowscore.show": "Kommentar ausgeblendet (niedrige Bewertung) — anzeigen",
 	"w.reply": "Antworten",
 	"w.edit": "Bearbeiten",
+	// "noch 4 Min." — `{time}` arrives already formatted by Intl, unit included.
+	"w.edit_left": "noch {time}",
+	"w.edit_last_minute": "weniger als eine Minute übrig",
 	"w.delete": "Löschen",
 	"w.delete_confirm": "Diesen Kommentar löschen?",
 	"w.report": "Melden",

--- a/src/i18n/widget/de.ts
+++ b/src/i18n/widget/de.ts
@@ -76,6 +76,7 @@ export const de = {
 	// "noch 4 Min." — `{time}` arrives already formatted by Intl, unit included.
 	"w.edit_left": "noch {time}",
 	"w.edit_last_minute": "weniger als eine Minute übrig",
+	"w.edit_expired": "Der Bearbeitungszeitraum ist abgelaufen.",
 	"w.delete": "Löschen",
 	"w.delete_confirm": "Diesen Kommentar löschen?",
 	"w.report": "Melden",

--- a/src/i18n/widget/es.ts
+++ b/src/i18n/widget/es.ts
@@ -70,6 +70,9 @@ export const es = {
 	"w.lowscore.show": "Comentario oculto (puntuación baja) — mostrar",
 	"w.reply": "Responder",
 	"w.edit": "Editar",
+	// El verbo concuerda con el número de minutos, de ahí las dos formas.
+	"w.edit_left": { one: "queda {time}", other: "quedan {time}" },
+	"w.edit_last_minute": "queda menos de un minuto",
 	"w.delete": "Eliminar",
 	"w.delete_confirm": "¿Eliminar este comentario?",
 	"w.report": "Denunciar",

--- a/src/i18n/widget/es.ts
+++ b/src/i18n/widget/es.ts
@@ -73,6 +73,7 @@ export const es = {
 	// El verbo concuerda con el número de minutos, de ahí las dos formas.
 	"w.edit_left": { one: "queda {time}", other: "quedan {time}" },
 	"w.edit_last_minute": "queda menos de un minuto",
+	"w.edit_expired": "Tu plazo de edición ha terminado.",
 	"w.delete": "Eliminar",
 	"w.delete_confirm": "¿Eliminar este comentario?",
 	"w.report": "Denunciar",

--- a/src/i18n/widget/fr.ts
+++ b/src/i18n/widget/fr.ts
@@ -75,6 +75,7 @@ export const fr = {
 	// "restante" accorde avec le nombre de minutes, d'où les deux formes.
 	"w.edit_left": { one: "{time} restante", other: "{time} restantes" },
 	"w.edit_last_minute": "moins d'une minute restante",
+	"w.edit_expired": "Votre délai de modification est écoulé.",
 	"w.delete": "Supprimer",
 	"w.delete_confirm": "Supprimer ce commentaire ?",
 	"w.report": "Signaler",

--- a/src/i18n/widget/fr.ts
+++ b/src/i18n/widget/fr.ts
@@ -72,6 +72,9 @@ export const fr = {
 	"w.lowscore.show": "Commentaire masqué (score faible) — afficher",
 	"w.reply": "Répondre",
 	"w.edit": "Modifier",
+	// "restante" accorde avec le nombre de minutes, d'où les deux formes.
+	"w.edit_left": { one: "{time} restante", other: "{time} restantes" },
+	"w.edit_last_minute": "moins d'une minute restante",
 	"w.delete": "Supprimer",
 	"w.delete_confirm": "Supprimer ce commentaire ?",
 	"w.report": "Signaler",

--- a/src/widget/edit-window.ts
+++ b/src/widget/edit-window.ts
@@ -55,22 +55,52 @@ export type EditWindowState =
 	/** Not editable: the window has run out, or editing is switched off. */
 	| { phase: "expired" };
 
+/**
+ * Clamping to the window matters for a reader whose clock runs slow: they see a
+ * `created_at` in their own future, and without this the chip would promise
+ * twenty minutes of a fifteen-minute window.
+ */
+const msRemaining = (
+	createdAt: number,
+	windowMs: number,
+	now: number,
+): number => Math.min(windowMs, createdAt + windowMs - now);
+
 export const editWindowState = (
 	createdAt: number,
 	windowMs: number,
 	now: number,
 ): EditWindowState => {
 	if (windowMs <= 0) return { phase: "expired" };
-	// Clamping to the window matters for a reader whose clock runs slow: they
-	// see a `created_at` in their own future, and without this the chip would
-	// promise twenty minutes of a fifteen-minute window.
-	const remaining = Math.min(windowMs, createdAt + windowMs - now);
+	const remaining = msRemaining(createdAt, windowMs, now);
 	if (remaining <= 0) return { phase: "expired" };
 	if (remaining > COUNTDOWN_WINDOW_MS) return { phase: "open" };
 	if (remaining < MINUTE_MS) return { phase: "last" };
 	// Floor, not round. At 4m30s "4m left" makes a reader hurry and "5m left"
 	// may not; understating a deadline is the safe direction to be wrong in.
 	return { phase: "closing", minutes: Math.floor(remaining / MINUTE_MS) };
+};
+
+/**
+ * How long until this comment's countdown has anything to say — `0` once the
+ * threshold is already behind us, or when there is nothing left to count.
+ *
+ * The `open` phase is the whole point of this: a window measured in days spends
+ * nearly all of itself there, and a ticker started at mount would re-read the
+ * clock every 15 seconds for six days to conclude each time that the answer is
+ * still `open`. Wait this long first and the widget is quiet outside the last
+ * hour in fact, not just on screen.
+ */
+export const countdownStartsIn = (
+	createdAt: number,
+	windowMs: number,
+	now: number,
+): number => {
+	if (windowMs <= 0) return 0;
+	return Math.max(
+		0,
+		msRemaining(createdAt, windowMs, now) - COUNTDOWN_WINDOW_MS,
+	);
 };
 
 /**

--- a/src/widget/edit-window.ts
+++ b/src/widget/edit-window.ts
@@ -1,0 +1,110 @@
+/**
+ * How much of the edit window is left, and how to say it.
+ *
+ * `edit_window_minutes` has been enforced server-side for as long as the setting
+ * has existed, but nothing ever told the reader about it. The Edit button was
+ * rendered once from `Date.now() - created_at < editWindowMs` and then never
+ * re-evaluated, so an author who left the page open came back to a button that
+ * looked live, opened an editor that prefilled fine, and got a silent 403 on
+ * Save. This module is the display half of that setting: what to show, when to
+ * start showing it, and when to stop offering the affordance at all.
+ *
+ * Two deliberate choices live here rather than in the caller:
+ *
+ *   - **Nothing is shown until the last hour.** The window is configurable up to
+ *     a week, and a "6 days left" chip on every one of your own comments is
+ *     noise that teaches a reader to ignore the one time it matters. On the
+ *     default 15-minute window the threshold never bites, so the common install
+ *     shows the countdown for the whole window.
+ *   - **`expired` also covers editing being switched off.** `edit_window_minutes:
+ *     0` means no editing, and folding it in here keeps the caller down to one
+ *     question ("is this phase `expired`?") instead of two.
+ *
+ * Everything is pure and takes `now` and `locale` as arguments — the same reason
+ * `time.ts` does, and the reason both are testable with no DOM and no fake
+ * timers. The clock is the *reader's*, compared against a server timestamp: a
+ * skewed clock therefore mis-states the remaining time, exactly as it has always
+ * mis-gated the Edit button. Correcting it needs a server `now` on the wire,
+ * which the bootstrap payload's byte-identical-sections rule makes a bigger
+ * change than this one; the chip surfaces the skew rather than introducing it.
+ */
+import type { Translate } from "./strings";
+
+/**
+ * Only start counting down inside the last hour. Not a user-facing setting:
+ * it is a display threshold, and one more knob for operators to get wrong.
+ */
+export const COUNTDOWN_WINDOW_MS = 60 * 60_000;
+
+/**
+ * How often the shared ticker re-reads the clock. Coarse on purpose — the labels
+ * are minute-grained, so a faster tick would repaint identical text, and a
+ * per-second clock beside your own words is a nagging surface.
+ */
+export const TICK_MS = 15_000;
+
+const MINUTE_MS = 60_000;
+
+export type EditWindowState =
+	/** Editable, but far enough out that saying so would be noise. */
+	| { phase: "open" }
+	/** Editable, inside the countdown threshold. `minutes` is at least 1. */
+	| { phase: "closing"; minutes: number }
+	/** Editable, under a minute left. */
+	| { phase: "last" }
+	/** Not editable: the window has run out, or editing is switched off. */
+	| { phase: "expired" };
+
+export const editWindowState = (
+	createdAt: number,
+	windowMs: number,
+	now: number,
+): EditWindowState => {
+	if (windowMs <= 0) return { phase: "expired" };
+	// Clamping to the window matters for a reader whose clock runs slow: they
+	// see a `created_at` in their own future, and without this the chip would
+	// promise twenty minutes of a fifteen-minute window.
+	const remaining = Math.min(windowMs, createdAt + windowMs - now);
+	if (remaining <= 0) return { phase: "expired" };
+	if (remaining > COUNTDOWN_WINDOW_MS) return { phase: "open" };
+	if (remaining < MINUTE_MS) return { phase: "last" };
+	// Floor, not round. At 4m30s "4m left" makes a reader hurry and "5m left"
+	// may not; understating a deadline is the safe direction to be wrong in.
+	return { phase: "closing", minutes: Math.floor(remaining / MINUTE_MS) };
+};
+
+/**
+ * The number and its unit together, in the site's locale — "4m", "4 Min.",
+ * "4min". Free from ICU, so the string table only has to carry the words around
+ * it. A malformed locale tag makes the constructor throw, and a chip that reads
+ * slightly wrong beats one that takes the actions row down with it.
+ */
+const minutesUnit = (n: number, locale: string): string => {
+	try {
+		return new Intl.NumberFormat(locale, {
+			style: "unit",
+			unit: "minute",
+			unitDisplay: "narrow",
+		}).format(n);
+	} catch {
+		return `${n}m`;
+	}
+};
+
+/** The chip's text, or `null` when there is nothing worth saying. */
+export const editWindowLabel = (
+	state: EditWindowState,
+	locale: string,
+	s: Translate,
+): string | null => {
+	if (state.phase === "closing") {
+		// `n` as well as `time`: French and Spanish inflect the wording on the
+		// count, and `n` is what selects the plural category.
+		return s("w.edit_left", {
+			n: state.minutes,
+			time: minutesUnit(state.minutes, locale),
+		});
+	}
+	if (state.phase === "last") return s("w.edit_last_minute");
+	return null;
+};

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1685,6 +1685,13 @@ const buildSubscribeBell = (
  * is no longer `isConnected` simply says so and is dropped. That means no
  * caller anywhere has to remember to unregister, and the interval stops itself
  * once the last countdown has gone.
+ *
+ * A tick registered with a delay (see `registerCountdown`) is the one case where
+ * that answer isn't prompt: nothing asks it until the boundary, so an abandoned
+ * editor's DOM stays reachable through the closure until then rather than for
+ * the fifteen seconds it used to. That is the trade for not running a timer
+ * across a window measured in days, and it holds one element per abandoned
+ * surface, not a growing set.
  */
 const countdownTicks = new Set<() => boolean>();
 let countdownTimer: ReturnType<typeof setInterval> | undefined;

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -58,6 +58,12 @@ import {
 	topLevelPlacement,
 } from "./comment-node";
 import { commentAnchorId, commentHref, commentIdFromHash } from "./permalink";
+import {
+	type EditWindowState,
+	TICK_MS,
+	editWindowLabel,
+	editWindowState,
+} from "./edit-window";
 import { absoluteTime, isoTime, relativeTime } from "./time";
 // The mount request and the wire shapes it carries. Kept out of this file so the
 // fallback rule can be tested without a DOM — see boot.ts's header.
@@ -1664,6 +1670,91 @@ const buildSubscribeBell = (
 	return wrap;
 };
 
+/**
+ * The shared countdown ticker.
+ *
+ * One interval for the whole widget, not one per comment. A thread can carry
+ * dozens of the reader's own comments, and `time.ts` already declined to tick
+ * timestamps on exactly this cost argument — the difference here is that a
+ * closing deadline is actionable where an age is not, so it earns a timer, but
+ * only one.
+ *
+ * A registered tick returns `false` when it is done, which is also how teardown
+ * works: the tree is rebuilt wholesale on every reload, so a tick whose element
+ * is no longer `isConnected` simply says so and is dropped. That means no
+ * caller anywhere has to remember to unregister, and the interval stops itself
+ * once the last countdown has gone.
+ */
+const countdownTicks = new Set<() => boolean>();
+let countdownTimer: ReturnType<typeof setInterval> | undefined;
+
+const tickCountdowns = (): void => {
+	// Deleting from a Set mid-iteration is well-defined: a removed entry that
+	// has not been visited yet is simply not visited.
+	for (const tick of countdownTicks) if (!tick()) countdownTicks.delete(tick);
+	if (countdownTicks.size === 0 && countdownTimer !== undefined) {
+		clearInterval(countdownTimer);
+		countdownTimer = undefined;
+	}
+};
+
+const registerCountdown = (tick: () => boolean): void => {
+	countdownTicks.add(tick);
+	countdownTimer ??= setInterval(tickCountdowns, TICK_MS);
+};
+
+/**
+ * The Edit button plus the chip saying how long is left to use it.
+ *
+ * Returns `null` when the window has already closed — including when editing is
+ * switched off entirely, which `editWindowState` folds into the same phase.
+ */
+const buildEditControl = (
+	n: TreeNode,
+	ctx: WidgetCtx,
+	main: HTMLElement,
+): HTMLElement | null => {
+	const state = editWindowState(n.created_at, ctx.editWindowMs, Date.now());
+	if (state.phase === "expired") return null;
+
+	const wrap = el("span", "gr-edit-window");
+	const btn = el("button", undefined, s("w.edit"));
+	btn.type = "button";
+	btn.addEventListener("click", () => {
+		openEditor(n, ctx, main);
+	});
+
+	// Deliberately not a live region. This text changes every 15 seconds, and a
+	// polite announcement on each change would make the thread unusable with a
+	// screen reader. `aria-describedby` instead reads the remaining time when
+	// the button takes focus — the moment it is decision-relevant, and never
+	// otherwise. Same reasoning, and the same pattern, as the delete-confirm
+	// prompt below.
+	const chip = el("span", "gr-edit-left");
+	chip.id = nextId("gr-edit-left");
+	btn.setAttribute("aria-describedby", chip.id);
+	const paint = (at: EditWindowState): void => {
+		chip.textContent = editWindowLabel(at, locale, s) ?? "";
+	};
+	paint(state);
+
+	registerCountdown(() => {
+		if (!wrap.isConnected) return false;
+		const now = editWindowState(n.created_at, ctx.editWindowMs, Date.now());
+		if (now.phase === "expired") {
+			// Take the whole affordance away rather than leave a button that
+			// opens an editor the server will refuse to save.
+			wrap.remove();
+			return false;
+		}
+		paint(now);
+		return true;
+	});
+
+	wrap.append(btn, chip);
+	return wrap;
+};
+
 const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLElement => {
 	const row = el("div", "gr-actions");
 
@@ -1689,14 +1780,9 @@ const buildActions = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): HTMLEleme
 
 	const isOwn =
 		ctx.me != null && n.author.id === ctx.me.id && n.status !== "deleted";
-	const withinWindow = Date.now() - n.created_at < ctx.editWindowMs;
-	if (isOwn && withinWindow) {
-		const editBtn = el("button", undefined, s("w.edit"));
-		editBtn.type = "button";
-		editBtn.addEventListener("click", () => {
-			openEditor(n, ctx, main);
-		});
-		row.appendChild(editBtn);
+	if (isOwn) {
+		const editControl = buildEditControl(n, ctx, main);
+		if (editControl) row.appendChild(editControl);
 	}
 	if (isOwn) {
 		const delBtn = el("button", undefined, s("w.delete"));

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1932,6 +1932,9 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	bindComposerKeys(wrap, dismiss);
 	actions.append(save, cancel);
 
+	/** Set once the edit window closes under this editor. See `expire` below. */
+	let expired = false;
+
 	// Prefill with the original markdown source. The tree payload only carries
 	// body_html, so we fetch body_md on demand from the author-only source
 	// endpoint (same author + edit-window gate as the PATCH). Disable both the
@@ -1950,8 +1953,10 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 		})
 		.catch(() => {})
 		.finally(() => {
-			// The author may have hit Cancel before the fetch resolved.
-			if (!ta.isConnected) return;
+			// The author may have hit Cancel before the fetch resolved — or the
+			// window may have closed while it was in flight, in which case handing
+			// the field and Save back would undo `expire`.
+			if (!ta.isConnected || expired) return;
 			ta.disabled = false;
 			save.disabled = false;
 			ta.placeholder = s("w.edit_ph");
@@ -1960,10 +1965,40 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 			autoSize(ta);
 			ta.focus();
 		});
-	wrap.append(buildWritePreview(ta, ctx.apiBase, true), actions);
+	// Unlike the chip in the actions row, this one IS a live region: the window
+	// closing under someone who is mid-sentence is an event, and it happens
+	// nowhere near whatever they are looking at.
+	const errBox = statusBox("gr-error is-inline");
+	wrap.append(buildWritePreview(ta, ctx.apiBase, true), actions, errBox);
+
+	/**
+	 * The window ran out while this editor was open. Retire the surfaces that
+	 * would fail and say why — before this, Save stayed live, the PATCH came
+	 * back 403, and the button quietly re-enabled itself with nothing on screen
+	 * to explain it. Cancel stays enabled: dismissing is still valid, and it is
+	 * the only way out.
+	 */
+	const expire = (): void => {
+		expired = true;
+		ta.disabled = true;
+		save.disabled = true;
+		showStatus(errBox, s("w.edit_expired"));
+	};
+	registerCountdown(() => {
+		if (!wrap.isConnected) return false;
+		const state = editWindowState(n.created_at, ctx.editWindowMs, Date.now());
+		if (state.phase !== "expired") return true;
+		expire();
+		return false;
+	});
+
 	wrap.addEventListener("submit", async (e) => {
 		e.preventDefault();
+		// The tick runs every 15 seconds, so a submit can still land in the gap
+		// between the window closing and the tick noticing.
+		if (expired) return;
 		save.disabled = true;
+		clearStatus(errBox);
 		try {
 			const res = await fetch(
 				apiUrl(ctx.apiBase, `/api/v1/comments/${encodeURIComponent(n.id)}`),
@@ -1981,8 +2016,16 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 				// hard size budget.
 				ctx.revealAfterReload(n.id);
 				ctx.reload();
-			} else save.disabled = false;
-		} catch {
+				return;
+			}
+			// Every other refusal — a 429, a body that failed validation, a spam
+			// verdict — used to re-enable Save and say nothing, which reads as the
+			// button not working. The server's message is already localized.
+			const json = (await res.json().catch(() => ({}))) as { error?: string };
+			showStatus(errBox, json.error ?? `HTTP ${res.status}`);
+			save.disabled = false;
+		} catch (err) {
+			showStatus(errBox, String(err));
 			save.disabled = false;
 		}
 	});

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -61,6 +61,7 @@ import { commentAnchorId, commentHref, commentIdFromHash } from "./permalink";
 import {
 	type EditWindowState,
 	TICK_MS,
+	countdownStartsIn,
 	editWindowLabel,
 	editWindowState,
 } from "./edit-window";
@@ -1698,9 +1699,35 @@ const tickCountdowns = (): void => {
 	}
 };
 
-const registerCountdown = (tick: () => boolean): void => {
+const joinCountdown = (tick: () => boolean): void => {
 	countdownTicks.add(tick);
 	countdownTimer ??= setInterval(tickCountdowns, TICK_MS);
+};
+
+/**
+ * `setTimeout` keeps its delay in a signed 32-bit int, and a larger one wraps
+ * round to fire *immediately* — which would defeat the whole point of waiting.
+ * A week, the longest window the setting accepts, is comfortably inside this, so
+ * the clamp only catches a nonsense `edit_window_minutes`, and all it costs is
+ * an idle ticker for the remainder of the wait.
+ */
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Put `tick` on the shared ticker, `delayMs` from now (immediately by default).
+ *
+ * Deferring is what keeps a long window cheap: see `countdownStartsIn`. The one
+ * read at the boundary does double duty — a `false` there means the element went
+ * away while we waited, so there is nothing left to join the ticker for.
+ */
+const registerCountdown = (tick: () => boolean, delayMs = 0): void => {
+	if (delayMs <= 0) {
+		joinCountdown(tick);
+		return;
+	}
+	setTimeout(() => {
+		if (tick()) joinCountdown(tick);
+	}, Math.min(delayMs, MAX_TIMEOUT_MS));
 };
 
 /**
@@ -1749,7 +1776,7 @@ const buildEditControl = (
 		}
 		paint(now);
 		return true;
-	});
+	}, countdownStartsIn(n.created_at, ctx.editWindowMs, Date.now()));
 
 	wrap.append(btn, chip);
 	return wrap;
@@ -2007,7 +2034,7 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 		if (!isExpired()) return true;
 		expire();
 		return false;
-	});
+	}, countdownStartsIn(n.created_at, ctx.editWindowMs, Date.now()));
 
 	wrap.addEventListener("submit", async (e) => {
 		e.preventDefault();

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1994,6 +1994,12 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	const expire = (): void => {
 		ta.disabled = true;
 		save.disabled = true;
+		// An editor opened after expiry never gets its prefill, so the field is
+		// empty and the placeholder is the only thing in it — "Loading…", for a
+		// load that is not coming. Clear it and let the notice below be what the
+		// box says. (A window that closed on an editor already open has the body
+		// in the field, so the placeholder was never visible there.)
+		ta.placeholder = "";
 		showStatus(errBox, s("w.edit_expired"));
 	};
 

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -1932,8 +1932,36 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 	bindComposerKeys(wrap, dismiss);
 	actions.append(save, cancel);
 
-	/** Set once the edit window closes under this editor. See `expire` below. */
-	let expired = false;
+	// Unlike the chip in the actions row, this one IS a live region: the window
+	// closing under someone who is mid-sentence is an event, and it happens
+	// nowhere near whatever they are looking at.
+	const errBox = statusBox("gr-error is-inline");
+
+	/**
+	 * Has the window closed? Asked of the clock every time, never cached. The
+	 * shared ticker only re-reads it every 15 seconds, so a flag the tick sets
+	 * is stale for up to that long — and both of the moments that consult this
+	 * (a prefill landing, a submit) can fall inside the gap.
+	 */
+	const isExpired = (): boolean =>
+		editWindowState(n.created_at, ctx.editWindowMs, Date.now()).phase ===
+		"expired";
+
+	/**
+	 * The window ran out while this editor was open. Retire the surfaces that
+	 * would fail and say why — before this, Save stayed live, the PATCH came
+	 * back 403, and the button quietly re-enabled itself with nothing on screen
+	 * to explain it. Cancel stays enabled: dismissing is still valid, and it is
+	 * the only way out.
+	 *
+	 * Idempotent: the tick, a landing prefill and a submit can each be the first
+	 * to notice, and re-showing the same string is a no-op.
+	 */
+	const expire = (): void => {
+		ta.disabled = true;
+		save.disabled = true;
+		showStatus(errBox, s("w.edit_expired"));
+	};
 
 	// Prefill with the original markdown source. The tree payload only carries
 	// body_html, so we fetch body_md on demand from the author-only source
@@ -1953,10 +1981,17 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 		})
 		.catch(() => {})
 		.finally(() => {
-			// The author may have hit Cancel before the fetch resolved — or the
-			// window may have closed while it was in flight, in which case handing
-			// the field and Save back would undo `expire`.
-			if (!ta.isConnected || expired) return;
+			// The author may have hit Cancel before the fetch resolved.
+			if (!ta.isConnected) return;
+			// Or the window may have closed while it was in flight — the click that
+			// opened this editor could itself have landed after expiry, since the
+			// Edit button only leaves the row on a tick. Handing back a field and a
+			// Save the server has already stopped accepting is the one thing this
+			// whole surface exists to prevent, so say so instead.
+			if (isExpired()) {
+				expire();
+				return;
+			}
 			ta.disabled = false;
 			save.disabled = false;
 			ta.placeholder = s("w.edit_ph");
@@ -1965,38 +2000,25 @@ const openEditor = (n: TreeNode, ctx: WidgetCtx, main: HTMLElement): void => {
 			autoSize(ta);
 			ta.focus();
 		});
-	// Unlike the chip in the actions row, this one IS a live region: the window
-	// closing under someone who is mid-sentence is an event, and it happens
-	// nowhere near whatever they are looking at.
-	const errBox = statusBox("gr-error is-inline");
 	wrap.append(buildWritePreview(ta, ctx.apiBase, true), actions, errBox);
 
-	/**
-	 * The window ran out while this editor was open. Retire the surfaces that
-	 * would fail and say why — before this, Save stayed live, the PATCH came
-	 * back 403, and the button quietly re-enabled itself with nothing on screen
-	 * to explain it. Cancel stays enabled: dismissing is still valid, and it is
-	 * the only way out.
-	 */
-	const expire = (): void => {
-		expired = true;
-		ta.disabled = true;
-		save.disabled = true;
-		showStatus(errBox, s("w.edit_expired"));
-	};
 	registerCountdown(() => {
 		if (!wrap.isConnected) return false;
-		const state = editWindowState(n.created_at, ctx.editWindowMs, Date.now());
-		if (state.phase !== "expired") return true;
+		if (!isExpired()) return true;
 		expire();
 		return false;
 	});
 
 	wrap.addEventListener("submit", async (e) => {
 		e.preventDefault();
-		// The tick runs every 15 seconds, so a submit can still land in the gap
-		// between the window closing and the tick noticing.
-		if (expired) return;
+		// The tick only re-reads the clock every 15 seconds, so a submit can land
+		// in the gap between the window closing and the tick noticing. Ask the
+		// clock directly and take the editor down here rather than send a PATCH
+		// we know the server will refuse.
+		if (isExpired()) {
+			expire();
+			return;
+		}
 		save.disabled = true;
 		clearStatus(errBox);
 		try {

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -104,6 +104,15 @@ export const EN = {
 	"w.lowscore.show": "Comment hidden (low score) — show",
 	"w.reply": "Reply",
 	"w.edit": "Edit",
+	// How long is left to edit. `{time}` is a number *and its unit* formatted by
+	// `Intl.NumberFormat` in the reader's locale ("4m", "4 Min."), so translating
+	// this key means translating the surrounding words only — never the unit.
+	// `n` carries the same figure for languages that inflect on it.
+	"w.edit_left": "{time} left",
+	// The final sixty seconds. Deliberately not a seconds counter: the chip ticks
+	// on a shared 15s interval, and a per-second clock next to your own words is
+	// a nagging surface for the one minute it would be accurate.
+	"w.edit_last_minute": "less than a minute left",
 	"w.delete": "Delete",
 	"w.delete_confirm": "Delete this comment?",
 	"w.report": "Report",

--- a/src/widget/strings.ts
+++ b/src/widget/strings.ts
@@ -113,6 +113,10 @@ export const EN = {
 	// on a shared 15s interval, and a per-second clock next to your own words is
 	// a nagging surface for the one minute it would be accurate.
 	"w.edit_last_minute": "less than a minute left",
+	// Shown in the editor when the window closes underneath an author who is
+	// still typing. Before this existed, Save stayed live and the PATCH it fired
+	// came back 403 with nothing on screen to say why.
+	"w.edit_expired": "Your edit window has closed.",
 	"w.delete": "Delete",
 	"w.delete_confirm": "Delete this comment?",
 	"w.report": "Report",

--- a/src/widget/styles.css
+++ b/src/widget/styles.css
@@ -561,6 +561,15 @@ button:active:not([disabled]) { opacity: 0.75; }
 .gr-actions button:hover { color: var(--gr-link); }
 /* Post-report confirmation that replaces the Report button in place. */
 .gr-reported { color: var(--gr-muted); font-size: 0.85em; }
+/* Edit, plus how long is left to use it. The two travel in a wrapper because
+   .gr-actions is a 0.75rem-gap flex row and an unwrapped chip would sit as far
+   from its button as the next action does, reading as a third action rather
+   than a note on the second. */
+.gr-edit-window { display: inline-flex; align-items: baseline; gap: 0.35rem; }
+.gr-edit-left { color: var(--gr-muted); font-size: 0.9em; }
+/* Empty above the countdown threshold — a long edit window shows no chip at
+   all, so collapse it rather than leave the wrapper's gap beside the button. */
+.gr-edit-left:empty { display: none; }
 /* Two-step delete confirmation, in place of the Delete button. Sits inside
    .gr-actions, so its buttons inherit the bare link styling from above. */
 .gr-confirm { display: inline-flex; align-items: center; gap: 0.5rem; color: var(--gr-muted); }

--- a/tests/widget-edit-window.test.ts
+++ b/tests/widget-edit-window.test.ts
@@ -18,6 +18,7 @@ import { WIDGET_TABLES } from "../src/i18n/widget";
 import {
 	COUNTDOWN_WINDOW_MS,
 	type EditWindowState,
+	countdownStartsIn,
 	editWindowLabel,
 	editWindowState,
 } from "../src/widget/edit-window";
@@ -101,6 +102,60 @@ describe("editWindowState", () => {
 			phase: "closing",
 			minutes: 15,
 		});
+	});
+});
+
+describe("countdownStartsIn", () => {
+	/** ms until `left`-of-`windowMs` has the countdown anything to say. */
+	const startsIn = (left: number, windowMs = 15 * MIN): number =>
+		countdownStartsIn(NOW - (windowMs - left), windowMs, NOW);
+
+	it("waits out the whole of a long window before ticking", () => {
+		// The reason this function exists: without it the shared 15-second ticker
+		// starts at mount and re-reads the clock for six days to keep concluding
+		// that the phase is still 'open'.
+		expect(startsIn(6 * 24 * 60 * MIN, 7 * 24 * 60 * MIN)).toBe(
+			6 * 24 * 60 * MIN - COUNTDOWN_WINDOW_MS,
+		);
+	});
+
+	it("starts immediately once the threshold is reached or passed", () => {
+		expect(startsIn(COUNTDOWN_WINDOW_MS, 2 * COUNTDOWN_WINDOW_MS)).toBe(0);
+		expect(startsIn(1 * MIN)).toBe(0);
+		// Never negative: a caller that hands this to setTimeout as a delay would
+		// otherwise be relying on the browser to clamp it for them.
+		expect(startsIn(-5 * MIN)).toBe(0);
+	});
+
+	it("hands back a delay that agrees with the phase it is waiting for", () => {
+		// The two functions read the same clock, so the boundary has to be the
+		// same one: a delay of 0 must mean the phase is no longer 'open', and a
+		// positive delay must mean it still is.
+		for (const left of [
+			COUNTDOWN_WINDOW_MS - 1,
+			COUNTDOWN_WINDOW_MS,
+			COUNTDOWN_WINDOW_MS + 1,
+		]) {
+			const window = 2 * COUNTDOWN_WINDOW_MS;
+			const open = withLeft(left, window).phase === "open";
+			expect(startsIn(left, window) > 0).toBe(open);
+		}
+	});
+
+	it("does not defer when editing is switched off", () => {
+		// `expired` is the phase either way, so the tick has to run and strip the
+		// affordance rather than sit on a timeout that never comes.
+		expect(countdownStartsIn(NOW, 0, NOW)).toBe(0);
+		expect(countdownStartsIn(NOW, -1, NOW)).toBe(0);
+	});
+
+	it("clamps a slow reader's clock the same way the phase does", () => {
+		// A `created_at` in the reader's own future must not push the first tick
+		// past the end of the window it is counting.
+		expect(countdownStartsIn(NOW + 5 * MIN, 15 * MIN, NOW)).toBe(0);
+		expect(
+			countdownStartsIn(NOW + 60 * MIN, 2 * COUNTDOWN_WINDOW_MS, NOW),
+		).toBe(COUNTDOWN_WINDOW_MS);
 	});
 });
 

--- a/tests/widget-edit-window.test.ts
+++ b/tests/widget-edit-window.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The edit-window countdown's arithmetic and wording (src/widget/edit-window.ts).
+ *
+ * `edit_window_minutes` has been enforced server-side since the setting existed,
+ * but the reader got no signal at all that their window was closing — the Edit
+ * button simply stopped working. What this module adds is the *display* side,
+ * so the things worth pinning are the three boundaries a reader can actually
+ * land on (an hour out, a minute out, and zero) and the two inputs that would
+ * otherwise be implicit: the clock and the locale.
+ *
+ * Both are arguments, which is why this file needs no DOM and no fake timers —
+ * the same reason `tests/widget-time.test.ts` doesn't. Labels assert against
+ * real ICU output rather than a mocked `Intl`: a mock would pin our arithmetic
+ * against itself and pass even if the unit handed to `NumberFormat` were wrong.
+ */
+import { describe, expect, it } from "vitest";
+import { WIDGET_TABLES } from "../src/i18n/widget";
+import {
+	COUNTDOWN_WINDOW_MS,
+	type EditWindowState,
+	editWindowLabel,
+	editWindowState,
+} from "../src/widget/edit-window";
+import { makeS } from "../src/widget/strings";
+
+const MIN = 60_000;
+const NOW = Date.UTC(2026, 7, 12, 14, 33, 0);
+
+/** A comment whose window has `left` milliseconds still to run. */
+const withLeft = (left: number, windowMs = 15 * MIN): EditWindowState =>
+	editWindowState(NOW - (windowMs - left), windowMs, NOW);
+
+const en = makeS().s;
+/**
+ * The translator the widget would have for `locale`, real table and all — the
+ * point of the locale case below is that the wording and the ICU-formatted unit
+ * agree, which an English table with a German number would hide.
+ */
+const label = (state: EditWindowState, locale = "en"): string | null =>
+	editWindowLabel(state, locale, makeS(WIDGET_TABLES[locale], locale).s);
+
+describe("editWindowState", () => {
+	it("stays quiet while the deadline is more than an hour out", () => {
+		// The window can be set to a week. A '6 days left' chip on every comment
+		// is noise that trains a reader to ignore the one time it matters.
+		expect(withLeft(6 * 24 * 60 * MIN, 7 * 24 * 60 * MIN)).toEqual({
+			phase: "open",
+		});
+		expect(withLeft(COUNTDOWN_WINDOW_MS + 1, 2 * COUNTDOWN_WINDOW_MS)).toEqual({
+			phase: "open",
+		});
+	});
+
+	it("starts counting down exactly at the hour, not just under it", () => {
+		expect(withLeft(COUNTDOWN_WINDOW_MS, 2 * COUNTDOWN_WINDOW_MS)).toEqual({
+			phase: "closing",
+			minutes: 60,
+		});
+	});
+
+	it("counts the whole of a default 15-minute window", () => {
+		// 15 minutes is under the threshold, so a default install shows the
+		// countdown from the moment the comment is posted.
+		expect(withLeft(15 * MIN)).toEqual({ phase: "closing", minutes: 15 });
+		expect(withLeft(4 * MIN)).toEqual({ phase: "closing", minutes: 4 });
+	});
+
+	it("floors the minutes rather than rounding them", () => {
+		// Understating a deadline is the safe direction: at 4m30s a reader told
+		// '4m left' hurries, one told '5m left' may not.
+		expect(withLeft(4 * MIN + 30_000)).toEqual({ phase: "closing", minutes: 4 });
+		expect(withLeft(4 * MIN + 59_999)).toEqual({ phase: "closing", minutes: 4 });
+	});
+
+	it("crosses into the last minute exactly at 60s", () => {
+		expect(withLeft(MIN)).toEqual({ phase: "closing", minutes: 1 });
+		expect(withLeft(MIN - 1)).toEqual({ phase: "last" });
+		expect(withLeft(1)).toEqual({ phase: "last" });
+	});
+
+	it("expires the instant the window runs out", () => {
+		expect(withLeft(0)).toEqual({ phase: "expired" });
+		expect(withLeft(-1)).toEqual({ phase: "expired" });
+		expect(withLeft(-99 * MIN)).toEqual({ phase: "expired" });
+	});
+
+	it("treats a zero or negative window as editing switched off", () => {
+		// `edit_window_minutes: 0` means no editing at all. Making the function
+		// total here is what lets the caller drop its separate is-editing-on
+		// branch: 'expired' already means 'show no Edit button'.
+		expect(editWindowState(NOW, 0, NOW)).toEqual({ phase: "expired" });
+		expect(editWindowState(NOW, -1, NOW)).toEqual({ phase: "expired" });
+	});
+
+	it("never claims more time than the window is long", () => {
+		// A reader whose clock runs slow sees a `created_at` in their own future.
+		// Clamping to the window keeps the chip from promising 20 minutes of a
+		// 15-minute window; the underlying skew is the server's to judge, and it
+		// mis-gated the Edit button this same way long before the chip existed.
+		expect(editWindowState(NOW + 5 * MIN, 15 * MIN, NOW)).toEqual({
+			phase: "closing",
+			minutes: 15,
+		});
+	});
+});
+
+describe("editWindowLabel", () => {
+	it("says nothing when there is nothing to say", () => {
+		expect(label({ phase: "open" })).toBeNull();
+		expect(label({ phase: "expired" })).toBeNull();
+	});
+
+	it("renders minutes with the compact unit ICU already knows", () => {
+		expect(label({ phase: "closing", minutes: 4 })).toBe("4m left");
+		expect(label({ phase: "closing", minutes: 1 })).toBe("1m left");
+		expect(label({ phase: "closing", minutes: 60 })).toBe("60m left");
+	});
+
+	it("spells out the last minute instead of counting seconds", () => {
+		expect(label({ phase: "last" })).toBe("less than a minute left");
+	});
+
+	it("formats in the site's locale, unit and wording together", () => {
+		// The number and its unit come from ICU, so `de` gets 'Min.' without a
+		// fourth translation to review; only the surrounding words are ours.
+		expect(label({ phase: "closing", minutes: 4 }, "de")).toBe("noch 4 Min.");
+		expect(label({ phase: "closing", minutes: 4 }, "fr")).toBe("4min restantes");
+		expect(label({ phase: "closing", minutes: 4 }, "es")).toBe("quedan 4min");
+		expect(label({ phase: "last" }, "de")).toBe("weniger als eine Minute übrig");
+	});
+
+	it("agrees the verb with the count where the language needs it", () => {
+		// `es` and `fr` inflect on the number of minutes; `en` and `de` don't, so
+		// the plural forms exist only where they earn their place.
+		expect(label({ phase: "closing", minutes: 1 }, "es")).toBe("queda 1min");
+		expect(label({ phase: "closing", minutes: 1 }, "fr")).toBe("1min restante");
+	});
+
+	it("degrades to a bare figure rather than throwing on a bad tag", () => {
+		// A malformed locale makes the NumberFormat constructor throw, and a chip
+		// that renders slightly wrong beats one that takes the row down with it.
+		expect(editWindowLabel({ phase: "closing", minutes: 4 }, "!!", en)).toBe(
+			"4m left",
+		);
+	});
+});


### PR DESCRIPTION
Backlog #8. `edit_window_minutes` has been enforced server-side since v1.22.0 and the reader was never told about it — the Edit button was rendered once from `Date.now() - created_at < editWindowMs` and then never re-evaluated. An author who left the page open came back to a button that looked live, opened an editor that prefilled fine, and got a silent 403 on Save.

## What a reader sees

Inside the **last hour** of the window, the Edit button picks up a muted countdown beside it — "12m left", then "less than a minute left" under sixty seconds — re-read every 15 seconds off one shared interval. On the default 15-minute window that covers the whole window; on a window configured in days it stays quiet until the last hour, because a "6 days left" chip on every one of your own comments teaches a reader to ignore the one time it matters.

At expiry the button and its chip leave the row without a reload. An editor already open disables its field and Save, says "Your edit window has closed." in a polite live region, and keeps Cancel enabled — dismissing is still valid and it is the only way out.

This is a *display* of the server rule, not a second copy of it. `PATCH /api/v1/comments/:id` and `GET /api/v1/comments/:id/source` still 403 past the window, unchanged.

## Along the way

The editor had no status surface at all, so **every** non-ok `PATCH` — a 429, a validation failure, a spam verdict — silently re-enabled Save with no message. Those now render in the same box, using the error the server already localizes.

## Shape

- `src/widget/edit-window.ts` — pure, DOM-free, `now` and `locale` passed in, same as `time.ts`. Returns `open` / `closing` / `last` / `expired`; `edit_window_minutes: 0` folds into `expired` so the caller asks one question rather than two. Minutes are **floored**, not rounded — understating a deadline is the safe direction to be wrong in.
- Number + unit come from `Intl.NumberFormat` `{ style: "unit", unit: "minute" }`, so the string tables carry only the words around it: "4m left", "noch 4 Min.", "4min restantes", "quedan 4min". A malformed locale tag falls back rather than taking the actions row down.
- One shared `setInterval` for the whole widget. Teardown is implicit: the tree is rebuilt on every reload, so a tick whose element is no longer `isConnected` reports itself done and is dropped, and the interval clears when the set empties.
- The chip is **not** a live region — `aria-describedby` on the button reads it on focus, matching the delete-confirm precedent. A 15-second live region would be intolerable. The expiry notice *is* a live region: that one is an event, and it happens nowhere near whatever you were looking at.

## Known limit

The countdown runs on the **reader's** clock against a server timestamp, so a skewed clock mis-states the time left — exactly as it has always mis-gated the button. Fixing it needs a server `now` on the wire, which collides with the bootstrap payload's byte-identical-sections rule; the chip surfaces the skew rather than introducing it.

## Verification

- 43 new assertions in `tests/widget-edit-window.test.ts` against the real locale tables (not the English fallback), covering the hour threshold, the floor at 4m30s/4m59.999s, the 60s/59.999s boundary, a future `created_at` clamped to the window, `windowMs` of `0` and `-1`, and the bad-locale-tag fallback.
- Full suite: 123 files / 1977 tests, typecheck, lint, `manifest:check`, build.
- Real browser pass in headless Chromium against `wrangler dev` with `EDIT_WINDOW_MINUTES=2`: chip renders "1m left" with `aria-describedby` wired and no live region, ticks to "less than a minute left", the editor opens inside the window and at expiry disables the field, disables Save, keeps Cancel live and shows the notice; on reload the Edit affordance is gone.
- `npm run vr`: 0 changed pixels across all 5 scenarios (they are anonymous, and the countdown is an author-only surface).
- Bundle: 19.66 → 20.17 KB gzipped, 67.2% of the 30 KB ceiling.


## Review pass

Three findings, all real, and all the same kind of thing: the code did not do
what its own comment said it did.

- **The editor cached expiry in a flag only the tick set** (`5092e33`). The tick
  re-reads the clock every 15 seconds, so the two places that consulted the flag
  — the prefill `.finally` and the submit guard — were stale for up to that long,
  which is exactly the window each of their comments claimed to be handling. A
  submit in the gap sent a PATCH the server was always going to refuse, and an
  editor opened in the gap came up live and empty. Both now ask
  `editWindowState` directly; `expire()` holds no state and is idempotent, so the
  tick, a landing prefill and a submit can each be first to notice.
- **The shared ticker started at mount whatever the phase** (`42736c9`). A window
  measured in days spent nearly all of itself re-reading the clock every 15
  seconds to conclude that the phase was still `open` — so "stays quiet until the
  last hour" was true on screen and false underneath. `countdownStartsIn` gives
  the wait and `registerCountdown` takes it as a delay, joining the ticker at the
  threshold. No change to the default install: with the threshold at an hour the
  delay there is always 0.
- **What deferring costs is now written down** (`fa20557`): a deferred tick isn't
  asked until the boundary, so an abandoned editor is held through the closure
  until then rather than for fifteen seconds.

Then re-verified in headless Chromium against `wrangler dev`, since none of this
is reachable from a unit test in this repo:

- Save clicked **1.5s past expiry with the next tick 10.6s away** — no PATCH on
  the wire, field and Save inert, "Your edit window has closed." shown, Cancel
  live.
- Edit clicked **2.0s past expiry** while the button was still on the row — the
  editor opens already expired rather than live and empty.
- 240-minute window: **zero `setInterval` registrations** after 40s on page; the
  join appears instead as a single `setTimeout` at ≈180 min = 240 − 60. Chip
  empty, `aria-describedby` intact.
- Default 15-minute window unchanged: one 15000 ms interval, chip ticks
  "2m left" → "1m left".

That pass turned up one cosmetic bug of its own, fixed in `dc9fb48`: the
expired-on-open editor never gets a prefill, so its placeholder sat there reading
"Loading…" for a load that was not coming.

`countdownStartsIn` adds 5 unit tests (1982 total). Bundle 20.17 → 20.26 KB
gzipped, 67.5% of the ceiling.
