### PR TITLE
feat(import): Remark42 adapter, CLI and admin upload path

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -872,7 +872,7 @@ tracked by the `_migrations` table. Current set:
 - `0006_webhook_endpoints.sql` — outbound signed webhooks + retry queue
 - `0007_votes.sql` — vote storage + denormalized score counters
 - `0008_saved_replies.sql` — moderator saved replies
-- `0009_import_tracking.sql` — Disqus import idempotency
+- `0009_import_tracking.sql` — import idempotency, `(import_source, import_id)`
 - `0010_settings.sql` — DB-backed runtime settings overrides
 - `0011_page_engagement.sql` — page-level reactions + votes
 - `0012_deleted_by.sql` — records who deleted a comment
@@ -901,9 +901,10 @@ action id count) are applied *after* `c.req.json()` has already deserialized the
 whole body, so without it a multi-megabyte payload costs a full parse against the
 Worker's 10 ms CPU budget before any of them get a say. 64 KB is far above every
 legitimate payload — the largest is a comment at the 10,000-character body limit.
-The one exemption is `POST /admin/api/ops/import-disqus`, which takes a
-Disqus XML export — gzipped or not — up to 50 MB and enforces its own limit,
-on the decompressed bytes as well as the compressed ones. Implementation:
+The exemptions are the two import uploads, `POST /admin/api/ops/import-disqus`
+and `POST /admin/api/ops/import-remark42`, which take an export — gzipped or
+not — up to 50 MB and enforce their own limit, on the decompressed bytes as
+well as the compressed ones. Implementation:
 `src/lib/body-limit.ts`.
 
 **Client IP is required, not guessed.** Every endpoint that meters or dedupes
@@ -947,7 +948,7 @@ Pages (top nav):
 | `/admin/users/:id` | User detail: all their comments paginated, reactions received, audit history affecting them, the **Moderator notes** card, Ban/Unban, role controls, and two folded-away admin-only panels — **Export personal data** and **Erase personal data** (both below). |
 | `/admin/audit` | Audit log with filter form (admin, action, target kind/id, date range). |
 | `/admin/subscriptions` | Email subscription list. Filter by email/post/confirmed/unsubscribed. Actions: manual unsubscribe, resend confirmation. |
-| `/admin/operator` | Batch operations: rerender stale comments (POSTs `/admin/api/ops/rerender` in 50-row chunks until done), seed-demo (idempotent; gated to `ENV != "production"`), the Disqus import upload (XML or .xml.gz — see below), and two retention cards — IP-hash and audit-log — each showing how many rows are past the configured window and offering a manual drain. |
+| `/admin/operator` | Batch operations: rerender stale comments (POSTs `/admin/api/ops/rerender` in 50-row chunks until done), seed-demo (idempotent; gated to `ENV != "production"`), the comment import upload (Disqus XML or a Remark42 backup, gzipped or not — see below), and two retention cards — IP-hash and audit-log — each showing how many rows are past the configured window and offering a manual drain. |
 | `/admin/settings` | Editable form for feature flags, display/pagination numbers, and the moderation dials (edit window, thread auto-close, community auto-collapse, the three anti-spam heuristics), saved to the `settings` D1 table (no redeploy — see section 5). Also renders a read-only `(set)`/`(unset)` summary of deploy-time config (Turnstile, email, OAuth, spam provider), which still changes via `wrangler secret put` / `wrangler.toml`. |
 | `/admin/webhooks` | Outbound webhook endpoints: add/pause/delete, per-endpoint secret + event filter, adapter (`generic` / `slack` / `discord` / `telegram`), failure counts and retry status. |
 | `/admin/telegram` | **Admin-only.** Telegram operator bot: shows whether the bot token/webhook secret are set, links your personal Telegram account (one-time code or deep link), toggles the daily digest, and unlinks. See `docs/telegram.md`. |
@@ -1238,18 +1239,23 @@ releases advertising a key that did nothing. `/` and `?` are inert
 while you are typing and under any modifier; `Esc` is matched before
 that guard, so a popover left open still closes from inside a textarea.
 
-**Disqus import.** Two entry points, both idempotent (deduplicated by
-Disqus comment ID, tracked in `0009_import_tracking.sql`; re-running
-the same export inserts zero rows):
+**Comment import.** Two sources today — Disqus and Remark42 — each
+with two entry points, all four idempotent (deduplicated by the
+source's own comment ID, tracked in `0009_import_tracking.sql`;
+re-running the same export inserts zero rows):
 
 - CLI (preferred for big exports):
-  `IP_HASH_SECRET=... npm run import-disqus -- ./export.xml --dry-run`,
-  then without `--dry-run` to commit.
-- Admin upload on `/admin/operator` — capped at 50 MB, with dry-run /
-  include-deleted / include-spam toggles.
+  `IP_HASH_SECRET=... npm run import-disqus -- ./export.xml --dry-run`
+  or `IP_HASH_SECRET=... npm run import-remark42 -- ./userbackup.gz
+  --dry-run`, then without `--dry-run` to commit.
+- Admin upload on `/admin/operator` — one card with a source select,
+  capped at 50 MB, with dry-run / include-deleted / include-spam
+  toggles.
 
-**Gzipped exports work as-is, on both paths.** Disqus hands you a
-`.xml.gz`; hand it straight to the CLI or the upload and it is
+**Gzipped exports work as-is, on every path.** Disqus hands you a
+`.xml.gz` and Remark42's nightly `backup` writes a
+`userbackup-<site>-<ts>.gz`; hand either straight to the CLI or the
+upload and it is
 inflated in memory. The 50 MB cap applies to the *decompressed* size
 too — a file that inflates past it is rejected with `413
 {"error":"too_large"}` partway through rather than allocated, which is
@@ -1298,13 +1304,39 @@ threads merged three. If the count surprises you, run with `--slug=`
 to force everything onto one page deliberately, in which case
 `merged_pages` reports zero because the collapse is what you asked
 for.
+**Remark42 specifics.** The export is JSONL — one metadata header
+object, then one object per comment — and Garrul takes it with or
+without that header, so both `backup`'s file and the export API's
+`mode=stream` work. Three things differ from Disqus and are worth
+knowing before you run it:
+
+- **Pages are reconstructed, not imported.** A Remark42 export carries
+  no page records at all, so each page is derived from the `url` its
+  comments name, taking its title from the first comment that has one
+  and its creation time from the earliest. `read_only` in the header
+  becomes `posts.closed`.
+- **Bodies prefer the markdown the author typed.** Remark42 stores both
+  the original source (`orig`) and its rendered HTML (`text`). Garrul
+  takes `orig` where it exists and falls back to converting `text`
+  where it does not, so an import is lossless for anything the author
+  wrote in markdown.
+- **One site per export.** An export spanning two `locator.site`
+  values is refused rather than merged; Garrul is single-site, so
+  merging two would silently interleave two comment systems onto one
+  set of slugs. Export per site.
+
+`--include-spam` is accepted for flag parity and does nothing here:
+Remark42 has no spam verdict, so the adapter never emits
+`status='spam'`. Deleted comments are skipped unless
+`--include-deleted`.
 
 **The importer is source-agnostic underneath.** `src/lib/import/core.ts`
 holds everything true of every source — identity derivation,
 idempotency, threading, depth capping, the size and gzip handling — and
-`src/lib/import/disqus.ts` is just the adapter that knows how to read
-Disqus XML. Adapters for other comment systems are tracked in #104;
-they inherit all of the above rather than reimplementing it.
+`src/lib/import/disqus.ts` and `src/lib/import/remark42.ts` are just the
+adapters that know how to read one format each. A new adapter is one
+file exporting an `ImportAdapter`; the remaining sources are tracked in
+ #104, and they inherit all of the above rather than reimplementing it.
 
 **`IP_HASH_SECRET` is required for the CLI, and must be the same
 secret the Worker uses.** It keys the ghost-identity HMAC above, so a

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1325,6 +1325,12 @@ knowing before you run it:
   merging two would silently interleave two comment systems onto one
   set of slugs. Export per site.
 
+A line missing its comment `id`, its `locator.url`, or its `user.id`
+fails the whole run with the line number — never the line body, which
+may carry an `ip` field. `user.id` is in that list because it is the
+identity key: without it the importer would fall back to keying on
+display name, merging two commenters who picked the same one.
+
 `--include-spam` is accepted for flag parity and does nothing here:
 Remark42 has no spam verdict, so the adapter never emits
 `status='spam'`. Deleted comments are skipped unless

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ dashboard page); every other integration is optional.
   sanitizer always on, four tunable heuristics and an optional classifier
   on top, everything routed to the queue
   ([`docs/ANTISPAM.md`](docs/ANTISPAM.md))
-- **Import from Disqus**: upload the export in the admin UI — the
-  `.xml.gz` Disqus hands you, no unzipping — or run
-  `npm run import-disqus -- ./export.xml.gz --dry-run` first. Idempotent,
+- **Import from Disqus or Remark42**: upload the export in the admin UI —
+  the `.xml.gz` Disqus hands you or the `userbackup-<site>-<ts>.gz`
+  Remark42 writes nightly, no unzipping — or run
+  `npm run import-disqus -- ./export.xml.gz --dry-run` /
+  `npm run import-remark42 -- ./userbackup.gz --dry-run` first. Idempotent,
   so a re-run inserts nothing; closed threads stay closed and spam stays
   out of the public tree
 - **Admin UI**: moderation queue, user management, and settings you

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "rerender": "tsx scripts/rerender.ts",
     "seed-demo": "tsx scripts/seed-demo.ts",
     "import-disqus": "tsx scripts/import-disqus.ts",
+    "import-remark42": "tsx scripts/import-remark42.ts",
     "db:export": "bash scripts/db-export.sh",
     "upgrade": "tsx scripts/upgrade.ts",
     "manifest:build": "tsx scripts/upgrade/build-manifest.ts",

--- a/scripts/import-remark42.ts
+++ b/scripts/import-remark42.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env tsx
+/**
+ * Import a Remark42 native export into the local or remote D1.
+ *
+ *   npm run import-remark42 -- ./userbackup-site-20260101.gz      # local D1
+ *   npm run import-remark42 -- ./export.jsonl                     # plain, too
+ *   npm run import-remark42 -- ./userbackup-site.gz --remote      # production D1
+ *
+ * Flags:
+ *   --remote            Use the deployed D1 binding instead of Miniflare.
+ *   --dry-run           Parse + plan only. No INSERTs run.
+ *   --include-deleted   Bring Remark42-deleted comments across (default: skip).
+ *   --include-spam      Bring source-spam comments across (default: skip).
+ *                       Inert for this source — Remark42 has no spam verdict, so
+ *                       the adapter never emits `status='spam'`. Kept so every
+ *                       importer CLI takes the same flags.
+ *   --slug=<slug>       Pin every imported thread to one slug (rare —
+ *                       useful when migrating a single page).
+ *
+ * Idempotent: re-running on the same backup inserts zero new rows (every
+ * comment carries `import_source='remark42'` + Remark42's own comment id
+ * under `import_id`, and migration 0009 puts a partial UNIQUE index on that
+ * pair).
+ *
+ * Why this is a local CLI, not a Worker endpoint:
+ *   Big exports easily exceed the Workers free-tier 100k D1 writes/day
+ *   quota in a single import. Running locally via wrangler d1 execute
+ *   counts those writes against your D1 budget, but does NOT spend any
+ *   Worker requests. The admin upload endpoint (operator page) wraps this
+ *   same library, and bounds a run only by capping the upload at
+ *   MAX_IMPORT_BYTES on the decompressed side — which is a cap on input,
+ *   not on writes. A backup under that cap can still be a lot of rows.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import { ImportTooLargeError, decodeImportInput } from "../src/lib/import/core";
+import { runRemark42Import } from "../src/lib/import/remark42";
+
+// The binding, not `database_name` — see the docblock in src/db/migrate.ts.
+const DB_BINDING = "DB";
+
+const args = process.argv.slice(2);
+const positional = args.filter((a) => !a.startsWith("--"));
+const backupPath = positional[0];
+if (!backupPath) {
+	console.error(
+		"usage: npm run import-remark42 -- <path-to-remark42-backup> [--remote] [--dry-run]",
+	);
+	process.exit(2);
+}
+const isRemote = args.includes("--remote");
+const dryRun = args.includes("--dry-run");
+const includeDeleted = args.includes("--include-deleted");
+const includeSpam = args.includes("--include-spam");
+const slugFlag = args.find((a) => a.startsWith("--slug="));
+const slugOverride = slugFlag ? slugFlag.slice("--slug=".length) : null;
+
+const remoteFlag = isRemote ? "--remote" : "--local";
+
+// The importer needs to talk to D1. tsx running locally can't bind D1
+// directly — we drive it through `wrangler d1 execute` per statement.
+// That's only viable for thousands-not-millions of rows. The admin
+// endpoint uses the same library inside the Worker where DB is bound
+// natively, which is the production path.
+//
+// Why this interpolates instead of binding: `wrangler d1 execute` accepts
+// only `--command` and `--file`. There is no parameter-binding flag, so a
+// CLI-driven shim has no way to hand D1 a statement and its values
+// separately — the SQL text is the entire interface. Every statement here
+// is therefore assembled by substitution, over values parsed out of an
+// untrusted Remark42 export.
+//
+// What makes that survivable, and what does not:
+//   * SQLite string literals escape a quote by doubling it, and recognize
+//     no backslash escapes, so `''` is the complete escape for a literal.
+//   * wrangler splits multi-statement input with a quote-aware scanner
+//     (`splitSqlIntoStatements` consumes to the closing quote), so a
+//     semicolon inside a correctly-escaped literal — routine in comment
+//     bodies — does not start a new statement.
+//   * Neither of those helps if the *value* never reaches a literal
+//     intact. `resolve` below therefore refuses anything it cannot inline
+//     exactly, rather than emitting approximately-right SQL.
+const sqlEsc = (s: string): string => s.replace(/'/g, "''");
+
+const runWrangler = (sql: string): string =>
+	execFileSync(
+		"wrangler",
+		["d1", "execute", DB_BINDING, remoteFlag, "--command", sql],
+		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+	);
+
+const d1: D1Database = {
+	prepare(rawSql: string) {
+		const sql = rawSql;
+		const binds: unknown[] = [];
+		return {
+			bind(...args: unknown[]) {
+				binds.push(...args);
+				return this;
+			},
+			async first<T = unknown>(): Promise<T | null> {
+				const resolved = resolve(sql, binds);
+				const out = runWrangler(resolved);
+				const rows = parseRows(out);
+				return (rows[0] as T) ?? null;
+			},
+			async all<T = unknown>(): Promise<{ results: T[] }> {
+				const resolved = resolve(sql, binds);
+				const out = runWrangler(resolved);
+				return { results: parseRows(out) as T[] };
+			},
+			async run() {
+				const resolved = resolve(sql, binds);
+				runWrangler(resolved);
+				return { meta: { changes: 1 } };
+			},
+		} as unknown as D1PreparedStatement;
+	},
+} as unknown as D1Database;
+
+// A value that can't be inlined exactly. Aborts the import rather than
+// letting a wrong-but-valid statement reach D1.
+class BindError extends Error {}
+
+const inline = (v: unknown, index: number): string => {
+	if (v === null || v === undefined) return "NULL";
+	if (typeof v === "number") {
+		// String(NaN) is `NaN` and String(Infinity) is `Infinity`, both bare
+		// identifiers to SQLite rather than values. Not reachable from a Remark42
+		// export today — the adapter's parseTime falls back to Date.now() on an
+		// unparseable `time` — so this holds the invariant for future callers
+		// rather than fixing a live bug.
+		if (!Number.isFinite(v)) {
+			throw new BindError(`bind ${index}: non-finite number ${String(v)}`);
+		}
+		return String(v);
+	}
+	if (typeof v === "string") {
+		// argv is NUL-terminated, so a NUL in the value truncates the SQL
+		// mid-statement on its way to wrangler — silently, and at a position
+		// the attacker picks. Nothing in a Remark42 export legitimately carries
+		// one; refuse rather than truncate.
+		if (v.includes("\u0000")) {
+			throw new BindError(`bind ${index}: NUL byte in string value`);
+		}
+		return `'${sqlEsc(v)}'`;
+	}
+	// Booleans, bigints, objects and functions all used to reach String(),
+	// which produced `true`, `[object Object]` and worse. The importer binds
+	// only strings, numbers and null; anything else is a bug in the caller.
+	throw new BindError(`bind ${index}: unsupported type ${typeof v}`);
+};
+
+const resolve = (sql: string, binds: unknown[]): string => {
+	let i = 0;
+	// `replace` does not rescan its own output, so a `?` inside an inlined
+	// value can't consume the next bind.
+	const out = sql.replace(/\?/g, () => inline(binds[i++], i));
+	// A placeholder/bind mismatch used to be invisible: a surplus placeholder
+	// read `undefined` and quietly became NULL, so a mis-shaped INSERT wrote a
+	// row with a hole in it instead of failing. Both directions are bugs.
+	if (i !== binds.length) {
+		throw new BindError(
+			`placeholder/bind mismatch: ${i} placeholder(s), ${binds.length} bound value(s) in: ${sql.slice(0, 120)}`,
+		);
+	}
+	return out;
+};
+
+/**
+ * The rows from one `wrangler d1 execute --command` run.
+ *
+ * wrangler prints a banner and then a JSON envelope, one element per
+ * statement, each `{ results, success, meta }`:
+ *
+ *     🚣 1 command executed successfully.
+ *     [ { "results": [], "success": true, "meta": { "duration": 0 } } ]
+ *
+ * Unwrap properly rather than treating the envelope itself as the rows: for
+ * this caller an envelope object is truthy, so every `SELECT … WHERE …`
+ * existence probe would report "this row already exists" and the import would
+ * insert nothing while printing DONE with all-zero counters.
+ *
+ * Throws rather than returning [] when the output can't be read: for this
+ * caller "no rows" means "go ahead and insert", so guessing it on a parse
+ * failure is how a silently-broken import looks. A loud failure is recoverable;
+ * a no-op that claims success is not.
+ */
+type D1Envelope = { results?: unknown };
+
+const parseRows = (output: string): Record<string, unknown>[] => {
+	// The banner precedes the JSON, so anchor on the first `[` that starts a
+	// line — wrangler pretty-prints, and a nested `]` inside a row value would
+	// end a non-greedy match early.
+	const start = output.search(/^\[/m);
+	if (start === -1) {
+		// No envelope at all. wrangler exited 0, so this is an output-format
+		// change, not a query error (execFileSync throws on non-zero).
+		throw new Error(
+			`could not find a JSON result envelope in wrangler output:\n${output.slice(0, 400)}`,
+		);
+	}
+	let envelope: unknown;
+	try {
+		envelope = JSON.parse(output.slice(start));
+	} catch (err) {
+		throw new Error(`could not parse wrangler output as JSON: ${String(err)}`);
+	}
+	if (!Array.isArray(envelope)) {
+		throw new Error("wrangler result envelope was not an array");
+	}
+	// One statement in, so one element out; be tolerant of more.
+	return envelope.flatMap((e) => {
+		const results = (e as D1Envelope)?.results;
+		if (results === undefined) return [];
+		if (!Array.isArray(results)) {
+			throw new Error("wrangler result envelope had a non-array `results`");
+		}
+		return results as Record<string, unknown>[];
+	});
+};
+
+(async () => {
+	if (!isRemote) {
+		console.warn(`[import-remark42] running against LOCAL D1 (Miniflare).`);
+	}
+	// Read bytes, not utf8, and let decodeImportInput sniff the gzip magic.
+	// This is load-bearing here in a way it is not for every source: a
+	// Remark42 backup is normally gzipped binary — `backup` writes
+	// `userbackup-<site>-<ts>.gz` nightly and the API's `mode=file` hands
+	// back the same thing — while `mode=stream` returns plain JSONL. Sniffing
+	// the bytes lets one script accept both transports with no per-transport
+	// code, and reading a `.gz` as utf8 would corrupt it before the sniff
+	// ever ran.
+	const backup = await decodeImportInput(readFileSync(backupPath));
+	// No fallback. This keys the HMAC that derives each imported ghost's
+	// `provider_id` from its Remark42 user id, so a literal committed to a
+	// public repo is a published key: anyone could recompute the provider_id for
+	// a known commenter, and every instance that ever imported without setting
+	// the variable shares the same derivation. It also has to be the *same*
+	// secret the Worker uses, or the same person imported twice — or imported
+	// and then commenting live — resolves to two different ghosts.
+	const secret = process.env.IP_HASH_SECRET;
+	if (!secret) {
+		console.error(
+			"[import-remark42] IP_HASH_SECRET is not set.\n" +
+				"  It must match the secret your Worker uses, or imported commenters\n" +
+				"  will not resolve to the same identities. Read it from .dev.vars for a\n" +
+				"  local import, or your password manager for --remote:\n" +
+				"    IP_HASH_SECRET=... npm run import-remark42 -- <backup.gz>",
+		);
+		process.exit(2);
+	}
+
+	const plan = await runRemark42Import(d1, backup, secret, {
+		dry_run: dryRun,
+		include_deleted: includeDeleted,
+		include_spam: includeSpam,
+		slug_override: slugOverride,
+	});
+
+	console.log(
+		`[import-remark42] ${dryRun ? "DRY RUN" : "DONE"}`,
+		JSON.stringify(plan, null, 2),
+	);
+})().catch((err) => {
+	// Print the message, never the error object and never a slice of the file.
+	// A Remark42 export carries display names and Remark42's own hashed IPs, and
+	// an unlucky `err` — a JSON.parse failure, say — quotes the input it choked
+	// on. Every throw on this path is already written to name a line NUMBER
+	// rather than a line, so the message alone is both content-free and enough
+	// to find the bad record by hand.
+	if (err instanceof ImportTooLargeError) {
+		// Worth its own branch here because gzip is this source's normal
+		// transport: a backup that inflates past the cap is the expected way a
+		// legitimate large instance fails, and "too large" is a different
+		// instruction to the operator than "malformed".
+		console.error(
+			`[import-remark42] export is too large to import: ${err.message}`,
+		);
+		process.exit(1);
+	}
+	console.error(
+		`[import-remark42] failed: ${err instanceof Error ? err.message : String(err)}`,
+	);
+	process.exit(1);
+});

--- a/src/admin-ui/pages/operator.ts
+++ b/src/admin-ui/pages/operator.ts
@@ -283,9 +283,24 @@ ${seedCard}
   busy: false,
   result: null,
   error: null,
+  source: 'disqus',
   dryRun: true,
   includeDeleted: false,
   includeSpam: false,
+  // One card, two sources. The endpoints stay separate on the server —
+  // their format sniffs and error codes differ — but from here the only
+  // things that vary are the URL, the content type and the file filter,
+  // so a second copy of this component would be a second place for the
+  // size cap and the dry-run wiring to drift.
+  get endpoint() { return '/admin/api/ops/import-' + this.source },
+  get contentType() {
+    return this.source === 'disqus' ? 'application/xml' : 'application/x-ndjson'
+  },
+  get accept() {
+    return this.source === 'disqus'
+      ? '.xml,.gz,application/xml,text/xml,application/gzip'
+      : '.json,.jsonl,.gz,application/json,application/gzip'
+  },
   async run(file) {
     if (!file) return;
     if (file.size > ${MAX_IMPORT_BYTES}) {
@@ -298,10 +313,10 @@ ${seedCard}
       // .text() would replace every byte it can't decode before the server
       // ever saw it. The Worker sniffs the gzip magic off the raw bytes.
       const body = await file.arrayBuffer();
-      const r = await fetch('/admin/api/ops/import-disqus', {
+      const r = await fetch(this.endpoint, {
         method: 'POST',
         headers: {
-          'content-type': 'application/xml',
+          'content-type': this.contentType,
           'x-dry-run': this.dryRun ? '1' : '0',
           'x-include-deleted': this.includeDeleted ? '1' : '0',
           'x-include-spam': this.includeSpam ? '1' : '0',
@@ -318,12 +333,28 @@ ${seedCard}
     }
   }
 }">
-  <h3>Import Disqus export</h3>
-  <p class="muted">Uploads a Disqus comment-export XML file — gzipped
-    (<code>.xml.gz</code>) or not — and ingests it into D1. Idempotent:
-    re-running the same file is a no-op (deduplicated by Disqus comment
-    ID). Imported HTML is stripped and re-rendered through the standard
-    markdown allowlist.</p>
+  <h3>Import comments</h3>
+  <p>
+    <label style="display:inline-flex;gap:0.3rem;align-items:center">
+      Source
+      <select x-model="source" :disabled="busy">
+        <option value="disqus">Disqus</option>
+        <option value="remark42">Remark42</option>
+      </select>
+    </label>
+  </p>
+  <p class="muted" x-show="source === 'disqus'">Uploads a Disqus
+    comment-export XML file — gzipped (<code>.xml.gz</code>) or not — and
+    ingests it into D1. Idempotent: re-running the same file is a no-op
+    (deduplicated by Disqus comment ID). Imported HTML is stripped and
+    re-rendered through the standard markdown allowlist.</p>
+  <p class="muted" x-show="source === 'remark42'">Uploads a Remark42
+    backup — the <code>.gz</code> that <code>backup</code> writes nightly,
+    or the plain JSONL the export API streams. Idempotent, deduplicated by
+    Remark42 comment ID. Bodies come from the markdown the author typed
+    where Remark42 kept it, and from its rendered HTML where it did not.
+    Pages are reconstructed from comment URLs, because a Remark42 export
+    carries no page records.</p>
   <p>
     <label style="display:inline-flex;gap:0.3rem;align-items:center;margin-right:0.8rem">
       <input type="checkbox" x-model="dryRun"> Dry run (parse + plan only)
@@ -335,7 +366,7 @@ ${seedCard}
       <input type="checkbox" x-model="includeSpam"> Include spam
     </label>
   </p>
-  <input type="file" accept=".xml,.gz,application/xml,text/xml,application/gzip"
+  <input type="file" :accept="accept"
          :disabled="busy"
          @change="run($event.target.files[0])">
   <p class="muted" x-show="busy">Importing… don't navigate away.</p>
@@ -344,7 +375,9 @@ ${seedCard}
   <p style="color:var(--bad)" x-show="error" x-text="error"></p>
   <p class="muted">Max upload: ${MAX_IMPORT_MB} MB, and a gzipped file must
     also stay under ${MAX_IMPORT_MB} MB once expanded. For larger exports use
-    the CLI: <code>npm run import-disqus -- ./export.xml --dry-run</code>.</p>
+    the CLI: <code x-text="source === 'disqus'
+      ? 'npm run import-disqus -- ./export.xml --dry-run'
+      : 'npm run import-remark42 -- ./userbackup.gz --dry-run'"></code>.</p>
 </div>
 `;
 };

--- a/src/lib/import/remark42.ts
+++ b/src/lib/import/remark42.ts
@@ -1,0 +1,352 @@
+/**
+ * Remark42 native-export adapter (#107).
+ *
+ * Reads a Remark42 backup — the format `Native.Export` writes and `backup`
+ * saves nightly — and normalises it for the importer core:
+ *
+ *   line 1               → export metadata (version, per-user and per-post state)
+ *   every line after     → one comment
+ *   locator.url          → SourceThread   (pages are RECONSTRUCTED; see below)
+ *   comment              → SourceComment
+ *   comment.user         → SourceAuthor   (users.provider='anon')
+ *   comment.pid          → parent_source_id
+ *
+ * ## The format is framed JSONL, and line 1 is not a comment
+ *
+ * `Native.Export` writes `exportMeta` first and the comments after it, so the
+ * first line is `{"version":1,"users":[…],"posts":[…]}`. Remark42's own struct
+ * doc describes the opposite order; the code wins. A parser that treats every
+ * line as a comment imports the metadata as a bodyless comment and reports one
+ * more than the file contains.
+ *
+ * The header is tolerated as absent, because the two things that produce these
+ * files disagree about whether it is there in practice: a captured export
+ * carried `{"version":1,"users":[],"posts":[]}` with both arrays EMPTY, so an
+ * adapter that reads `users[]`/`posts[]` for fidelity state has to treat an
+ * empty array and a missing header as the same "the source does not say".
+ *
+ * ## Pages do not exist in the export
+ *
+ * There is no page or thread record: `locator.url` is the only page key, and
+ * `title` hangs off the comment rather than the locator. So threads are
+ * synthesised by grouping on the url, the title is taken from the first comment
+ * that has one, and `created_at` is the earliest comment on the page — Remark42
+ * has no page-creation timestamp to carry.
+ *
+ * ## The body trap
+ *
+ * `orig` is the markdown the author typed, `text` is Remark42's rendered HTML.
+ * Prefer `orig` — `text` runs through smartypants, so straight quotes come back
+ * as guillemets and every source newline as `<br/>`, importing typography the
+ * author never wrote.
+ *
+ * But `orig` is `omitempty` and all three of Remark42's own migrators
+ * (disqus.go, wordpress.go, commento.go) set only `Text`. So every comment that
+ * reached Remark42 through a migration has no `orig` key at all, and
+ * "take orig, ignore text" imports those with an empty body, silently. Hence
+ * the fallback through `htmlToMarkdown` — which is why that converter lives in
+ * its own module rather than inside the Disqus adapter.
+ *
+ * ## Identity is the source's id, and that choice is permanent
+ *
+ * A Remark42 export has NO email field, at any level — not on the user, not on
+ * the comment. So `name|email` would reduce to name alone, forking a renamed
+ * commenter into two ghosts and merging two people who picked the same display
+ * name. `user.id` is the only stable key, so `source_id` is set from day one.
+ * Per the core's contract this can never change for a source that has shipped:
+ * the seed feeds an HMAC, so a different seed re-ghosts everyone.
+ *
+ * Note the id is only stable *within one Remark42 instance* — the hash is keyed
+ * with that instance's SECRET — and for anonymous users it is derived from the
+ * display name, so an anonymous rename does fork after all. It is still the
+ * better key: it separates two people who share a name, which name-keying
+ * cannot do at any price.
+ *
+ * ## Deliberately discarded
+ *
+ * `score`, `vote`, `votes`, `controversy`, `pin`, `user.admin`, `user.site_id`,
+ * and `user.picture` — the last provably carries nothing, its avatar hash being
+ * exactly sha1(user.id).
+ *
+ * `user.ip` and `voted_ips` are dropped as a rule, not as an oversight. Remark42
+ * stores the IP already hashed, but a hash is still an identity-linking token
+ * and Garrul's rule is that raw or derived IPs are neither stored nor logged.
+ * The same rule shapes the parse errors below: a malformed line is exactly the
+ * case where the content is unclassified and may carry an `ip` field, so an
+ * error names the line NUMBER and the parser's message, never the line.
+ */
+import {
+	type ImportAdapter,
+	type ImportOptions,
+	type ImportPlan,
+	MAX_IMPORT_BYTES,
+	type SourceComment,
+	type SourceExport,
+	type SourceThread,
+	runImport,
+} from "./core";
+import { htmlToMarkdown } from "./html-to-markdown";
+
+/** Export format versions this parser has been read against. */
+const SUPPORTED_VERSIONS = new Set([0, 1]);
+
+export type Remark42Meta = {
+	version: number;
+	/** Per-user state. Empty in a fresh instance's export. */
+	users: { id: string; blocked?: { status?: boolean } | undefined; verified?: boolean | undefined }[];
+	/** Per-page state. Empty in a fresh instance's export. */
+	posts: { url: string; read_only?: boolean | undefined }[];
+};
+
+export type Remark42Comment = {
+	id: string;
+	/** Parent comment id. An empty string — never null, never absent — at root. */
+	pid: string;
+	/** Rendered HTML. Only read when `orig` is missing. */
+	text: string;
+	/** The markdown as typed. Absent for anything Remark42 itself imported. */
+	orig?: string | undefined;
+	user: {
+		id: string;
+		name: string;
+		admin?: boolean | undefined;
+	};
+	locator: { site?: string | undefined; url: string };
+	/** RFC 3339 with nanoseconds and a numeric offset — Go's time.Time default. */
+	time: string;
+	title?: string | undefined;
+	delete?: boolean | undefined;
+	edit?: { time?: string | undefined } | undefined;
+};
+
+export type Remark42Export = {
+	meta: Remark42Meta;
+	comments: Remark42Comment[];
+};
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+/**
+ * A JSON line, or a throw naming only where it was.
+ *
+ * `JSON.parse`'s own message quotes a slice of the input on some engines, so it
+ * is replaced rather than appended — see the IP note in the module header.
+ */
+const parseLine = (line: string, lineNo: number): Record<string, unknown> => {
+	let value: unknown;
+	try {
+		value = JSON.parse(line);
+	} catch {
+		throw new Error(`remark42 export: line ${lineNo} is not valid JSON`);
+	}
+	if (!isObject(value)) {
+		throw new Error(`remark42 export: line ${lineNo} is not a JSON object`);
+	}
+	return value;
+};
+
+const EMPTY_META: Remark42Meta = { version: 1, users: [], posts: [] };
+
+const readMeta = (row: Record<string, unknown>, lineNo: number): Remark42Meta => {
+	const version = typeof row.version === "number" ? row.version : 1;
+	if (!SUPPORTED_VERSIONS.has(version)) {
+		throw new Error(
+			`remark42 export: line ${lineNo} declares version ${version}, which this importer has not been read against`,
+		);
+	}
+	const users = Array.isArray(row.users) ? row.users : [];
+	const posts = Array.isArray(row.posts) ? row.posts : [];
+	return {
+		version,
+		users: users.filter(isObject).map((u) => ({
+			id: str(u.id),
+			blocked: isObject(u.blocked)
+				? { status: u.blocked.status === true }
+				: undefined,
+			verified: u.verified === true,
+		})),
+		posts: posts.filter(isObject).map((p) => ({
+			url: str(p.url),
+			read_only: p.read_only === true,
+		})),
+	};
+};
+
+const readComment = (
+	row: Record<string, unknown>,
+	lineNo: number,
+): Remark42Comment => {
+	const id = str(row.id);
+	if (!id) throw new Error(`remark42 export: line ${lineNo} has no comment id`);
+	const locator = isObject(row.locator) ? row.locator : {};
+	const url = str(locator.url);
+	if (!url) {
+		throw new Error(`remark42 export: line ${lineNo} has no locator.url`);
+	}
+	const user = isObject(row.user) ? row.user : {};
+	const edit = isObject(row.edit) ? row.edit : undefined;
+	return {
+		id,
+		pid: str(row.pid),
+		text: str(row.text),
+		// Distinguish "absent" from "present but empty": a deleted comment has
+		// its orig blanked, and that must fall through to the same tombstone
+		// path as a migrated comment rather than import as an empty body.
+		orig: typeof row.orig === "string" && row.orig !== "" ? row.orig : undefined,
+		user: {
+			id: str(user.id),
+			// Remark42 hard-delete rewrites the name to the literal "deleted";
+			// nothing here special-cases it, and the core's identity handling
+			// then collapses every hard-deleted comment onto one ghost. That is
+			// the intended outcome: they are, at the source, one anonymised
+			// non-person.
+			name: str(user.name) || "anonymous",
+			admin: user.admin === true,
+		},
+		locator: {
+			site: typeof locator.site === "string" ? locator.site : undefined,
+			url,
+		},
+		time: str(row.time),
+		title: typeof row.title === "string" && row.title ? row.title : undefined,
+		delete: row.delete === true,
+		edit: edit && typeof edit.time === "string" ? { time: edit.time } : undefined,
+	};
+};
+
+/**
+ * Parse a Remark42 native export.
+ *
+ * Blank lines are skipped rather than rejected: the file ends with a newline,
+ * and an operator who concatenated two backups should not be stopped by the
+ * join.
+ */
+export const parseRemark42Export = (input: string): Remark42Export => {
+	if (input.length > MAX_IMPORT_BYTES) {
+		throw new Error(
+			`remark42 export too large: ${input.length} > ${MAX_IMPORT_BYTES}`,
+		);
+	}
+
+	let meta = EMPTY_META;
+	let sawMeta = false;
+	const comments: Remark42Comment[] = [];
+	const lines = input.split("\n");
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!.trim();
+		if (!line) continue;
+		const lineNo = i + 1;
+		const row = parseLine(line, lineNo);
+		// The header is identified by shape, not by position. A file assembled
+		// by hand, or one whose header was stripped, still parses — and a
+		// comment can never be mistaken for it, because a comment always has an
+		// id and never has a `version`.
+		if (!sawMeta && row.version !== undefined && row.id === undefined) {
+			meta = readMeta(row, lineNo);
+			sawMeta = true;
+			continue;
+		}
+		comments.push(readComment(row, lineNo));
+	}
+
+	// One export is one site. Remark42 runs many sites in one instance and
+	// exports one at a time, so more than one site id means two files were
+	// concatenated — importing them together would merge two comment sections
+	// onto whichever pages happen to share a URL.
+	const sites = new Set(comments.map((c) => c.locator.site ?? ""));
+	if (sites.size > 1) {
+		throw new Error(
+			`remark42 export: ${sites.size} distinct site ids in one file — import one site at a time`,
+		);
+	}
+
+	return { meta, comments };
+};
+
+const parseTime = (s: string): number => {
+	const t = Date.parse(s);
+	return Number.isFinite(t) ? t : Date.now();
+};
+
+export const REMARK42_ADAPTER: ImportAdapter = {
+	source: "remark42",
+	slugFallbackPrefix: "remark42-",
+	parse(input: string): SourceExport {
+		const { meta, comments: rows } = parseRemark42Export(input);
+
+		const readOnly = new Map(meta.posts.map((p) => [p.url, p.read_only === true]));
+		const blocked = new Map(
+			meta.users.map((u) => [u.id, u.blocked?.status === true]),
+		);
+
+		// Pages, reconstructed. First comment on a url wins the title; earliest
+		// comment on it becomes its created_at.
+		const threads = new Map<string, SourceThread>();
+		for (const r of rows) {
+			const at = parseTime(r.time);
+			const existing = threads.get(r.locator.url);
+			if (!existing) {
+				threads.set(r.locator.url, {
+					source_id: r.locator.url,
+					link: r.locator.url,
+					title: r.title ?? null,
+					created_at: at,
+					// undefined, not false, when the header did not list this
+					// page: absent means "the source does not say", and the core
+					// must not read that as "open".
+					// Spread rather than assign: `closed: undefined` is not the
+					// same as an absent key under exactOptionalPropertyTypes, and
+					// the core reads absence as "the source does not say".
+					...(readOnly.has(r.locator.url)
+						? { closed: readOnly.get(r.locator.url) === true }
+						: {}),
+				});
+				continue;
+			}
+			if (at < existing.created_at) existing.created_at = at;
+			if (!existing.title && r.title) existing.title = r.title;
+		}
+
+		const comments: SourceComment[] = rows.map((r) => ({
+			source_id: r.id,
+			thread_source_id: r.locator.url,
+			// Root is an empty string here, never null and never absent.
+			parent_source_id: r.pid || null,
+			created_at: parseTime(r.time),
+			// Remark42 has no moderation queue and no spam verdict, so 'pending'
+			// and 'spam' have no source and are never emitted. A deleted row has
+			// had its body blanked at the source, so it imports as a tombstone
+			// or, by default, is skipped — the same treatment Disqus's deleted
+			// rows get.
+			status: r.delete ? "deleted" : "approved",
+			edited_at: r.edit?.time ? parseTime(r.edit.time) : null,
+			body_md: r.orig ?? htmlToMarkdown(r.text),
+			author: {
+				name: r.user.name,
+				// Not "not found" — the field does not exist in this format.
+				email: null,
+				// No is_anonymous field either. Remark42 encodes the provider in
+				// the id: an anonymous commenter is `anonymous_<hash>`, an OAuth
+				// one `github_<id>`.
+				is_anonymous: r.user.id.startsWith("anonymous_"),
+				source_id: r.user.id,
+				...(blocked.has(r.user.id)
+					? { is_banned: blocked.get(r.user.id) === true }
+					: {}),
+			},
+		}));
+
+		return { threads: [...threads.values()], comments };
+	},
+};
+
+export const runRemark42Import = (
+	db: D1Database,
+	input: string,
+	secret: string,
+	opts: ImportOptions = {},
+): Promise<ImportPlan> => runImport(db, REMARK42_ADAPTER, input, secret, opts);

--- a/src/lib/import/remark42.ts
+++ b/src/lib/import/remark42.ts
@@ -62,6 +62,10 @@
  * better key: it separates two people who share a name, which name-keying
  * cannot do at any price.
  *
+ * Because that key is the whole design, a comment with no `user.id` is a parse
+ * error, not a degraded row: the core keys on name+email when `source_id` is
+ * empty, which is precisely the merge this adapter exists to avoid.
+ *
  * ## Deliberately discarded
  *
  * `score`, `vote`, `votes`, `controversy`, `pin`, `user.admin`, `user.site_id`,
@@ -187,6 +191,15 @@ const readComment = (
 		throw new Error(`remark42 export: line ${lineNo} has no locator.url`);
 	}
 	const user = isObject(row.user) ? row.user : {};
+	const userId = str(user.id);
+	// `user.id` is this adapter's identity seed, and the core falls back to
+	// name-keying when `source_id` is empty. That fallback is exactly the
+	// merge this adapter refuses (see the header): two people who picked the
+	// same display name would land on one ghost. An export without it is
+	// malformed, so fail the parse rather than degrade the key silently.
+	if (!userId) {
+		throw new Error(`remark42 export: line ${lineNo} has no user.id`);
+	}
 	const edit = isObject(row.edit) ? row.edit : undefined;
 	return {
 		id,
@@ -197,7 +210,7 @@ const readComment = (
 		// path as a migrated comment rather than import as an empty body.
 		orig: typeof row.orig === "string" && row.orig !== "" ? row.orig : undefined,
 		user: {
-			id: str(user.id),
+			id: userId,
 			// Remark42 hard-delete rewrites the name to the literal "deleted";
 			// nothing here special-cases it, and the core's identity handling
 			// then collapses every hard-deleted comment onto one ghost. That is

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -173,6 +173,7 @@ import {
 	decodeImportInput,
 } from "../lib/import/core";
 import { runDisqusImport } from "../lib/import/disqus";
+import { runRemark42Import } from "../lib/import/remark42";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
 import {
 	MIN_RETENTION_DAYS,
@@ -2543,6 +2544,86 @@ admin.post("/api/ops/import-disqus", async (c) => {
 		});
 		return c.json({ ok: true, dry_run: dryRun, plan });
 	} catch (err) {
+		return c.json({ error: `import_failed:${(err as Error).message}` }, 400);
+	}
+});
+
+// --------------------------- Remark42 import -------------------------------
+//
+// Admin-only, and the same shape as the Disqus route above: raw body,
+// gzipped or not, capped on both the compressed and the decompressed side,
+// idempotent on re-upload.
+//
+// It is a separate endpoint rather than a `source` parameter on the Disqus
+// one. The two differ in exactly the places an operator notices — the
+// format sniff, and the error code a wrong file produces — and
+// `not_disqus_xml` is already a published contract that must keep meaning
+// what it says. A shared route would have to return one of the two codes
+// for both sources, or invent a third that means neither.
+
+admin.post("/api/ops/import-remark42", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+
+	const contentLength = Number(c.req.header("content-length") ?? "0");
+	if (contentLength > MAX_IMPORT_BYTES) {
+		return c.json({ error: "too_large" }, 413);
+	}
+	const buf = await c.req.arrayBuffer();
+	if (buf.byteLength === 0) return c.json({ error: "empty_body" }, 400);
+	if (buf.byteLength > MAX_IMPORT_BYTES) {
+		return c.json({ error: "too_large" }, 413);
+	}
+	// A Remark42 backup is gzipped by default — `backup` writes
+	// userbackup-<site>-<ts>.gz and the API's mode=file returns gzip — while
+	// mode=stream returns the same bytes as plain JSONL. The magic-byte
+	// sniff covers all three with no per-transport branch.
+	let jsonl: string;
+	try {
+		jsonl = await decodeImportInput(buf);
+	} catch (err) {
+		if (err instanceof ImportTooLargeError) {
+			return c.json({ error: "too_large" }, 413);
+		}
+		return c.json({ error: "not_remark42_export" }, 400);
+	}
+	// Sanity check on the first line only. A Remark42 export opens with the
+	// `{"version":…}` metadata object, or — if that header was stripped —
+	// with a comment object carrying an id and a locator. Anything else is
+	// the wrong file, and saying so here beats a parser error.
+	const firstLine = jsonl.slice(0, 4096).split("\n", 1)[0]?.trim() ?? "";
+	const looksRight =
+		firstLine.startsWith("{") &&
+		(firstLine.includes('"version"') || firstLine.includes('"locator"'));
+	if (!looksRight) {
+		return c.json({ error: "not_remark42_export" }, 400);
+	}
+
+	const dryRun = c.req.header("x-dry-run") === "1";
+	const includeDeleted = c.req.header("x-include-deleted") === "1";
+	const includeSpam = c.req.header("x-include-spam") === "1";
+
+	const secret = c.env.IP_HASH_SECRET;
+	if (!secret) return c.json({ error: "ip_hash_secret_missing" }, 500);
+
+	try {
+		const plan = await runRemark42Import(c.env.DB, jsonl, secret, {
+			dry_run: dryRun,
+			include_deleted: includeDeleted,
+			include_spam: includeSpam,
+		});
+		await adminInsertAudit(c.env.DB, {
+			admin_id: user.id,
+			action: "import.remark42",
+			target_kind: "system",
+			target_id: null,
+			meta: { dry_run: dryRun, ...plan },
+		});
+		return c.json({ ok: true, dry_run: dryRun, plan });
+	} catch (err) {
+		// The adapter's messages carry a line number and never a line, which
+		// is what makes it safe to hand one back in a response body — a
+		// Remark42 export carries display names and hashed IPs.
 		return c.json({ error: `import_failed:${(err as Error).message}` }, 400);
 	}
 });

--- a/tests/admin-import-endpoint.test.ts
+++ b/tests/admin-import-endpoint.test.ts
@@ -1,5 +1,5 @@
 /**
- * POST /admin/api/ops/import-disqus — the upload behind the Operator card.
+ * POST /admin/api/ops/import-<source> — the uploads behind the Operator card.
  *
  * Exercised through the real Hono route against real SQLite, because what
  * matters here is the order the route does things in, and unit tests on the
@@ -15,6 +15,12 @@
  *     is an unbounded allocation inside the Worker.
  *   - Rows actually land, so the whole chain — decode, parse, adapter,
  *     core, D1 — is wired together rather than merely type-compatible.
+ *
+ * Both source endpoints are exercised here rather than in a file each,
+ * because the three properties above are properties of the *route shape*,
+ * not of either adapter: they were established once for Disqus and a second
+ * endpoint that quietly got the order wrong would look identical from the
+ * outside. One harness, two sources, so the same six questions get asked.
  */
 import { Hono } from "hono";
 import { readFileSync, readdirSync } from "node:fs";
@@ -143,22 +149,27 @@ beforeEach(() => {
 
 afterEach(() => uninstallMockCaches());
 
-const upload = (body: BodyInit, headers: Record<string, string> = {}) =>
-	new Hono<{ Bindings: Bindings }>().route("/admin", admin).request(
-		"/admin/api/ops/import-disqus",
-		{
-			method: "POST",
-			headers: {
-				"content-type": "application/xml",
-				cookie: `__Host-garrul_sess=${ADMIN_SID}`,
-				origin: "http://localhost",
-				...headers,
+const uploadTo =
+	(source: string, contentType: string) =>
+	(body: BodyInit, headers: Record<string, string> = {}) =>
+		new Hono<{ Bindings: Bindings }>().route("/admin", admin).request(
+			`/admin/api/ops/import-${source}`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": contentType,
+					cookie: `__Host-garrul_sess=${ADMIN_SID}`,
+					origin: "http://localhost",
+					...headers,
+				},
+				body,
 			},
-			body,
-		},
-		env as unknown as Record<string, unknown>,
-		execCtx,
-	);
+			env as unknown as Record<string, unknown>,
+			execCtx,
+		);
+
+const upload = uploadTo("disqus", "application/xml");
+const uploadJsonl = uploadTo("remark42", "application/x-ndjson");
 
 const commentCount = (): number =>
 	(
@@ -232,5 +243,113 @@ describe("POST /admin/api/ops/import-disqus", () => {
 		expect(body.dry_run).toBe(true);
 		expect(body.plan.new_comments).toBe(1);
 		expect(commentCount()).toBe(0);
+	});
+});
+
+// A four-line export: the metadata header, one comment, and the trailing
+// newline a JSONL writer leaves behind. Identity-free, like every fixture
+// here — invented names on example.com.
+const JSONL = [
+	JSON.stringify({
+		version: 1,
+		users: [],
+		posts: [{ url: "https://example.com/hello", read_only: false }],
+	}),
+	JSON.stringify({
+		id: "c1",
+		pid: "",
+		text: "<p>first</p>",
+		orig: "first",
+		user: { id: "github_9f1", name: "Ada" },
+		locator: { site: "lab", url: "https://example.com/hello" },
+		time: "2026-01-01T00:00:00Z",
+	}),
+	"",
+].join("\n");
+
+describe("POST /admin/api/ops/import-remark42", () => {
+	it("imports a plain JSONL upload", async () => {
+		const res = await uploadJsonl(JSONL);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			plan: { new_comments: number; new_pages: number };
+		};
+		expect(body.plan.new_comments).toBe(1);
+		expect(body.plan.new_pages).toBe(1);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("imports a gzipped backup identically", async () => {
+		// The shape an operator actually has on disk: `backup` writes
+		// userbackup-<site>-<ts>.gz and never a plain file. If the decode sat
+		// after the format sniff, the nightly backup — the one artifact this
+		// endpoint exists to accept — would be the one it rejected.
+		const res = await uploadJsonl(await gzip(JSONL));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { plan: { new_comments: number } };
+		expect(body.plan.new_comments).toBe(1);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("answers 413 for a decompression bomb rather than inflating it", async () => {
+		const bomb = await gzip("A".repeat(MAX_IMPORT_BYTES + 1024));
+		expect(bomb.byteLength).toBeLessThan(1024 * 1024);
+		const res = await uploadJsonl(bomb);
+		expect(res.status).toBe(413);
+		expect(await res.json()).toEqual({ error: "too_large" });
+		expect(commentCount()).toBe(0);
+	});
+
+	it("rejects a file that is neither gzip nor a Remark42 export", async () => {
+		const res = await uploadJsonl("just some notes");
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "not_remark42_export" });
+	});
+
+	it("rejects a Disqus export sent to the Remark42 endpoint", async () => {
+		// Two upload buttons on one card is two chances to pick the wrong
+		// one. The sniff has to name the mismatch rather than hand the XML
+		// to a JSONL parser and surface whatever it says about line 1.
+		const res = await uploadJsonl(XML);
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "not_remark42_export" });
+	});
+
+	it("accepts an export whose metadata header was stripped", async () => {
+		// The stream API can be pointed at a site and yield comments with no
+		// header at all, so the sniff recognises a bare comment object too.
+		const res = await uploadJsonl(JSONL.split("\n")[1] ?? "");
+		expect(res.status).toBe(200);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("is idempotent across a plain and a gzipped upload of the same file", async () => {
+		expect((await uploadJsonl(JSONL)).status).toBe(200);
+		const res = await uploadJsonl(await gzip(JSONL));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { plan: { new_comments: number } };
+		expect(body.plan.new_comments).toBe(0);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("writes nothing on a dry run", async () => {
+		const res = await uploadJsonl(JSONL, { "x-dry-run": "1" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			dry_run: boolean;
+			plan: { new_comments: number };
+		};
+		expect(body.dry_run).toBe(true);
+		expect(body.plan.new_comments).toBe(1);
+		expect(commentCount()).toBe(0);
+	});
+
+	it("reports a malformed line by number, never by content", async () => {
+		const bad = [JSONL.split("\n")[0], "{ not json"].join("\n");
+		const res = await uploadJsonl(bad);
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("line 2");
+		expect(body.error).not.toContain("not json");
 	});
 });

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -1219,3 +1219,42 @@ describe("global keyboard shortcuts", () => {
 		expect(html).toContain("n.offsetParent !== null");
 	});
 });
+
+describe("renderOperator — the import card", () => {
+	const html = renderOperator({
+		rerender: {
+			current_version: 1,
+			up_to_date: 10,
+			stale: 0,
+			oldest_version: null,
+		},
+		retention: retentionOff,
+		audit_retention: auditRetentionOff,
+		seed_demo_allowed: false,
+	});
+
+	// The card is one Alpine component whose endpoint, content type and file
+	// filter are computed getters over `source`. Those live inside a template
+	// literal, so nothing else in the build would notice a typo in one, and
+	// the symptom would be an import that 404s or that posts XML to the JSONL
+	// route. Assert the pieces the getters are assembled from.
+	it("offers both sources", () => {
+		expect(html).toContain('x-model="source"');
+		expect(html).toContain('value="disqus"');
+		expect(html).toContain('value="remark42"');
+	});
+
+	it("builds the endpoint from the selected source", () => {
+		expect(html).toContain("'/admin/api/ops/import-' + this.source");
+		// Both halves of that concatenation have to stay true: the prefix
+		// above, and a source value that names a route the server has. A
+		// third <option> added without its route would pass the first
+		// assertion and 404 in the browser.
+		expect(html).not.toContain("/admin/api/ops/import-disqus'");
+	});
+
+	it("names the backup file a Remark42 operator already has", () => {
+		expect(html).toContain("import-remark42");
+		expect(html).toContain("userbackup");
+	});
+});

--- a/tests/remark42-import.test.ts
+++ b/tests/remark42-import.test.ts
@@ -1,0 +1,528 @@
+/**
+ * Remark42 importer tests cover:
+ *
+ *   1. Framed JSONL parsing — the metadata header is consumed, not
+ *      imported; blank lines are skipped; an unknown version fails.
+ *   2. The body trap — `orig` wins when present, `text` through
+ *      htmlToMarkdown when it is absent. A comment Remark42 itself
+ *      imported has no `orig` at all, and taking `orig` blindly would
+ *      give it an empty body.
+ *   3. Identity — `user.id` keys the ghost, so two commenters sharing a
+ *      display name become two users and one commenter across two
+ *      names stays one.
+ *   4. Page reconstruction — there are no page records, so threads come
+ *      from distinct `locator.url` with the earliest comment's time.
+ *   5. Error hygiene — a malformed line names its number and never its
+ *      content, because an unparsed line may carry an `ip` field.
+ *
+ * Fixtures are hand-written and identity-free. The shapes come from a
+ * real capture (an export whose header carried EMPTY users/posts arrays,
+ * whose comments all had `pid: ""`, and whose `text` had been through
+ * smartypants); the bytes do not.
+ *
+ * No Miniflare. Hand-rolled D1 stub with capture, same as the Disqus
+ * suite.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	REMARK42_ADAPTER,
+	parseRemark42Export,
+	runRemark42Import,
+} from "../src/lib/import/remark42";
+import { asD1 } from "./helpers/d1";
+
+type Captured = { sql: string; binds: unknown[] };
+
+// Every SELECT misses, so every insert proceeds.
+const makeFreshDb = () => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => ({
+		_binds: [] as unknown[],
+		bind(...args: unknown[]) {
+			this._binds = args;
+			return this;
+		},
+		async first() {
+			captured.push({ sql, binds: this._binds });
+			return null;
+		},
+		async all() {
+			captured.push({ sql, binds: this._binds });
+			return { results: [] };
+		},
+		async run() {
+			captured.push({ sql, binds: this._binds });
+			return { meta: { changes: 1 } };
+		},
+	});
+	return {
+		db: asD1({ prepare: (sql: string) => chain(sql) }),
+		captured,
+	};
+};
+
+// A stub where every existence check hits, so a re-run inserts nothing.
+const makeAlreadyImportedDb = () => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => ({
+		_binds: [] as unknown[],
+		bind(...args: unknown[]) {
+			this._binds = args;
+			return this;
+		},
+		async first() {
+			captured.push({ sql, binds: this._binds });
+			if (sql.includes("FROM comments WHERE import_source")) {
+				return { id: "01HX0000000000000000000001" };
+			}
+			if (sql.includes("FROM posts WHERE slug")) return { slug: "hello" };
+			if (sql.includes("FROM users WHERE provider")) {
+				return { id: "01HU0000000000000000000001" };
+			}
+			return null;
+		},
+		async all() {
+			captured.push({ sql, binds: this._binds });
+			return { results: [] };
+		},
+		async run() {
+			captured.push({ sql, binds: this._binds });
+			return { meta: { changes: 1 } };
+		},
+	});
+	return {
+		db: asD1({ prepare: (sql: string) => chain(sql) }),
+		captured,
+	};
+};
+
+const META = `{"version":1,"users":[],"posts":[]}`;
+
+const comment = (over: Record<string, unknown> = {}) =>
+	JSON.stringify({
+		id: "c1",
+		pid: "",
+		text: "<p>hello</p>\n",
+		orig: "hello",
+		user: {
+			id: "anonymous_1111111111111111111111111111111111111111",
+			name: "Ada",
+			picture: "https://example.com/avatar.image",
+			ip: "0000000000000000000000000000000000000000",
+			admin: false,
+			site_id: "lab",
+		},
+		locator: { site: "lab", url: "https://example.com/hello" },
+		score: 0,
+		vote: 0,
+		time: "2026-08-22T22:12:53.539535119-05:00",
+		title: "Hello World",
+		...over,
+	});
+
+const jsonl = (...lines: string[]) => `${[META, ...lines].join("\n")}\n`;
+
+const inserts = (captured: Captured[], table: string) =>
+	captured.filter((c) => c.sql.startsWith(`INSERT INTO ${table}`));
+
+// --------------------------- parseRemark42Export ---------------------------
+
+describe("parseRemark42Export", () => {
+	it("consumes the header line as metadata, not as a comment", () => {
+		const parsed = parseRemark42Export(jsonl(comment()));
+		expect(parsed.meta.version).toBe(1);
+		expect(parsed.comments).toHaveLength(1);
+		expect(parsed.comments[0]!.id).toBe("c1");
+	});
+
+	// The header is identified by shape, so a file whose header was stripped —
+	// or one assembled by hand — still parses. A comment always has an id and
+	// never a version, so the two can never be confused.
+	it("parses a file with no header line at all", () => {
+		const parsed = parseRemark42Export(`${comment()}\n`);
+		expect(parsed.comments).toHaveLength(1);
+		expect(parsed.meta.users).toEqual([]);
+	});
+
+	it("skips blank lines, including the trailing newline", () => {
+		const parsed = parseRemark42Export(
+			`${META}\n\n${comment()}\n\n${comment({ id: "c2" })}\n`,
+		);
+		expect(parsed.comments.map((c) => c.id)).toEqual(["c1", "c2"]);
+	});
+
+	// Remark42's own Native.Import accepts 0 and 1 and rejects the rest. A
+	// version we have not read the writer for is far more likely to be
+	// mis-parsed than to be compatible.
+	it("accepts version 0 and rejects an unseen version", () => {
+		expect(() =>
+			parseRemark42Export(`{"version":0,"users":[],"posts":[]}\n${comment()}\n`),
+		).not.toThrow();
+		expect(() =>
+			parseRemark42Export(`{"version":9,"users":[],"posts":[]}\n`),
+		).toThrow(/version 9/);
+	});
+
+	// One export is one site. Two site ids means two files were concatenated,
+	// and importing them together merges two comment sections wherever a URL
+	// happens to match.
+	it("refuses a file carrying two distinct site ids", () => {
+		const other = comment({
+			id: "c2",
+			locator: { site: "other", url: "https://example.com/hello" },
+		});
+		expect(() => parseRemark42Export(jsonl(comment(), other))).toThrow(
+			/site ids/,
+		);
+	});
+
+	it("treats an absent site the same as one distinct site", () => {
+		const noSite = comment({
+			id: "c2",
+			locator: { url: "https://example.com/hello" },
+		});
+		const bare = comment({
+			id: "c3",
+			locator: { url: "https://example.com/hello" },
+		});
+		expect(() => parseRemark42Export(jsonl(noSite, bare))).not.toThrow();
+	});
+});
+
+// ------------------------------ error hygiene ------------------------------
+
+describe("parse errors", () => {
+	// A malformed line is exactly the case where the content is unclassified —
+	// it may carry `"ip":"…"`, which Garrul never logs. So the message gets the
+	// line number and nothing from the line.
+	it("names the line number and never the line content", () => {
+		const secret = "203.0.113.77";
+		const bad = `{"id":"c2","ip":"${secret}",`;
+		expect(() => parseRemark42Export(`${META}\n${comment()}\n${bad}\n`)).toThrow(
+			/line 3/,
+		);
+		try {
+			parseRemark42Export(`${META}\n${comment()}\n${bad}\n`);
+		} catch (e) {
+			expect((e as Error).message).not.toContain(secret);
+			expect((e as Error).message).not.toContain("c2");
+		}
+	});
+
+	it("rejects a comment with no locator.url", () => {
+		const noUrl = comment({ locator: { site: "lab" } });
+		expect(() => parseRemark42Export(jsonl(noUrl))).toThrow(/locator\.url/);
+	});
+
+	it("rejects a comment with no id", () => {
+		const noId = comment({ id: "" });
+		expect(() => parseRemark42Export(jsonl(noId))).toThrow(/comment id/);
+	});
+});
+
+// -------------------------------- the body ---------------------------------
+
+describe("body", () => {
+	// `text` has been through smartypants — straight quotes come back as
+	// guillemets and every newline as <br/>. Taking it when `orig` exists
+	// imports typography the author never wrote.
+	it("prefers orig, the markdown as typed", () => {
+		const c = comment({
+			orig: 'It\'s the "obvious" answer.',
+			text: "<p>It’s the «obvious» answer.</p>\n",
+		});
+		const [out] = REMARK42_ADAPTER.parse(jsonl(c)).comments;
+		expect(out!.body_md).toBe('It\'s the "obvious" answer.');
+	});
+
+	// THE TRAP. All three of Remark42's own migrators set Text and never Orig,
+	// and `orig` is omitempty — so every comment that reached Remark42 through
+	// a migration has no `orig` key. "Take orig, ignore text" gives all of them
+	// an empty body, silently.
+	it("falls back to text when orig is absent", () => {
+		const c = comment({
+			orig: undefined,
+			text: "<p>migrated from somewhere <b>else</b></p>",
+		});
+		const [out] = REMARK42_ADAPTER.parse(jsonl(c)).comments;
+		expect(out!.body_md).toContain("migrated from somewhere");
+		expect(out!.body_md).not.toContain("<p>");
+	});
+
+	// A present-but-empty orig is the deleted case: SetDeleted blanks Orig and
+	// Text both. It must not be read as "the author typed nothing" and it must
+	// not read as a reason to import the rendered HTML either.
+	it("treats an empty orig as absent", () => {
+		const c = comment({ orig: "", text: "<p>still here</p>" });
+		const [out] = REMARK42_ADAPTER.parse(jsonl(c)).comments;
+		expect(out!.body_md).toContain("still here");
+	});
+
+	it("keeps markdown in orig as markdown", () => {
+		const c = comment({
+			orig: "- **derivation** — stable per source\n\n> a quote",
+			text: "<ul><li><strong>derivation</strong></li></ul>",
+		});
+		const [out] = REMARK42_ADAPTER.parse(jsonl(c)).comments;
+		expect(out!.body_md).toContain("**derivation**");
+		expect(out!.body_md).toContain("> a quote");
+	});
+});
+
+// ------------------------------- identity ----------------------------------
+
+describe("identity", () => {
+	it("keys the ghost on user.id, not on the display name", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(
+				comment({ id: "c1", user: { id: "anonymous_aaa", name: "Sam" } }),
+				comment({ id: "c2", user: { id: "anonymous_bbb", name: "Sam" } }),
+			),
+		);
+		expect(parsed.comments.map((c) => c.author.source_id)).toEqual([
+			"anonymous_aaa",
+			"anonymous_bbb",
+		]);
+	});
+
+	// Two people who chose the same display name must not merge. Name-keying
+	// cannot tell them apart at any price, which is why source_id is set from
+	// day one rather than added later — adding it later re-ghosts everyone.
+	it("two commenters sharing a name become two ghost users", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runRemark42Import(
+			db,
+			jsonl(
+				comment({ id: "c1", user: { id: "anonymous_aaa", name: "Sam" } }),
+				comment({ id: "c2", user: { id: "anonymous_bbb", name: "Sam" } }),
+			),
+			"secret",
+		);
+		expect(plan.new_users).toBe(2);
+		expect(inserts(captured, "users")).toHaveLength(2);
+	});
+
+	it("one commenter under two names stays one ghost user", async () => {
+		const { db } = makeFreshDb();
+		const plan = await runRemark42Import(
+			db,
+			jsonl(
+				comment({ id: "c1", user: { id: "anonymous_aaa", name: "Sam" } }),
+				comment({ id: "c2", user: { id: "anonymous_aaa", name: "Samantha" } }),
+			),
+			"secret",
+		);
+		expect(plan.new_users).toBe(1);
+	});
+
+	// The export has no is_anonymous field. Remark42 encodes the provider in
+	// the id itself.
+	it("reads anonymity from the id's provider prefix", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(
+				comment({ id: "c1", user: { id: "anonymous_aaa", name: "A" } }),
+				comment({ id: "c2", user: { id: "github_12345", name: "B" } }),
+			),
+		);
+		expect(parsed.comments.map((c) => c.author.is_anonymous)).toEqual([
+			true,
+			false,
+		]);
+	});
+
+	// There is no email field anywhere in a Remark42 export, at any level.
+	it("always reports a null email", () => {
+		const [out] = REMARK42_ADAPTER.parse(jsonl(comment())).comments;
+		expect(out!.author.email).toBeNull();
+	});
+});
+
+// ---------------------------- page reconstruction --------------------------
+
+describe("pages", () => {
+	it("builds one page per distinct locator.url", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(
+				comment({ id: "c1", locator: { site: "lab", url: "https://example.com/a" } }),
+				comment({ id: "c2", locator: { site: "lab", url: "https://example.com/b" } }),
+				comment({ id: "c3", locator: { site: "lab", url: "https://example.com/a" } }),
+			),
+		);
+		expect(parsed.threads.map((t) => t.source_id)).toEqual([
+			"https://example.com/a",
+			"https://example.com/b",
+		]);
+	});
+
+	// Remark42 has no page-creation timestamp, so the earliest comment on a
+	// page is the closest honest answer.
+	it("dates a page from its earliest comment, whatever the file order", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(
+				comment({ id: "c1", time: "2026-08-22T22:30:00.000000000-05:00" }),
+				comment({ id: "c2", time: "2026-08-22T22:10:00.000000000-05:00" }),
+			),
+		);
+		expect(parsed.threads[0]!.created_at).toBe(
+			Date.parse("2026-08-22T22:10:00.000000000-05:00"),
+		);
+	});
+
+	it("takes the title from the first comment on the page that has one", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(
+				comment({ id: "c1", title: undefined }),
+				comment({ id: "c2", title: "Hello World" }),
+			),
+		);
+		expect(parsed.threads[0]!.title).toBe("Hello World");
+	});
+
+	// The captured export's header had `posts: []`, so the fidelity fields have
+	// to degrade to "the source does not say" rather than to false. `closed`
+	// absent is not the same as `closed: false` — the core only applies it to
+	// pages it creates, and an absent value must leave that default alone.
+	it("leaves closed unset when the header lists no posts", () => {
+		const parsed = REMARK42_ADAPTER.parse(jsonl(comment()));
+		expect("closed" in parsed.threads[0]!).toBe(false);
+	});
+
+	it("carries read_only from the header onto the page", () => {
+		const meta = `{"version":1,"users":[],"posts":[{"url":"https://example.com/hello","read_only":true}]}`;
+		const parsed = REMARK42_ADAPTER.parse(`${meta}\n${comment()}\n`);
+		expect(parsed.threads[0]!.closed).toBe(true);
+	});
+
+	it("carries a header block onto the ghost user's ban state", () => {
+		const meta = `{"version":1,"users":[{"id":"anonymous_1111111111111111111111111111111111111111","blocked":{"status":true}}],"posts":[]}`;
+		const parsed = REMARK42_ADAPTER.parse(`${meta}\n${comment()}\n`);
+		expect(parsed.comments[0]!.author.is_banned).toBe(true);
+	});
+
+	it("leaves is_banned unset when the header lists no users", () => {
+		const parsed = REMARK42_ADAPTER.parse(jsonl(comment()));
+		expect("is_banned" in parsed.comments[0]!.author).toBe(false);
+	});
+});
+
+// ------------------------------ comment fields -----------------------------
+
+describe("comment fields", () => {
+	// Root is an empty string in this format, never null and never absent.
+	it("maps an empty pid to no parent", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(comment({ id: "c1" }), comment({ id: "c2", pid: "c1" })),
+		);
+		expect(parsed.comments.map((c) => c.parent_source_id)).toEqual([null, "c1"]);
+	});
+
+	it("re-parents a reply through the second pass", async () => {
+		const { db, captured } = makeFreshDb();
+		await runRemark42Import(
+			db,
+			jsonl(comment({ id: "c2", pid: "c1" }), comment({ id: "c1" })),
+			"secret",
+		);
+		const updates = captured.filter((c) =>
+			c.sql.startsWith("UPDATE comments SET parent_id"),
+		);
+		expect(updates).toHaveLength(1);
+	});
+
+	// Remark42 has no moderation queue and no spam verdict, so those two
+	// statuses have no source and can never be emitted.
+	it("maps delete to deleted and everything else to approved", () => {
+		const parsed = REMARK42_ADAPTER.parse(
+			jsonl(comment({ id: "c1" }), comment({ id: "c2", delete: true })),
+		);
+		expect(parsed.comments.map((c) => c.status)).toEqual([
+			"approved",
+			"deleted",
+		]);
+	});
+
+	it("skips deleted rows by default and counts them", async () => {
+		const { db } = makeFreshDb();
+		const plan = await runRemark42Import(
+			db,
+			jsonl(comment({ id: "c1" }), comment({ id: "c2", delete: true })),
+			"secret",
+		);
+		expect(plan.new_comments).toBe(1);
+		expect(plan.skipped_deleted).toBe(1);
+	});
+
+	it("carries edit.time onto edited_at", () => {
+		const c = comment({ edit: { time: "2026-08-23T09:00:00.000000000-05:00" } });
+		const [out] = REMARK42_ADAPTER.parse(jsonl(c)).comments;
+		expect(out!.edited_at).toBe(
+			Date.parse("2026-08-23T09:00:00.000000000-05:00"),
+		);
+	});
+
+	// RFC 3339 with nine fractional digits — Go's time.Time default. Date.parse
+	// handles it and truncates to milliseconds, which is the resolution
+	// comments.created_at has anyway.
+	it("parses a nanosecond timestamp with a numeric offset", () => {
+		const [out] = REMARK42_ADAPTER.parse(jsonl(comment())).comments;
+		expect(out!.created_at).toBe(
+			Date.parse("2026-08-22T22:12:53.539535119-05:00"),
+		);
+	});
+});
+
+// ------------------------------- the run -----------------------------------
+
+describe("runRemark42Import", () => {
+	it("inserts pages, ghost users and comments on a fresh DB", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runRemark42Import(db, jsonl(comment()), "secret");
+		expect(plan.pages_total).toBe(1);
+		expect(plan.comments_total).toBe(1);
+		expect(plan.new_pages).toBe(1);
+		expect(plan.new_users).toBe(1);
+		expect(plan.new_comments).toBe(1);
+
+		const [post] = inserts(captured, "posts");
+		expect(post!.binds[0]).toBe("hello");
+		expect(post!.binds[2]).toBe("https://example.com/hello");
+
+		const [c] = inserts(captured, "comments");
+		expect(c!.binds[c!.binds.length - 2]).toBe("remark42");
+		expect(c!.binds[c!.binds.length - 1]).toBe("c1");
+	});
+
+	it("is idempotent — a re-run inserts zero comments", async () => {
+		const { db, captured } = makeAlreadyImportedDb();
+		const plan = await runRemark42Import(db, jsonl(comment()), "secret");
+		expect(plan.new_comments).toBe(0);
+		expect(plan.new_pages).toBe(0);
+		expect(inserts(captured, "comments")).toHaveLength(0);
+	});
+
+	it("dry run reports counts and issues no writes", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runRemark42Import(db, jsonl(comment()), "secret", {
+			dry_run: true,
+		});
+		expect(plan.new_comments).toBe(1);
+		expect(
+			captured.filter((c) => /^(INSERT|UPDATE)/.test(c.sql)),
+		).toHaveLength(0);
+	});
+
+	// The gzip and plain-JSONL transports carry the same bytes — mode=file and
+	// mode=stream of one export are byte-identical, and the core sniffs the
+	// magic bytes — so one adapter covers both with no per-transport code.
+	it("stores a body sanitized through the markdown allowlist", async () => {
+		const c = comment({
+			orig: undefined,
+			text: "<p>hello <script>alert(1)</script> there</p>",
+		});
+		const { db, captured } = makeFreshDb();
+		await runRemark42Import(db, jsonl(c), "secret");
+		const bodyHtml = inserts(captured, "comments")[0]!.binds[4] as string;
+		expect(bodyHtml).not.toContain("<script>");
+		expect(bodyHtml).not.toContain("</script>");
+	});
+});

--- a/tests/remark42-import.test.ts
+++ b/tests/remark42-import.test.ts
@@ -9,7 +9,8 @@
  *      give it an empty body.
  *   3. Identity — `user.id` keys the ghost, so two commenters sharing a
  *      display name become two users and one commenter across two
- *      names stays one.
+ *      names stays one. A line without it is rejected rather than
+ *      name-keyed.
  *   4. Page reconstruction — there are no page records, so threads come
  *      from distinct `locator.url` with the earliest comment's time.
  *   5. Error hygiene — a malformed line names its number and never its
@@ -217,6 +218,18 @@ describe("parse errors", () => {
 	it("rejects a comment with no id", () => {
 		const noId = comment({ id: "" });
 		expect(() => parseRemark42Export(jsonl(noId))).toThrow(/comment id/);
+	});
+
+	// `user.id` is the identity seed. The core keys on name+email when
+	// `source_id` is empty, so tolerating an empty id would quietly merge two
+	// commenters who share a display name — the exact failure this adapter
+	// chose `user.id` to avoid. Fail the parse instead.
+	it("rejects a comment with no user.id", () => {
+		const noUserId = comment({ user: { name: "Ada" } });
+		expect(() => parseRemark42Export(jsonl(noUserId))).toThrow(/user\.id/);
+		expect(() => parseRemark42Export(jsonl(comment({ user: {} })))).toThrow(
+			/user\.id/,
+		);
 	});
 });
 


### PR DESCRIPTION
Second importer adapter, and the first one written against the contract rather than alongside it. #111 pulled everything source-agnostic out of the Disqus importer into `src/lib/import/core.ts`; this PR is the test of whether that boundary was drawn in the right place. It was: the adapter is one file exporting `source`, `slugFallbackPrefix` and `parse()`, plus a thin `runRemark42Import` wrapper. Nothing in the core changed to accommodate it.

Closes #105.

### What ships

- `src/lib/import/remark42.ts` — the adapter. Parses Remark42's backup format and maps it onto `SourceExport`.
- `scripts/import-remark42.ts` — the CLI (`npm run import:remark42`), matching the Disqus one.
- The admin upload endpoint accepts a Remark42 backup, and the operator card's import panel is now source-aware rather than Disqus-labelled.
- `AGENTS-OPERATE.md` and `README.md` document the path.

### Format notes worth knowing

**Remark42 backups are JSONL, optionally gzipped, with a metadata header line.** `decodeImportInput` in the core already sniffs gzip and inflates against the decompressed-size cap, so the adapter never sees compression. The header line carries `posts`/`users`/`version`; the parser tolerates its absence, because Remark42's own docs describe stripping it and operators do.

**`Orig` is `omitempty`, so it is often missing.** This is the one genuinely awkward part of the format. `Comment.Orig` holds the markdown as typed, and when it is present the import is verbatim — better fidelity than Disqus, which only stores rendered HTML. But Remark42's *own* importers (Disqus, WordPress, Commento) write only `Text` and never `Orig`, so any comment that reached Remark42 by migration exports with no markdown at all. The adapter falls back to `htmlToMarkdown` on `Text` for those. This is why that converter lives in the importer core and not inside the Disqus adapter — #111's commit message called this out as the reason, and this is the PR that depends on it.

**Threading is a two-pass map.** `pid` is the parent pointer; empty string means root. Replies can appear before their parents in the file, so parents are resolved in a second pass rather than assumed to be already-seen.

**Identity seeds are frozen as of this PR.** Per the adapter contract, `authorSeed` keys on Remark42's own `user.id`, HMAC'd with `IP_HASH_SECRET`. That choice cannot be revised later without re-ghosting every commenter imported by any version of this adapter, so it is deliberate and it is now load-bearing.

### Verification

528 lines of unit tests against hand-written fixtures (`tests/remark42-import.test.ts`), covering the header-stripped variant, the `Orig`-missing fallback, moderation-state mapping, out-of-order reply re-parenting, and idempotency.

Beyond that, the adapter has now been run end-to-end against a **real export from a live Remark42 instance** — parse, dry-run plan, import, re-import — and no bug surfaced:

- all 6 seeded comment bodies land **verbatim** in `body_md`
- re-importing the same bytes writes `new_pages=0 new_users=0 new_comments=0`
- 1 post, 4 users, 6 comments, matching the seed plan exactly

Two limitations of that run, stated so they are not mistaken for coverage:

1. **The real export contains no replies**, so the two-pass threading code was exercised only by the unit fixtures. That is faithful to the seed plan rather than a capture failure — the page these comments were seeded on declares no reply, and deep threading is a separate fixture page not yet seeded.
2. **The real export carries its metadata header**, so the header-stripped path is likewise unit-tested only.

Neither is a reason to hold the PR; both are reasons not to describe the real-export run as exhaustive.
