### PR TITLE
feat(import): Comentario v3 and legacy Commento v1 importer

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -901,10 +901,10 @@ action id count) are applied *after* `c.req.json()` has already deserialized the
 whole body, so without it a multi-megabyte payload costs a full parse against the
 Worker's 10 ms CPU budget before any of them get a say. 64 KB is far above every
 legitimate payload — the largest is a comment at the 10,000-character body limit.
-The exemptions are the two import uploads, `POST /admin/api/ops/import-disqus`
-and `POST /admin/api/ops/import-remark42`, which take an export — gzipped or
-not — up to 50 MB and enforce their own limit, on the decompressed bytes as
-well as the compressed ones. Implementation:
+The exemptions are the import uploads — `POST /admin/api/ops/import-disqus`,
+`POST /admin/api/ops/import-remark42` and `POST /admin/api/ops/import-comentario`
+— which take an export — gzipped or not — up to 50 MB and enforce their own
+limit, on the decompressed bytes as well as the compressed ones. Implementation:
 `src/lib/body-limit.ts`.
 
 **Client IP is required, not guessed.** Every endpoint that meters or dedupes
@@ -948,7 +948,7 @@ Pages (top nav):
 | `/admin/users/:id` | User detail: all their comments paginated, reactions received, audit history affecting them, the **Moderator notes** card, Ban/Unban, role controls, and two folded-away admin-only panels — **Export personal data** and **Erase personal data** (both below). |
 | `/admin/audit` | Audit log with filter form (admin, action, target kind/id, date range). |
 | `/admin/subscriptions` | Email subscription list. Filter by email/post/confirmed/unsubscribed. Actions: manual unsubscribe, resend confirmation. |
-| `/admin/operator` | Batch operations: rerender stale comments (POSTs `/admin/api/ops/rerender` in 50-row chunks until done), seed-demo (idempotent; gated to `ENV != "production"`), the comment import upload (Disqus XML or a Remark42 backup, gzipped or not — see below), and two retention cards — IP-hash and audit-log — each showing how many rows are past the configured window and offering a manual drain. |
+| `/admin/operator` | Batch operations: rerender stale comments (POSTs `/admin/api/ops/rerender` in 50-row chunks until done), seed-demo (idempotent; gated to `ENV != "production"`), the comment import upload (Disqus XML, a Remark42 backup or a Comentario/Commento JSON export, gzipped or not — see below), and two retention cards — IP-hash and audit-log — each showing how many rows are past the configured window and offering a manual drain. |
 | `/admin/settings` | Editable form for feature flags, display/pagination numbers, and the moderation dials (edit window, thread auto-close, community auto-collapse, the three anti-spam heuristics), saved to the `settings` D1 table (no redeploy — see section 5). Also renders a read-only `(set)`/`(unset)` summary of deploy-time config (Turnstile, email, OAuth, spam provider), which still changes via `wrangler secret put` / `wrangler.toml`. |
 | `/admin/webhooks` | Outbound webhook endpoints: add/pause/delete, per-endpoint secret + event filter, adapter (`generic` / `slack` / `discord` / `telegram`), failure counts and retry status. |
 | `/admin/telegram` | **Admin-only.** Telegram operator bot: shows whether the bot token/webhook secret are set, links your personal Telegram account (one-time code or deep link), toggles the daily digest, and unlinks. See `docs/telegram.md`. |
@@ -1239,23 +1239,25 @@ releases advertising a key that did nothing. `/` and `?` are inert
 while you are typing and under any modifier; `Esc` is matched before
 that guard, so a popover left open still closes from inside a textarea.
 
-**Comment import.** Two sources today — Disqus and Remark42 — each
-with two entry points, all four idempotent (deduplicated by the
-source's own comment ID, tracked in `0009_import_tracking.sql`;
-re-running the same export inserts zero rows):
+**Comment import.** Three sources today — Disqus, Remark42 and
+Comentario (which also reads a legacy Commento export) — each with two
+entry points, all of them idempotent (deduplicated by the source's own
+comment ID, tracked in `0009_import_tracking.sql`; re-running the same
+export inserts zero rows):
 
 - CLI (preferred for big exports):
-  `IP_HASH_SECRET=... npm run import-disqus -- ./export.xml --dry-run`
-  or `IP_HASH_SECRET=... npm run import-remark42 -- ./userbackup.gz
-  --dry-run`, then without `--dry-run` to commit.
+  `IP_HASH_SECRET=... npm run import-disqus -- ./export.xml --dry-run`,
+  `IP_HASH_SECRET=... npm run import-remark42 -- ./userbackup.gz
+  --dry-run`, or `IP_HASH_SECRET=... npm run import-comentario --
+  ./export.json --dry-run`, then without `--dry-run` to commit.
 - Admin upload on `/admin/operator` — one card with a source select,
   capped at 50 MB, with dry-run / include-deleted / include-spam
   toggles.
 
 **Gzipped exports work as-is, on every path.** Disqus hands you a
-`.xml.gz` and Remark42's nightly `backup` writes a
-`userbackup-<site>-<ts>.gz`; hand either straight to the CLI or the
-upload and it is
+`.xml.gz`, Remark42's nightly `backup` writes a
+`userbackup-<site>-<ts>.gz`, and Comentario offers its JSON gzipped;
+hand any of them straight to the CLI or the upload and it is
 inflated in memory. The 50 MB cap applies to the *decompressed* size
 too — a file that inflates past it is rejected with `413
 {"error":"too_large"}` partway through rather than allocated, which is
@@ -1336,11 +1338,56 @@ Remark42 has no spam verdict, so the adapter never emits
 `status='spam'`. Deleted comments are skipped unless
 `--include-deleted`.
 
+**Comentario and Commento specifics.** Both products write a single
+JSON document whose own `version` field says which shape it is —
+Comentario writes `3`, Commento wrote `1` — and one adapter reads
+both, so both go to the same CLI and the same upload. They share an
+`import_source` tag too, which means a v1 file and a later v3 file
+from the same instance deduplicate against each other rather than
+importing the same comments twice. Four things are worth knowing
+before you run it:
+
+- **One domain per run.** Both products are multi-site and neither
+  namespaces its page paths by site, so an export carrying two domains
+  is refused rather than flattened — two sites' `/about` would
+  silently become one page here. Pass `--domain=<id>` (or fill the
+  Domain field on the operator card) and run it once per domain. The
+  error names the domains it found. For a v3 export that value is a
+  `domainId` UUID, because a v3 export carries no hostnames at all;
+  for v1 it is a bare host.
+- **Bodies come across as the author typed them.** Comentario stores
+  markdown, so nothing is converted and nothing is inferred from
+  rendered HTML.
+- **What is marked spam is a moderator's decision, not a
+  classifier's.** Neither product ships spam detection. A v3 comment
+  that is neither approved nor pending is one a moderator rejected,
+  and a v1 comment `flagged`; both import as `status='spam'` and are
+  skipped without `--include-spam`. A comment still awaiting
+  moderation imports as `pending` and is never skipped.
+- **Pages come from page records in v3 and are reconstructed in v1.**
+  A v3 export has real page records — Garrul imports only the ones
+  that actually carry comments, so pages the widget merely loaded on
+  do not become empty rows — and takes `isReadonly` as `posts.closed`.
+  A v1 export has no page records, so each page is grouped from its
+  comments' host and path, and gets no title because Commento never
+  exported one.
+
+One v1 quirk worth naming: a Commento export never actually selected
+its `deleted` column, so the flag is always false even for comments
+that really were deleted. The rewritten body is the only signal left,
+so the adapter treats an empty body and a literal `[deleted]` body as
+deleted too — matching what Comentario's own importer does with these
+files.
+
 **The importer is source-agnostic underneath.** `src/lib/import/core.ts`
 holds everything true of every source — identity derivation,
 idempotency, threading, depth capping, the size and gzip handling — and
-`src/lib/import/disqus.ts` and `src/lib/import/remark42.ts` are just the
-adapters that know how to read one format each. A new adapter is one
+`src/lib/import/disqus.ts`, `src/lib/import/remark42.ts` and
+`src/lib/import/comentario.ts` are just the adapters that know how to
+read one format each. The CLIs are thin for the same reason:
+`scripts/import-cli.ts` holds the flag parsing, the wrangler-backed D1
+shim and the error hygiene, and each `scripts/import-<source>.ts` is a
+docblock plus a call. A new adapter is one
 file exporting an `ImportAdapter`; the remaining sources are tracked in
  #104, and they inherit all of the above rather than reimplementing it.
 

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1354,7 +1354,10 @@ before you run it:
   Domain field on the operator card) and run it once per domain. The
   error names the domains it found. For a v3 export that value is a
   `domainId` UUID, because a v3 export carries no hostnames at all;
-  for v1 it is a bare host.
+  for v1 it is a bare host. A value that matches nothing in the file
+  is refused as well, and the error names what would have worked — a
+  mistyped domain would otherwise select no records and report a
+  successful run that imported nothing.
 - **Bodies come across as the author typed them.** Comentario stores
   markdown, so nothing is converted and nothing is inferred from
   rendered HTML.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ src/
   lib/                  # session, markdown, turnstile, ratelimit, oauth, ulid, identicon, ip-hash,
                         #   webhook, webhook-sig, cors, log, settings, thread, email (Resend)
                         #   import/  — source-agnostic importer core + one file per source adapter
-                        #              core.ts, html-to-markdown.ts, disqus.ts
+                        #              core.ts, html-to-markdown.ts, disqus.ts, remark42.ts,
+                        #              comentario.ts
   i18n/                 # en.ts string table; t(key) shim
   widget/               # embed.ts (source), embed.bundled.ts (generated), load-error.ts
                         #   boot.ts — the mount fetches + fallback rule; DOM-free so it is the one
@@ -44,7 +45,8 @@ examples/               # host-site integration snippets (astro, wordpress, hugo
                         #   plain-html, iframe, lazy-load)
 scripts/                # setup.sh, rerender.ts, seed-demo.ts, db-export.sh, build-embed.ts,
                         #   build-agents-md.ts, build-version.ts, check-bundle-size.ts,
-                        #   import-disqus.ts, upgrade.ts, upgrade/
+                        #   import-cli.ts (shared CLI plumbing), import-disqus.ts,
+                        #   import-remark42.ts, import-comentario.ts, upgrade.ts, upgrade/
 docs/                   # THEMING.md, ANTISPAM.md, troubleshooting.md, webhooks.md, telegram.md,
                         #   api-keys-design.md, privacy-policy.template.md, tos.template.md
 .github/workflows/      # ci.yml, release.yml, docs-sync.yml
@@ -86,7 +88,10 @@ Server-side identicons for anonymous (deterministic from `user.id`, inline SVG).
 Never log or store raw IPs. Hash via HMAC-SHA-256 with `IP_HASH_SECRET` as the key (Workers don't ship BLAKE3 natively). `src/lib/ip-hash.ts` is the single entry point.
 
 ### Importers
-`src/lib/import/core.ts` owns everything that is true of every source; a source adapter owns only how to read its own export. Disqus is the first adapter (`disqus.ts`); #104 tracks the rest. A new adapter is one file exporting an `ImportAdapter` — `source`, `slugFallbackPrefix`, `parse(input) => SourceExport` — plus a thin `run<Source>Import` wrapper over `runImport`. Nothing else should need to change.
+`src/lib/import/core.ts` owns everything that is true of every source; a source adapter owns only how to read its own export. Disqus was the first adapter (`disqus.ts`), followed by `remark42.ts` and
+`comentario.ts` — which reads both Comentario v3 and legacy Commento v1 off
+the document's own `version` field, under one `import_source` tag because they
+are one product lineage. #104 tracks the rest. A new adapter is one file exporting an `ImportAdapter` — `source`, `slugFallbackPrefix`, `parse(input) => SourceExport` — plus a thin `run<Source>Import` wrapper over `runImport`. Nothing else should need to change.
 
 Five rules the core enforces, so no adapter has to:
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ dashboard page); every other integration is optional.
   sanitizer always on, four tunable heuristics and an optional classifier
   on top, everything routed to the queue
   ([`docs/ANTISPAM.md`](docs/ANTISPAM.md))
-- **Import from Disqus or Remark42**: upload the export in the admin UI —
-  the `.xml.gz` Disqus hands you or the `userbackup-<site>-<ts>.gz`
-  Remark42 writes nightly, no unzipping — or run
+- **Import from Disqus, Remark42 or Comentario**: upload the export in the
+  admin UI — the `.xml.gz` Disqus hands you, the `userbackup-<site>-<ts>.gz`
+  Remark42 writes nightly, or Comentario's JSON export, no unzipping — or run
   `npm run import-disqus -- ./export.xml.gz --dry-run` /
-  `npm run import-remark42 -- ./userbackup.gz --dry-run` first. Idempotent,
+  `npm run import-remark42 -- ./userbackup.gz --dry-run` /
+  `npm run import-comentario -- ./export.json --dry-run` first. The Comentario
+  reader also takes a legacy Commento export. Idempotent,
   so a re-run inserts nothing; closed threads stay closed and spam stays
   out of the public tree
 - **Admin UI**: moderation queue, user management, and settings you

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "seed-demo": "tsx scripts/seed-demo.ts",
     "import-disqus": "tsx scripts/import-disqus.ts",
     "import-remark42": "tsx scripts/import-remark42.ts",
+    "import-comentario": "tsx scripts/import-comentario.ts",
     "db:export": "bash scripts/db-export.sh",
     "upgrade": "tsx scripts/upgrade.ts",
     "manifest:build": "tsx scripts/upgrade/build-manifest.ts",

--- a/scripts/import-cli.ts
+++ b/scripts/import-cli.ts
@@ -1,0 +1,299 @@
+/**
+ * Shared plumbing for the `npm run import-<source>` CLIs.
+ *
+ * Every importer CLI is the same program with a different adapter bolted
+ * on: parse the same flags, drive D1 through `wrangler d1 execute`, read
+ * IP_HASH_SECRET from the environment, print the plan. Only the file it
+ * reads and the `run<Source>Import` it calls differ.
+ *
+ * This lived inline in each CLI until there were three of them. The
+ * duplication was not merely untidy — the copies had already drifted in a
+ * way that mattered: one printed the raw error object on failure (quoting
+ * the input it choked on, which for an untrusted export means display
+ * names and hashed IPs) while the other printed only the message. The
+ * hardened version is the one below, and now there is one of it.
+ *
+ * The SQL-assembly half is the part worth reading carefully; see the
+ * comment on `inline`.
+ */
+import { execFileSync } from "node:child_process";
+
+import { ImportTooLargeError } from "../src/lib/import/core";
+
+// The binding, not `database_name` — see the docblock in src/db/migrate.ts.
+const DB_BINDING = "DB";
+
+// --------------------------------- flags -----------------------------------
+
+export type ImportCliArgs = {
+	/** First non-flag argument: the export file to read. */
+	path: string;
+	isRemote: boolean;
+	dryRun: boolean;
+	includeDeleted: boolean;
+	includeSpam: boolean;
+	slugOverride: string | null;
+	/** `--name=value` for anything a single source adds on top. */
+	option: (name: string) => string | null;
+};
+
+/**
+ * Parse the flag set every importer CLI shares.
+ *
+ * Exits 2 with `usage` when no path is given, which is the one argument
+ * error worth stopping on — a missing adapter-specific flag is the
+ * adapter's business.
+ */
+export const parseImportArgs = (
+	argv: string[],
+	usage: string,
+): ImportCliArgs => {
+	const positional = argv.filter((a) => !a.startsWith("--"));
+	const path = positional[0];
+	if (!path) {
+		console.error(usage);
+		process.exit(2);
+	}
+	return {
+		path,
+		isRemote: argv.includes("--remote"),
+		dryRun: argv.includes("--dry-run"),
+		includeDeleted: argv.includes("--include-deleted"),
+		includeSpam: argv.includes("--include-spam"),
+		slugOverride: readOption(argv, "slug"),
+		option: (name) => readOption(argv, name),
+	};
+};
+
+const readOption = (argv: string[], name: string): string | null => {
+	const prefix = `--${name}=`;
+	const hit = argv.find((a) => a.startsWith(prefix));
+	return hit ? hit.slice(prefix.length) : null;
+};
+
+// -------------------------------- secret -----------------------------------
+
+/**
+ * Read IP_HASH_SECRET, or exit 2 explaining why there is no fallback.
+ *
+ * It keys the HMAC that derives each imported ghost's `provider_id`, so a
+ * literal committed to a public repo is a published key: anyone could
+ * recompute the provider_id for a known commenter, and every instance that
+ * imported without setting the variable would share one derivation. It also
+ * has to be the *same* secret the Worker uses, or the same person imported
+ * twice — or imported and then commenting live — resolves to two ghosts.
+ */
+export const requireSecret = (tag: string, example: string): string => {
+	const secret = process.env.IP_HASH_SECRET;
+	if (!secret) {
+		console.error(
+			`[${tag}] IP_HASH_SECRET is not set.\n` +
+				"  It must match the secret your Worker uses, or imported commenters\n" +
+				"  will not resolve to the same identities. Read it from .dev.vars for a\n" +
+				"  local import, or your password manager for --remote:\n" +
+				`    IP_HASH_SECRET=... ${example}`,
+		);
+		process.exit(2);
+	}
+	return secret;
+};
+
+// ------------------------------ SQL assembly -------------------------------
+
+/** A value that can't be inlined exactly. Aborts rather than approximating. */
+export class BindError extends Error {}
+
+// SQLite string literals escape a quote by doubling it, and recognize no
+// backslash escapes, so `''` is the complete escape for a literal.
+const sqlEsc = (s: string): string => s.replace(/'/g, "''");
+
+/**
+ * Render one bound value as a SQL literal.
+ *
+ * Why this exists at all: `wrangler d1 execute` accepts only `--command`
+ * and `--file`. There is no parameter-binding flag, so a CLI-driven shim
+ * has no way to hand D1 a statement and its values separately — the SQL
+ * text is the entire interface. Every statement is therefore assembled by
+ * substitution, over values parsed out of an untrusted export.
+ *
+ * What makes that survivable, and what does not:
+ *   * `''` is a complete escape for a SQLite literal (see `sqlEsc`).
+ *   * wrangler splits multi-statement input with a quote-aware scanner
+ *     (`splitSqlIntoStatements` consumes to the closing quote), so a
+ *     semicolon inside a correctly-escaped literal — routine in comment
+ *     bodies — does not start a new statement.
+ *   * Neither of those helps if the *value* never reaches a literal
+ *     intact. So this refuses anything it cannot inline exactly, rather
+ *     than emitting approximately-right SQL.
+ */
+export const inline = (v: unknown, index: number): string => {
+	if (v === null || v === undefined) return "NULL";
+	if (typeof v === "number") {
+		// String(NaN) is `NaN` and String(Infinity) is `Infinity`, both bare
+		// identifiers to SQLite rather than values. No adapter emits one today
+		// — each falls back to a real timestamp on an unparseable date — so
+		// this holds the invariant for future callers rather than fixing a
+		// live bug.
+		if (!Number.isFinite(v)) {
+			throw new BindError(`bind ${index}: non-finite number ${String(v)}`);
+		}
+		return String(v);
+	}
+	if (typeof v === "string") {
+		// argv is NUL-terminated, so a NUL in the value truncates the SQL
+		// mid-statement on its way to wrangler — silently, and at a position
+		// the attacker picks. Nothing in a legitimate export carries one;
+		// refuse rather than truncate.
+		if (v.includes("\u0000")) {
+			throw new BindError(`bind ${index}: NUL byte in string value`);
+		}
+		return `'${sqlEsc(v)}'`;
+	}
+	// Booleans, bigints, objects and functions all used to reach String(),
+	// which produced `true`, `[object Object]` and worse. The importer binds
+	// only strings, numbers and null; anything else is a bug in the caller.
+	throw new BindError(`bind ${index}: unsupported type ${typeof v}`);
+};
+
+/** Substitute bound values into a `?`-placeholder statement. */
+export const resolve = (sql: string, binds: unknown[]): string => {
+	let i = 0;
+	// `replace` does not rescan its own output, so a `?` inside an inlined
+	// value can't consume the next bind.
+	const out = sql.replace(/\?/g, () => inline(binds[i++], i));
+	// A placeholder/bind mismatch used to be invisible: a surplus placeholder
+	// read `undefined` and quietly became NULL, so a mis-shaped INSERT wrote a
+	// row with a hole in it instead of failing. Both directions are bugs.
+	if (i !== binds.length) {
+		throw new BindError(
+			`placeholder/bind mismatch: ${i} placeholder(s), ${binds.length} bound value(s) in: ${sql.slice(0, 120)}`,
+		);
+	}
+	return out;
+};
+
+/**
+ * The rows from one `wrangler d1 execute --command` run.
+ *
+ * wrangler prints a banner and then a JSON envelope, one element per
+ * statement, each `{ results, success, meta }`:
+ *
+ *     🚣 1 command executed successfully.
+ *     [ { "results": [], "success": true, "meta": { "duration": 0 } } ]
+ *
+ * Unwrap properly rather than treating the envelope itself as the rows: for
+ * this caller an envelope object is truthy, so every `SELECT … WHERE …`
+ * existence probe would report "this row already exists" and the import
+ * would insert nothing while printing DONE with all-zero counters.
+ *
+ * Throws rather than returning [] when the output can't be read: for this
+ * caller "no rows" means "go ahead and insert", so guessing it on a parse
+ * failure is how a silently-broken import looks. A loud failure is
+ * recoverable; a no-op that claims success is not.
+ */
+type D1Envelope = { results?: unknown };
+
+export const parseRows = (output: string): Record<string, unknown>[] => {
+	// The banner precedes the JSON, so anchor on the first `[` that starts a
+	// line — wrangler pretty-prints, and a nested `]` inside a row value would
+	// end a non-greedy match early.
+	const start = output.search(/^\[/m);
+	if (start === -1) {
+		// No envelope at all. wrangler exited 0, so this is an output-format
+		// change, not a query error (execFileSync throws on non-zero).
+		throw new Error(
+			`could not find a JSON result envelope in wrangler output:\n${output.slice(0, 400)}`,
+		);
+	}
+	let envelope: unknown;
+	try {
+		envelope = JSON.parse(output.slice(start));
+	} catch (err) {
+		throw new Error(`could not parse wrangler output as JSON: ${String(err)}`);
+	}
+	if (!Array.isArray(envelope)) {
+		throw new Error("wrangler result envelope was not an array");
+	}
+	// One statement in, so one element out; be tolerant of more.
+	return envelope.flatMap((e) => {
+		const results = (e as D1Envelope)?.results;
+		if (results === undefined) return [];
+		if (!Array.isArray(results)) {
+			throw new Error("wrangler result envelope had a non-array `results`");
+		}
+		return results as Record<string, unknown>[];
+	});
+};
+
+// --------------------------------- D1 shim ---------------------------------
+
+/**
+ * A `D1Database` that talks to wrangler, one statement per subprocess.
+ *
+ * tsx running locally can't bind D1 directly. That is only viable for
+ * thousands-not-millions of rows; the admin endpoint uses the same importer
+ * library inside the Worker where DB is bound natively, which is the
+ * production path.
+ */
+export const wranglerD1 = (isRemote: boolean): D1Database => {
+	const remoteFlag = isRemote ? "--remote" : "--local";
+	const run = (sql: string): string =>
+		execFileSync(
+			"wrangler",
+			["d1", "execute", DB_BINDING, remoteFlag, "--command", sql],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		);
+
+	return {
+		prepare(sql: string) {
+			const binds: unknown[] = [];
+			return {
+				bind(...args: unknown[]) {
+					binds.push(...args);
+					return this;
+				},
+				async first<T = unknown>(): Promise<T | null> {
+					return (parseRows(run(resolve(sql, binds)))[0] as T) ?? null;
+				},
+				async all<T = unknown>(): Promise<{ results: T[] }> {
+					return { results: parseRows(run(resolve(sql, binds))) as T[] };
+				},
+				async run() {
+					run(resolve(sql, binds));
+					return { meta: { changes: 1 } };
+				},
+			} as unknown as D1PreparedStatement;
+		},
+	} as unknown as D1Database;
+};
+
+// -------------------------------- reporting --------------------------------
+
+export const reportPlan = (tag: string, dryRun: boolean, plan: unknown): void => {
+	console.log(`[${tag}] ${dryRun ? "DRY RUN" : "DONE"}`, JSON.stringify(plan, null, 2));
+};
+
+/**
+ * Print a failure and exit 1.
+ *
+ * Prints the message, never the error object and never a slice of the file.
+ * An export carries display names, email addresses and sometimes the
+ * source's own hashed IPs, and an unlucky `err` — a JSON.parse failure, say
+ * — quotes the input it choked on. Every throw on this path is written to
+ * name a record POSITION rather than a record, so the message alone is both
+ * content-free and enough to find the bad row by hand.
+ */
+export const failImport = (tag: string, err: unknown): never => {
+	if (err instanceof ImportTooLargeError) {
+		// Its own branch because gzip is the normal transport for most
+		// sources: an export that inflates past the cap is the expected way a
+		// legitimate large instance fails, and "too large" is a different
+		// instruction to the operator than "malformed".
+		console.error(`[${tag}] export is too large to import: ${err.message}`);
+		process.exit(1);
+	}
+	console.error(
+		`[${tag}] failed: ${err instanceof Error ? err.message : String(err)}`,
+	);
+	process.exit(1);
+};

--- a/scripts/import-comentario.ts
+++ b/scripts/import-comentario.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env tsx
+/**
+ * Import a Comentario (v3) or legacy Commento (v1) export into the local
+ * or remote D1.
+ *
+ *   npm run import-comentario -- ./comentario.export.json          # local D1
+ *   npm run import-comentario -- ./comentario.export.json.gz       # gzipped, too
+ *   npm run import-comentario -- ./export.json --remote            # production D1
+ *
+ * Both products write a single JSON document whose `version` field says
+ * which of the two shapes it is. One adapter reads both — Commento is
+ * Comentario's ancestor, an operator leaving one is leaving the same
+ * product, and the source tag is shared so a v1 file and a later v3 file
+ * from the same instance deduplicate against each other.
+ *
+ * Flags:
+ *   --remote            Use the deployed D1 binding instead of Miniflare.
+ *   --dry-run           Parse + plan only. No INSERTs run.
+ *   --include-deleted   Bring source-deleted comments across (default: skip).
+ *   --include-spam      Bring moderator-rejected comments across (default:
+ *                       skip). Neither product has a spam classifier; what
+ *                       the adapter marks `spam` is a comment a human
+ *                       moderator rejected (v3) or flagged (v1).
+ *   --slug=<slug>       Pin every imported thread to one slug (rare —
+ *                       useful when migrating a single page).
+ *   --domain=<id>       Narrow a multi-domain export to one site. A
+ *                       `domainId` UUID for v3, a bare host for v1. Without
+ *                       it, an export carrying more than one is refused
+ *                       rather than flattened — see below.
+ *
+ * On --domain: both products are multi-site, and neither export namespaces
+ * its page paths by site. Two domains' `/about` would collide onto one
+ * Garrul slug with no way to tell afterwards which comments came from
+ * which, so the adapter stops instead. Run it once per domain. A v3 export
+ * carries no hostnames at all — pages reference a `domainId` UUID and the
+ * only place a real host appears is a comment permalink — so the value to
+ * pass for v3 is the UUID the error message prints.
+ *
+ * Idempotent: re-running on the same export inserts zero new rows (every
+ * comment carries `import_source='comentario'` + the source's own comment
+ * id under `import_id`, and migration 0009 puts a partial UNIQUE index on
+ * that pair).
+ *
+ * Why this is a local CLI, not a Worker endpoint:
+ *   Big exports easily exceed the Workers free-tier 100k D1 writes/day
+ *   quota in a single import. Running locally via wrangler d1 execute
+ *   counts those writes against your D1 budget, but does NOT spend any
+ *   Worker requests. The admin upload endpoint (operator page) wraps this
+ *   same library, and bounds a run only by capping the upload at
+ *   MAX_IMPORT_BYTES on the decompressed side — which is a cap on input,
+ *   not on writes.
+ *
+ * The D1 shim, flag parsing and error hygiene are shared with the other
+ * importer CLIs — see scripts/import-cli.ts.
+ */
+import { readFileSync } from "node:fs";
+
+import { runComentarioImport } from "../src/lib/import/comentario";
+import { decodeImportInput } from "../src/lib/import/core";
+import {
+	failImport,
+	parseImportArgs,
+	reportPlan,
+	requireSecret,
+	wranglerD1,
+} from "./import-cli";
+
+const TAG = "import-comentario";
+
+const args = parseImportArgs(
+	process.argv.slice(2),
+	`usage: npm run ${TAG} -- <path-to-export.json> [--remote] [--dry-run] [--domain=<id>]`,
+);
+
+(async () => {
+	if (!args.isRemote) {
+		console.warn(`[${TAG}] running against LOCAL D1 (Miniflare).`);
+	}
+	// Read bytes, not utf8, and let decodeImportInput sniff the gzip magic.
+	// Comentario's admin UI offers the export gzipped, and a `.gz` read as
+	// utf8 would be corrupt before the sniff ever ran.
+	const doc = await decodeImportInput(readFileSync(args.path));
+	const secret = requireSecret(TAG, `npm run ${TAG} -- <export.json>`);
+
+	const plan = await runComentarioImport(wranglerD1(args.isRemote), doc, secret, {
+		dry_run: args.dryRun,
+		include_deleted: args.includeDeleted,
+		include_spam: args.includeSpam,
+		slug_override: args.slugOverride,
+		domain: args.option("domain"),
+	});
+
+	reportPlan(TAG, args.dryRun, plan);
+})().catch((err) => failImport(TAG, err));

--- a/scripts/import-disqus.ts
+++ b/scripts/import-disqus.ts
@@ -26,235 +26,45 @@
  *   NOT spend any Worker requests. The admin upload endpoint
  *   (operator page) wraps this same library but caps the per-call
  *   write volume.
+ *
+ * The D1 shim, flag parsing and error hygiene are shared with the other
+ * importer CLIs — see scripts/import-cli.ts.
  */
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 import { decodeImportInput } from "../src/lib/import/core";
 import { runDisqusImport } from "../src/lib/import/disqus";
+import {
+	failImport,
+	parseImportArgs,
+	reportPlan,
+	requireSecret,
+	wranglerD1,
+} from "./import-cli";
 
-// The binding, not `database_name` — see the docblock in src/db/migrate.ts.
-const DB_BINDING = "DB";
+const TAG = "import-disqus";
 
-const args = process.argv.slice(2);
-const positional = args.filter((a) => !a.startsWith("--"));
-const xmlPath = positional[0];
-if (!xmlPath) {
-	console.error("usage: npm run import-disqus -- <path-to-disqus.xml> [--remote] [--dry-run]");
-	process.exit(2);
-}
-const isRemote = args.includes("--remote");
-const dryRun = args.includes("--dry-run");
-const includeDeleted = args.includes("--include-deleted");
-const includeSpam = args.includes("--include-spam");
-const slugFlag = args.find((a) => a.startsWith("--slug="));
-const slugOverride = slugFlag ? slugFlag.slice("--slug=".length) : null;
-
-const remoteFlag = isRemote ? "--remote" : "--local";
-
-// The importer needs to talk to D1. tsx running locally can't bind D1
-// directly — we drive it through `wrangler d1 execute` per statement.
-// That's only viable for thousands-not-millions of rows. The admin
-// endpoint uses the same library inside the Worker where DB is bound
-// natively, which is the production path.
-//
-// Why this interpolates instead of binding: `wrangler d1 execute` accepts
-// only `--command` and `--file`. There is no parameter-binding flag, so a
-// CLI-driven shim has no way to hand D1 a statement and its values
-// separately — the SQL text is the entire interface. Every statement here
-// is therefore assembled by substitution, over values parsed out of an
-// untrusted Disqus export.
-//
-// What makes that survivable, and what does not:
-//   * SQLite string literals escape a quote by doubling it, and recognize
-//     no backslash escapes, so `''` is the complete escape for a literal.
-//   * wrangler splits multi-statement input with a quote-aware scanner
-//     (`splitSqlIntoStatements` consumes to the closing quote), so a
-//     semicolon inside a correctly-escaped literal — routine in comment
-//     bodies — does not start a new statement.
-//   * Neither of those helps if the *value* never reaches a literal
-//     intact. `resolve` below therefore refuses anything it cannot inline
-//     exactly, rather than emitting approximately-right SQL.
-const sqlEsc = (s: string): string => s.replace(/'/g, "''");
-
-const runWrangler = (sql: string): string =>
-	execFileSync(
-		"wrangler",
-		["d1", "execute", DB_BINDING, remoteFlag, "--command", sql],
-		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-	);
-
-const d1: D1Database = {
-	prepare(rawSql: string) {
-		const sql = rawSql;
-		const binds: unknown[] = [];
-		return {
-			bind(...args: unknown[]) {
-				binds.push(...args);
-				return this;
-			},
-			async first<T = unknown>(): Promise<T | null> {
-				const resolved = resolve(sql, binds);
-				const out = runWrangler(resolved);
-				const rows = parseRows(out);
-				return (rows[0] as T) ?? null;
-			},
-			async all<T = unknown>(): Promise<{ results: T[] }> {
-				const resolved = resolve(sql, binds);
-				const out = runWrangler(resolved);
-				return { results: parseRows(out) as T[] };
-			},
-			async run() {
-				const resolved = resolve(sql, binds);
-				runWrangler(resolved);
-				return { meta: { changes: 1 } };
-			},
-		} as unknown as D1PreparedStatement;
-	},
-} as unknown as D1Database;
-
-// A value that can't be inlined exactly. Aborts the import rather than
-// letting a wrong-but-valid statement reach D1.
-class BindError extends Error {}
-
-const inline = (v: unknown, index: number): string => {
-	if (v === null || v === undefined) return "NULL";
-	if (typeof v === "number") {
-		// String(NaN) is `NaN` and String(Infinity) is `Infinity`, both bare
-		// identifiers to SQLite rather than values. Not reachable from the XML
-		// today — parseDisqusXml falls back to Date.now() on an unparseable
-		// <createdAt> — so this holds the invariant for future callers rather
-		// than fixing a live bug.
-		if (!Number.isFinite(v)) {
-			throw new BindError(`bind ${index}: non-finite number ${String(v)}`);
-		}
-		return String(v);
-	}
-	if (typeof v === "string") {
-		// argv is NUL-terminated, so a NUL in the value truncates the SQL
-		// mid-statement on its way to wrangler — silently, and at a position
-		// the attacker picks. Nothing in a Disqus export legitimately carries
-		// one; refuse rather than truncate.
-		if (v.includes("\u0000")) {
-			throw new BindError(`bind ${index}: NUL byte in string value`);
-		}
-		return `'${sqlEsc(v)}'`;
-	}
-	// Booleans, bigints, objects and functions all used to reach String(),
-	// which produced `true`, `[object Object]` and worse. The importer binds
-	// only strings, numbers and null; anything else is a bug in the caller.
-	throw new BindError(`bind ${index}: unsupported type ${typeof v}`);
-};
-
-const resolve = (sql: string, binds: unknown[]): string => {
-	let i = 0;
-	// `replace` does not rescan its own output, so a `?` inside an inlined
-	// value can't consume the next bind.
-	const out = sql.replace(/\?/g, () => inline(binds[i++], i));
-	// A placeholder/bind mismatch used to be invisible: a surplus placeholder
-	// read `undefined` and quietly became NULL, so a mis-shaped INSERT wrote a
-	// row with a hole in it instead of failing. Both directions are bugs.
-	if (i !== binds.length) {
-		throw new BindError(
-			`placeholder/bind mismatch: ${i} placeholder(s), ${binds.length} bound value(s) in: ${sql.slice(0, 120)}`,
-		);
-	}
-	return out;
-};
-
-/**
- * The rows from one `wrangler d1 execute --command` run.
- *
- * wrangler prints a banner and then a JSON envelope, one element per
- * statement, each `{ results, success, meta }`:
- *
- *     🚣 1 command executed successfully.
- *     [ { "results": [], "success": true, "meta": { "duration": 0 } } ]
- *
- * The previous version regex-matched the first `[ { … } ]` in that output and
- * returned it *as the rows* — so an empty result set came back as one truthy
- * envelope object. Every `SELECT … WHERE …` existence probe in the importer
- * therefore reported "this row already exists", and the CLI import inserted
- * nothing at all while printing DONE with all-zero counters. Unwrap properly.
- *
- * Throws rather than returning [] when the output can't be read: for this
- * caller "no rows" means "go ahead and insert", so guessing it on a parse
- * failure is how a silently-broken import looks. A loud failure is recoverable;
- * a no-op that claims success is not.
- */
-type D1Envelope = { results?: unknown };
-
-const parseRows = (output: string): Record<string, unknown>[] => {
-	// The banner precedes the JSON, so anchor on the first `[` that starts a
-	// line — wrangler pretty-prints, and a nested `]` inside a row value would
-	// end a non-greedy match early.
-	const start = output.search(/^\[/m);
-	if (start === -1) {
-		// No envelope at all. wrangler exited 0, so this is an output-format
-		// change, not a query error (execFileSync throws on non-zero).
-		throw new Error(
-			`could not find a JSON result envelope in wrangler output:\n${output.slice(0, 400)}`,
-		);
-	}
-	let envelope: unknown;
-	try {
-		envelope = JSON.parse(output.slice(start));
-	} catch (err) {
-		throw new Error(`could not parse wrangler output as JSON: ${String(err)}`);
-	}
-	if (!Array.isArray(envelope)) {
-		throw new Error("wrangler result envelope was not an array");
-	}
-	// One statement in, so one element out; be tolerant of more.
-	return envelope.flatMap((e) => {
-		const results = (e as D1Envelope)?.results;
-		if (results === undefined) return [];
-		if (!Array.isArray(results)) {
-			throw new Error("wrangler result envelope had a non-array `results`");
-		}
-		return results as Record<string, unknown>[];
-	});
-};
+const args = parseImportArgs(
+	process.argv.slice(2),
+	`usage: npm run ${TAG} -- <path-to-disqus.xml> [--remote] [--dry-run]`,
+);
 
 (async () => {
-	if (!isRemote) {
-		console.warn(`[import-disqus] running against LOCAL D1 (Miniflare).`);
+	if (!args.isRemote) {
+		console.warn(`[${TAG}] running against LOCAL D1 (Miniflare).`);
 	}
 	// Read bytes, not utf8: decodeImportInput sniffs the gzip magic, so
 	// `./export.xml.gz` works without inflating it first. Reading a gzipped
 	// file as utf8 would corrupt it before the sniff ever ran.
-	const xml = await decodeImportInput(readFileSync(xmlPath));
-	// No fallback. This keys the HMAC that derives each imported ghost's
-	// `provider_id` from its Disqus name and email, so a literal committed to a
-	// public repo is a published key: anyone could recompute the provider_id for
-	// a known commenter, and every instance that ever imported without setting
-	// the variable shares the same derivation. It also has to be the *same*
-	// secret the Worker uses, or the same person imported twice — or imported
-	// and then commenting live — resolves to two different ghosts.
-	const secret = process.env.IP_HASH_SECRET;
-	if (!secret) {
-		console.error(
-			"[import-disqus] IP_HASH_SECRET is not set.\n" +
-				"  It must match the secret your Worker uses, or imported commenters\n" +
-				"  will not resolve to the same identities. Read it from .dev.vars for a\n" +
-				"  local import, or your password manager for --remote:\n" +
-				"    IP_HASH_SECRET=... npm run import-disqus -- <file.xml>",
-		);
-		process.exit(2);
-	}
+	const xml = await decodeImportInput(readFileSync(args.path));
+	const secret = requireSecret(TAG, `npm run ${TAG} -- <file.xml>`);
 
-	const plan = await runDisqusImport(d1, xml, secret, {
-		dry_run: dryRun,
-		include_deleted: includeDeleted,
-		include_spam: includeSpam,
-		slug_override: slugOverride,
+	const plan = await runDisqusImport(wranglerD1(args.isRemote), xml, secret, {
+		dry_run: args.dryRun,
+		include_deleted: args.includeDeleted,
+		include_spam: args.includeSpam,
+		slug_override: args.slugOverride,
 	});
 
-	console.log(
-		`[import-disqus] ${dryRun ? "DRY RUN" : "DONE"}`,
-		JSON.stringify(plan, null, 2),
-	);
-})().catch((err) => {
-	console.error("[import-disqus] failed:", err);
-	process.exit(1);
-});
+	reportPlan(TAG, args.dryRun, plan);
+})().catch((err) => failImport(TAG, err));

--- a/scripts/import-remark42.ts
+++ b/scripts/import-remark42.ts
@@ -30,200 +30,32 @@
  *   same library, and bounds a run only by capping the upload at
  *   MAX_IMPORT_BYTES on the decompressed side — which is a cap on input,
  *   not on writes. A backup under that cap can still be a lot of rows.
+ *
+ * The D1 shim, flag parsing and error hygiene are shared with the other
+ * importer CLIs — see scripts/import-cli.ts.
  */
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-import { ImportTooLargeError, decodeImportInput } from "../src/lib/import/core";
+import { decodeImportInput } from "../src/lib/import/core";
 import { runRemark42Import } from "../src/lib/import/remark42";
+import {
+	failImport,
+	parseImportArgs,
+	reportPlan,
+	requireSecret,
+	wranglerD1,
+} from "./import-cli";
 
-// The binding, not `database_name` — see the docblock in src/db/migrate.ts.
-const DB_BINDING = "DB";
+const TAG = "import-remark42";
 
-const args = process.argv.slice(2);
-const positional = args.filter((a) => !a.startsWith("--"));
-const backupPath = positional[0];
-if (!backupPath) {
-	console.error(
-		"usage: npm run import-remark42 -- <path-to-remark42-backup> [--remote] [--dry-run]",
-	);
-	process.exit(2);
-}
-const isRemote = args.includes("--remote");
-const dryRun = args.includes("--dry-run");
-const includeDeleted = args.includes("--include-deleted");
-const includeSpam = args.includes("--include-spam");
-const slugFlag = args.find((a) => a.startsWith("--slug="));
-const slugOverride = slugFlag ? slugFlag.slice("--slug=".length) : null;
-
-const remoteFlag = isRemote ? "--remote" : "--local";
-
-// The importer needs to talk to D1. tsx running locally can't bind D1
-// directly — we drive it through `wrangler d1 execute` per statement.
-// That's only viable for thousands-not-millions of rows. The admin
-// endpoint uses the same library inside the Worker where DB is bound
-// natively, which is the production path.
-//
-// Why this interpolates instead of binding: `wrangler d1 execute` accepts
-// only `--command` and `--file`. There is no parameter-binding flag, so a
-// CLI-driven shim has no way to hand D1 a statement and its values
-// separately — the SQL text is the entire interface. Every statement here
-// is therefore assembled by substitution, over values parsed out of an
-// untrusted Remark42 export.
-//
-// What makes that survivable, and what does not:
-//   * SQLite string literals escape a quote by doubling it, and recognize
-//     no backslash escapes, so `''` is the complete escape for a literal.
-//   * wrangler splits multi-statement input with a quote-aware scanner
-//     (`splitSqlIntoStatements` consumes to the closing quote), so a
-//     semicolon inside a correctly-escaped literal — routine in comment
-//     bodies — does not start a new statement.
-//   * Neither of those helps if the *value* never reaches a literal
-//     intact. `resolve` below therefore refuses anything it cannot inline
-//     exactly, rather than emitting approximately-right SQL.
-const sqlEsc = (s: string): string => s.replace(/'/g, "''");
-
-const runWrangler = (sql: string): string =>
-	execFileSync(
-		"wrangler",
-		["d1", "execute", DB_BINDING, remoteFlag, "--command", sql],
-		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-	);
-
-const d1: D1Database = {
-	prepare(rawSql: string) {
-		const sql = rawSql;
-		const binds: unknown[] = [];
-		return {
-			bind(...args: unknown[]) {
-				binds.push(...args);
-				return this;
-			},
-			async first<T = unknown>(): Promise<T | null> {
-				const resolved = resolve(sql, binds);
-				const out = runWrangler(resolved);
-				const rows = parseRows(out);
-				return (rows[0] as T) ?? null;
-			},
-			async all<T = unknown>(): Promise<{ results: T[] }> {
-				const resolved = resolve(sql, binds);
-				const out = runWrangler(resolved);
-				return { results: parseRows(out) as T[] };
-			},
-			async run() {
-				const resolved = resolve(sql, binds);
-				runWrangler(resolved);
-				return { meta: { changes: 1 } };
-			},
-		} as unknown as D1PreparedStatement;
-	},
-} as unknown as D1Database;
-
-// A value that can't be inlined exactly. Aborts the import rather than
-// letting a wrong-but-valid statement reach D1.
-class BindError extends Error {}
-
-const inline = (v: unknown, index: number): string => {
-	if (v === null || v === undefined) return "NULL";
-	if (typeof v === "number") {
-		// String(NaN) is `NaN` and String(Infinity) is `Infinity`, both bare
-		// identifiers to SQLite rather than values. Not reachable from a Remark42
-		// export today — the adapter's parseTime falls back to Date.now() on an
-		// unparseable `time` — so this holds the invariant for future callers
-		// rather than fixing a live bug.
-		if (!Number.isFinite(v)) {
-			throw new BindError(`bind ${index}: non-finite number ${String(v)}`);
-		}
-		return String(v);
-	}
-	if (typeof v === "string") {
-		// argv is NUL-terminated, so a NUL in the value truncates the SQL
-		// mid-statement on its way to wrangler — silently, and at a position
-		// the attacker picks. Nothing in a Remark42 export legitimately carries
-		// one; refuse rather than truncate.
-		if (v.includes("\u0000")) {
-			throw new BindError(`bind ${index}: NUL byte in string value`);
-		}
-		return `'${sqlEsc(v)}'`;
-	}
-	// Booleans, bigints, objects and functions all used to reach String(),
-	// which produced `true`, `[object Object]` and worse. The importer binds
-	// only strings, numbers and null; anything else is a bug in the caller.
-	throw new BindError(`bind ${index}: unsupported type ${typeof v}`);
-};
-
-const resolve = (sql: string, binds: unknown[]): string => {
-	let i = 0;
-	// `replace` does not rescan its own output, so a `?` inside an inlined
-	// value can't consume the next bind.
-	const out = sql.replace(/\?/g, () => inline(binds[i++], i));
-	// A placeholder/bind mismatch used to be invisible: a surplus placeholder
-	// read `undefined` and quietly became NULL, so a mis-shaped INSERT wrote a
-	// row with a hole in it instead of failing. Both directions are bugs.
-	if (i !== binds.length) {
-		throw new BindError(
-			`placeholder/bind mismatch: ${i} placeholder(s), ${binds.length} bound value(s) in: ${sql.slice(0, 120)}`,
-		);
-	}
-	return out;
-};
-
-/**
- * The rows from one `wrangler d1 execute --command` run.
- *
- * wrangler prints a banner and then a JSON envelope, one element per
- * statement, each `{ results, success, meta }`:
- *
- *     🚣 1 command executed successfully.
- *     [ { "results": [], "success": true, "meta": { "duration": 0 } } ]
- *
- * Unwrap properly rather than treating the envelope itself as the rows: for
- * this caller an envelope object is truthy, so every `SELECT … WHERE …`
- * existence probe would report "this row already exists" and the import would
- * insert nothing while printing DONE with all-zero counters.
- *
- * Throws rather than returning [] when the output can't be read: for this
- * caller "no rows" means "go ahead and insert", so guessing it on a parse
- * failure is how a silently-broken import looks. A loud failure is recoverable;
- * a no-op that claims success is not.
- */
-type D1Envelope = { results?: unknown };
-
-const parseRows = (output: string): Record<string, unknown>[] => {
-	// The banner precedes the JSON, so anchor on the first `[` that starts a
-	// line — wrangler pretty-prints, and a nested `]` inside a row value would
-	// end a non-greedy match early.
-	const start = output.search(/^\[/m);
-	if (start === -1) {
-		// No envelope at all. wrangler exited 0, so this is an output-format
-		// change, not a query error (execFileSync throws on non-zero).
-		throw new Error(
-			`could not find a JSON result envelope in wrangler output:\n${output.slice(0, 400)}`,
-		);
-	}
-	let envelope: unknown;
-	try {
-		envelope = JSON.parse(output.slice(start));
-	} catch (err) {
-		throw new Error(`could not parse wrangler output as JSON: ${String(err)}`);
-	}
-	if (!Array.isArray(envelope)) {
-		throw new Error("wrangler result envelope was not an array");
-	}
-	// One statement in, so one element out; be tolerant of more.
-	return envelope.flatMap((e) => {
-		const results = (e as D1Envelope)?.results;
-		if (results === undefined) return [];
-		if (!Array.isArray(results)) {
-			throw new Error("wrangler result envelope had a non-array `results`");
-		}
-		return results as Record<string, unknown>[];
-	});
-};
+const args = parseImportArgs(
+	process.argv.slice(2),
+	`usage: npm run ${TAG} -- <path-to-remark42-backup> [--remote] [--dry-run]`,
+);
 
 (async () => {
-	if (!isRemote) {
-		console.warn(`[import-remark42] running against LOCAL D1 (Miniflare).`);
+	if (!args.isRemote) {
+		console.warn(`[${TAG}] running against LOCAL D1 (Miniflare).`);
 	}
 	// Read bytes, not utf8, and let decodeImportInput sniff the gzip magic.
 	// This is load-bearing here in a way it is not for every source: a
@@ -233,56 +65,20 @@ const parseRows = (output: string): Record<string, unknown>[] => {
 	// the bytes lets one script accept both transports with no per-transport
 	// code, and reading a `.gz` as utf8 would corrupt it before the sniff
 	// ever ran.
-	const backup = await decodeImportInput(readFileSync(backupPath));
-	// No fallback. This keys the HMAC that derives each imported ghost's
-	// `provider_id` from its Remark42 user id, so a literal committed to a
-	// public repo is a published key: anyone could recompute the provider_id for
-	// a known commenter, and every instance that ever imported without setting
-	// the variable shares the same derivation. It also has to be the *same*
-	// secret the Worker uses, or the same person imported twice — or imported
-	// and then commenting live — resolves to two different ghosts.
-	const secret = process.env.IP_HASH_SECRET;
-	if (!secret) {
-		console.error(
-			"[import-remark42] IP_HASH_SECRET is not set.\n" +
-				"  It must match the secret your Worker uses, or imported commenters\n" +
-				"  will not resolve to the same identities. Read it from .dev.vars for a\n" +
-				"  local import, or your password manager for --remote:\n" +
-				"    IP_HASH_SECRET=... npm run import-remark42 -- <backup.gz>",
-		);
-		process.exit(2);
-	}
+	const backup = await decodeImportInput(readFileSync(args.path));
+	const secret = requireSecret(TAG, `npm run ${TAG} -- <backup.gz>`);
 
-	const plan = await runRemark42Import(d1, backup, secret, {
-		dry_run: dryRun,
-		include_deleted: includeDeleted,
-		include_spam: includeSpam,
-		slug_override: slugOverride,
-	});
+	const plan = await runRemark42Import(
+		wranglerD1(args.isRemote),
+		backup,
+		secret,
+		{
+			dry_run: args.dryRun,
+			include_deleted: args.includeDeleted,
+			include_spam: args.includeSpam,
+			slug_override: args.slugOverride,
+		},
+	);
 
-	console.log(
-		`[import-remark42] ${dryRun ? "DRY RUN" : "DONE"}`,
-		JSON.stringify(plan, null, 2),
-	);
-})().catch((err) => {
-	// Print the message, never the error object and never a slice of the file.
-	// A Remark42 export carries display names and Remark42's own hashed IPs, and
-	// an unlucky `err` — a JSON.parse failure, say — quotes the input it choked
-	// on. Every throw on this path is already written to name a line NUMBER
-	// rather than a line, so the message alone is both content-free and enough
-	// to find the bad record by hand.
-	if (err instanceof ImportTooLargeError) {
-		// Worth its own branch here because gzip is this source's normal
-		// transport: a backup that inflates past the cap is the expected way a
-		// legitimate large instance fails, and "too large" is a different
-		// instruction to the operator than "malformed".
-		console.error(
-			`[import-remark42] export is too large to import: ${err.message}`,
-		);
-		process.exit(1);
-	}
-	console.error(
-		`[import-remark42] failed: ${err instanceof Error ? err.message : String(err)}`,
-	);
-	process.exit(1);
-});
+	reportPlan(TAG, args.dryRun, plan);
+})().catch((err) => failImport(TAG, err));

--- a/src/admin-ui/pages/operator.ts
+++ b/src/admin-ui/pages/operator.ts
@@ -342,7 +342,7 @@ ${seedCard}
           'x-include-spam': this.includeSpam ? '1' : '0',
           // Only Comentario reads it, and only a non-empty value means
           // anything — sending it blank would still be an empty header.
-          ...(this.spec.domainFlag && this.domain.trim()
+          ...(this.spec.domainFlag &amp;&amp; this.domain.trim()
             ? { 'x-import-domain': this.domain.trim() }
             : {}),
         },

--- a/src/admin-ui/pages/operator.ts
+++ b/src/admin-ui/pages/operator.ts
@@ -287,20 +287,40 @@ ${seedCard}
   dryRun: true,
   includeDeleted: false,
   includeSpam: false,
-  // One card, two sources. The endpoints stay separate on the server —
+  domain: '',
+  // One card, every source. The endpoints stay separate on the server —
   // their format sniffs and error codes differ — but from here the only
-  // things that vary are the URL, the content type and the file filter,
-  // so a second copy of this component would be a second place for the
-  // size cap and the dry-run wiring to drift.
+  // things that vary are the URL, the content type, the file filter and
+  // the CLI line, so a copy of this component per source would be a copy
+  // of the size cap and the dry-run wiring per source too.
+  //
+  // A table rather than a chain of ternaries: with two sources a ternary
+  // reads fine, with three it is four of them that each have to be edited
+  // in lockstep to add a fourth.
+  sources: {
+    disqus: {
+      contentType: 'application/xml',
+      accept: '.xml,.gz,application/xml,text/xml,application/gzip',
+      cli: 'npm run import-disqus -- ./export.xml --dry-run',
+      domainFlag: false,
+    },
+    remark42: {
+      contentType: 'application/x-ndjson',
+      accept: '.json,.jsonl,.gz,application/json,application/gzip',
+      cli: 'npm run import-remark42 -- ./userbackup.gz --dry-run',
+      domainFlag: false,
+    },
+    comentario: {
+      contentType: 'application/json',
+      accept: '.json,.gz,application/json,application/gzip',
+      cli: 'npm run import-comentario -- ./export.json --dry-run',
+      domainFlag: true,
+    },
+  },
+  get spec() { return this.sources[this.source] },
   get endpoint() { return '/admin/api/ops/import-' + this.source },
-  get contentType() {
-    return this.source === 'disqus' ? 'application/xml' : 'application/x-ndjson'
-  },
-  get accept() {
-    return this.source === 'disqus'
-      ? '.xml,.gz,application/xml,text/xml,application/gzip'
-      : '.json,.jsonl,.gz,application/json,application/gzip'
-  },
+  get contentType() { return this.spec.contentType },
+  get accept() { return this.spec.accept },
   async run(file) {
     if (!file) return;
     if (file.size > ${MAX_IMPORT_BYTES}) {
@@ -320,6 +340,11 @@ ${seedCard}
           'x-dry-run': this.dryRun ? '1' : '0',
           'x-include-deleted': this.includeDeleted ? '1' : '0',
           'x-include-spam': this.includeSpam ? '1' : '0',
+          // Only Comentario reads it, and only a non-empty value means
+          // anything — sending it blank would still be an empty header.
+          ...(this.spec.domainFlag && this.domain.trim()
+            ? { 'x-import-domain': this.domain.trim() }
+            : {}),
         },
         body,
       });
@@ -340,6 +365,7 @@ ${seedCard}
       <select x-model="source" :disabled="busy">
         <option value="disqus">Disqus</option>
         <option value="remark42">Remark42</option>
+        <option value="comentario">Comentario / Commento</option>
       </select>
     </label>
   </p>
@@ -355,6 +381,27 @@ ${seedCard}
     where Remark42 kept it, and from its rendered HTML where it did not.
     Pages are reconstructed from comment URLs, because a Remark42 export
     carries no page records.</p>
+  <p class="muted" x-show="source === 'comentario'">Uploads a Comentario
+    export — the single JSON document its admin UI writes, gzipped or not
+    — or a legacy Commento one. The document's own <code>version</code>
+    field picks the reader, so both go here. Idempotent, deduplicated by
+    the source's comment ID. Comentario stores markdown, so bodies come
+    across as the author typed them. What is marked spam is a comment a
+    human moderator rejected; neither product has a spam classifier.</p>
+  <p x-show="spec.domainFlag">
+    <label style="display:inline-flex;gap:0.3rem;align-items:center">
+      Domain (optional)
+      <input type="text" x-model="domain" :disabled="busy"
+             placeholder="domainId UUID, or a host for Commento v1"
+             style="min-width:22rem">
+    </label>
+  </p>
+  <p class="muted" x-show="spec.domainFlag">Both products are multi-site
+    and neither namespaces page paths by site, so an export carrying two
+    domains is refused rather than flattened — two sites'
+    <code>/about</code> would silently become one page here. Leave this
+    blank for a single-domain export; if the import is refused, the error
+    names the domains it found, and you run it once per domain.</p>
   <p>
     <label style="display:inline-flex;gap:0.3rem;align-items:center;margin-right:0.8rem">
       <input type="checkbox" x-model="dryRun"> Dry run (parse + plan only)
@@ -375,9 +422,7 @@ ${seedCard}
   <p style="color:var(--bad)" x-show="error" x-text="error"></p>
   <p class="muted">Max upload: ${MAX_IMPORT_MB} MB, and a gzipped file must
     also stay under ${MAX_IMPORT_MB} MB once expanded. For larger exports use
-    the CLI: <code x-text="source === 'disqus'
-      ? 'npm run import-disqus -- ./export.xml --dry-run'
-      : 'npm run import-remark42 -- ./userbackup.gz --dry-run'"></code>.</p>
+    the CLI: <code x-text="spec.cli"></code>.</p>
 </div>
 `;
 };

--- a/src/lib/import/comentario.ts
+++ b/src/lib/import/comentario.ts
@@ -95,7 +95,9 @@
  *   v1  every anonymous comment shares one sentinel — either 64 zeros or the
  *       literal string `anonymous`, which upstream calls *"a special ugly case
  *       for the anonymous commenter in Commento"*. Keying on it would collapse
- *       every anonymous commenter in the forum onto a single ghost.
+ *       every anonymous commenter in the forum onto a single ghost. A comment
+ *       with no `commenterHex` at all is read the same way: `commenters[]`
+ *       rejects an empty one, so there is no author it could ever name.
  *   v3  the sentinel is the zero UUID, and the unregistered author's real name
  *       lives on the comment as `authorName`. Keying on the sentinel would
  *       throw that name away.
@@ -499,7 +501,13 @@ const toV1Export = (
 	}
 
 	const comments: SourceComment[] = rows.map((c) => {
-		const anonymous = V1_ANONYMOUS_HEXES.has(c.commenterHex);
+		// A missing hex is a third spelling of "nobody": `commenters[]` rejects
+		// an empty one, so it can never resolve to a registered author, and
+		// reading it as registered would emit an author named "anonymous" that
+		// claims not to be — the one shape the rest of the pipeline has no way
+		// to tell from a real account.
+		const anonymous =
+			!c.commenterHex || V1_ANONYMOUS_HEXES.has(c.commenterHex);
 		const commenter = byHex.get(c.commenterHex);
 		const author: SourceAuthor = {
 			name: commenter?.name || "anonymous",
@@ -508,7 +516,7 @@ const toV1Export = (
 			// Anonymous shares one sentinel hex forum-wide, so keying on it
 			// would collapse every anonymous commenter onto one ghost. Fall
 			// through to the core's name+email seed instead.
-			...(anonymous || !c.commenterHex ? {} : { source_id: c.commenterHex }),
+			...(anonymous ? {} : { source_id: c.commenterHex }),
 		};
 		return {
 			source_id: c.commentHex,

--- a/src/lib/import/comentario.ts
+++ b/src/lib/import/comentario.ts
@@ -1,0 +1,644 @@
+/**
+ * Comentario v3 + legacy Commento v1 export adapter (#106).
+ *
+ * Both formats are gzipped JSON with a `version` field at the top level, and
+ * they are the same lineage: Comentario began as a Commento 1.8 fork and its
+ * own importer still reads v1. So one adapter sniffs the version and parses
+ * both, exactly as upstream's `comentarioImport` does.
+ *
+ *   { "version": 1, comments[], commenters[] }              → Commento
+ *   { "version": 3, pages[], comments[], commenters[] }     → Comentario
+ *
+ * Anything else is refused by version number rather than guessed at. Upstream
+ * does the same, and a v2 export does not exist in the wild — v2 was the fork's
+ * transitional line and never had its own export format.
+ *
+ * ## The two formats disagree about where a page lives
+ *
+ * v3 has a real `pages[]` array: a page is a row with its own UUID, a `path`,
+ * an optional `title` and an `isReadonly` flag. v1 has no page records at all —
+ * a page exists only as the `host` + `path` pair repeated on every comment, so
+ * threads are reconstructed by grouping, the way the Remark42 adapter groups on
+ * `locator.url`.
+ *
+ * v1 also files the path under **either** key. Upstream's comment on this is
+ * the whole explanation: *"Commento filed the path under `url`, whereas
+ * Comentario used `path`"* — so v1 comments carry both fields and the reader
+ * takes `path` when set and `url` when not, then forces a single leading
+ * slash. Getting this wrong does not fail loudly; it silently slugs every
+ * thread wrong.
+ *
+ * ## Neither format exports a hostname you can rely on
+ *
+ * A v3 export has no domain record. Pages carry a `domainId` UUID and nothing
+ * else, so the only place a real host ever appears is `comment.url`, which is
+ * a full permalink of the shape `https://host/path#comentario-<uuid>`. The
+ * page link is therefore recovered from the first comment on that page with a
+ * parseable url, minus the fragment; a page with no comments has no link and no
+ * comments to hang off one, so it is not emitted at all.
+ *
+ * v1 is the easier half: `host` is on every comment, so the link is
+ * `https://<host><path>`. The scheme is assumed because v1 does not record
+ * one — `safePostUrl` in the core still gets the last word on what may reach
+ * `posts.url`.
+ *
+ * ## One export is one domain, and that is not enforced by the format
+ *
+ * A v3 export can legitimately contain pages from several domains, and v1
+ * comments can carry several `host` values. Garrul slugs are single-site, so
+ * flattening them collides `/about` from two different sites onto one page
+ * without saying so. The parse therefore **throws** when it sees more than one,
+ * and `comentarioAdapter({ domain })` narrows to a single domain — the v3
+ * `domainId` UUID, or the v1 host — for operators who cannot re-export.
+ *
+ * ## Moderation state
+ *
+ * v3 carries three independent booleans and v1 a state string. Upstream's
+ * mapping is authoritative and is reproduced here:
+ *
+ *   v1  state === "approved"     → approved
+ *       state === "unapproved"   → pending
+ *       anything else            → spam      (Commento's "flagged")
+ *   v3  isDeleted                → deleted
+ *       isPending                → pending
+ *       isApproved               → approved
+ *       neither                  → spam      (moderator-rejected)
+ *
+ * "Rejected" has no separate Garrul status and `spam` is the one that
+ * `include_spam` gates, so a rejected comment stays out by default. It is not a
+ * claim that the comment was spam — it is a claim that the operator already
+ * refused it once.
+ *
+ * ## The v1 deletion trap
+ *
+ * A Commento export's SQL never selects `html` or `deleted`, so `html` is
+ * always `""` and **`deleted` is always `false`** — including for comments that
+ * really were deleted. Deletion elsewhere in Commento rewrites `markdown` to
+ * the literal `[deleted]`, and that sentinel is the only surviving signal.
+ *
+ * Trusting `deleted` therefore imports tombstones as live comments whose body
+ * reads `[deleted]`. Upstream reached the same conclusion and treats all three
+ * as deletion:
+ *
+ *     del := comment.Deleted || comment.Markdown == "" || comment.Markdown == "[deleted]"
+ *
+ * That is adopted verbatim. `isModerator` on a v1 commenter is unselected for
+ * the same reason and is always false, so it is not read at all rather than
+ * read and disbelieved.
+ *
+ * ## Identity
+ *
+ * Registered authors key on the source's own id — `commenterHex` (a sha256 hex)
+ * in v1, the commenter UUID in v3. Anonymous ones deliberately do not, and fall
+ * back to the core's name+email seed:
+ *
+ *   v1  every anonymous comment shares one sentinel — either 64 zeros or the
+ *       literal string `anonymous`, which upstream calls *"a special ugly case
+ *       for the anonymous commenter in Commento"*. Keying on it would collapse
+ *       every anonymous commenter in the forum onto a single ghost.
+ *   v3  the sentinel is the zero UUID, and the unregistered author's real name
+ *       lives on the comment as `authorName`. Keying on the sentinel would
+ *       throw that name away.
+ *
+ * Per the core's contract this choice is permanent for `import_source`
+ * `comentario`: the seed feeds an HMAC, so changing it re-ghosts every
+ * commenter this adapter has ever imported.
+ *
+ * ## Deliberately discarded
+ *
+ * `score`, `direction`, `isSticky`, `countViews`, `countComments`,
+ * `colourIndex`, `hasAvatar`, `avatarUrl`, `websiteUrl`, `provider`,
+ * `federatedIdP`, and the `userModerated` / `userDeleted` / `userEdited`
+ * attribution ids — Garrul has no column for any of them. Votes and scores are
+ * out of scope for every importer per #104.
+ *
+ * `authorIP` and `authorCountry` are dropped as a rule rather than an
+ * oversight. Garrul neither stores nor logs a raw or derived IP, and a v3
+ * export carries the raw one. Nothing in this file reads either field, and a
+ * parse error names a record's id or index, never its contents.
+ */
+import {
+	type ImportAdapter,
+	type ImportOptions,
+	type ImportPlan,
+	MAX_IMPORT_BYTES,
+	type SourceAuthor,
+	type SourceComment,
+	type SourceExport,
+	type SourceStatus,
+	type SourceThread,
+	runImport,
+} from "./core";
+
+/** Export format versions this parser has been read against. */
+const SUPPORTED_VERSIONS = new Set([1, 3]);
+
+/**
+ * Go's zero `time.Time`, which is what both formats emit for an unset
+ * timestamp. It is a valid date, so `Date.parse` accepts it happily and every
+ * comment comes back looking deleted and edited in the year 1.
+ */
+const GO_ZERO_TIME_YEAR = 1;
+
+/** Commento's two spellings of "nobody". */
+const V1_ANONYMOUS_HEXES = new Set([
+	"0".repeat(64),
+	"anonymous",
+]);
+
+/** Comentario's zero UUID stands in for the unregistered author. */
+const V3_ANONYMOUS_ID = "00000000-0000-0000-0000-000000000000";
+
+/** Commento's root sentinel is a word, not an empty string. */
+const V1_ROOT_PARENT = "root";
+
+export type ComentarioV1Comment = {
+	commentHex: string;
+	commenterHex: string;
+	creationDate: string;
+	/** Always false in a real export — see the deletion trap in the header. */
+	deleted: boolean;
+	host: string;
+	markdown: string;
+	/** `"root"` at the top level, never empty and never absent. */
+	parentHex: string;
+	/** Either of these carries the page path; `path` wins when both are set. */
+	path: string;
+	url: string;
+	state: string;
+};
+
+export type ComentarioV1Commenter = {
+	commenterHex: string;
+	email: string;
+	name: string;
+};
+
+export type ComentarioV3Page = {
+	id: string;
+	domainId: string;
+	path: string;
+	/** Absent when the operator never set one and none was scraped. */
+	title?: string | undefined;
+	isReadonly: boolean;
+	createdTime: string;
+};
+
+export type ComentarioV3Comment = {
+	id: string;
+	/** Absent at root — go-swagger omits the empty uuid. */
+	parentId?: string | undefined;
+	pageId: string;
+	markdown: string;
+	isApproved: boolean;
+	isPending: boolean;
+	isDeleted: boolean;
+	createdTime: string;
+	editedTime: string;
+	userCreated: string;
+	/** The unregistered author's name; absent for a registered one. */
+	authorName?: string | undefined;
+	/** Full permalink. The only place a v3 export names a host. */
+	url: string;
+};
+
+export type ComentarioV3Commenter = {
+	id: string;
+	email: string;
+	name: string;
+};
+
+export type ComentarioExport =
+	| {
+			version: 1;
+			comments: ComentarioV1Comment[];
+			commenters: ComentarioV1Commenter[];
+	  }
+	| {
+			version: 3;
+			pages: ComentarioV3Page[];
+			comments: ComentarioV3Comment[];
+			commenters: ComentarioV3Commenter[];
+	  };
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+/** A missing array and an empty one mean the same thing: an empty export. */
+const arr = (v: unknown): Record<string, unknown>[] =>
+	Array.isArray(v) ? v.filter(isObject) : [];
+
+/**
+ * A timestamp in epoch milliseconds, or null when the source did not set one.
+ *
+ * Go's zero time is the sentinel both formats use for "never happened", and it
+ * parses cleanly, so it has to be rejected by value rather than by parse
+ * failure.
+ */
+const parseTime = (s: string): number | null => {
+	if (!s) return null;
+	const t = Date.parse(s);
+	if (!Number.isFinite(t)) return null;
+	if (new Date(t).getUTCFullYear() <= GO_ZERO_TIME_YEAR) return null;
+	return t;
+};
+
+/** Same, but for a field that must produce something. */
+const parseTimeOr = (s: string, fallback: number): number =>
+	parseTime(s) ?? fallback;
+
+/**
+ * The page path a v1 comment belongs to.
+ *
+ * `path` when it is set, `url` when it is not, then exactly one leading slash —
+ * upstream's `comentarioImportV1` does the same three steps in the same order.
+ */
+const v1PagePath = (c: ComentarioV1Comment): string =>
+	`/${(c.path || c.url).replace(/^\/+/, "")}`;
+
+const readV1Comment = (
+	row: Record<string, unknown>,
+	index: number,
+): ComentarioV1Comment => {
+	const commentHex = str(row.commentHex);
+	if (!commentHex) {
+		throw new Error(
+			`commento v1 export: comments[${index}] has no commentHex`,
+		);
+	}
+	const path = str(row.path);
+	const url = str(row.url);
+	if (!path && !url) {
+		throw new Error(
+			`commento v1 export: comments[${index}] has neither path nor url`,
+		);
+	}
+	return {
+		commentHex,
+		commenterHex: str(row.commenterHex),
+		creationDate: str(row.creationDate),
+		deleted: row.deleted === true,
+		host: str(row.host),
+		markdown: str(row.markdown),
+		parentHex: str(row.parentHex),
+		path,
+		url,
+		state: str(row.state),
+	};
+};
+
+const readV3Page = (
+	row: Record<string, unknown>,
+	index: number,
+): ComentarioV3Page => {
+	const id = str(row.id);
+	if (!id) throw new Error(`comentario v3 export: pages[${index}] has no id`);
+	const title = str(row.title);
+	return {
+		id,
+		domainId: str(row.domainId),
+		path: str(row.path),
+		...(title ? { title } : {}),
+		isReadonly: row.isReadonly === true,
+		createdTime: str(row.createdTime),
+	};
+};
+
+const readV3Comment = (
+	row: Record<string, unknown>,
+	index: number,
+): ComentarioV3Comment => {
+	const id = str(row.id);
+	if (!id) throw new Error(`comentario v3 export: comments[${index}] has no id`);
+	const pageId = str(row.pageId);
+	if (!pageId) {
+		throw new Error(`comentario v3 export: comments[${index}] has no pageId`);
+	}
+	const parentId = str(row.parentId);
+	const authorName = str(row.authorName);
+	return {
+		id,
+		// Absent, empty and the zero UUID all mean "root". Only the first occurs
+		// in practice, but a hand-assembled file may carry either of the others.
+		...(parentId && parentId !== V3_ANONYMOUS_ID ? { parentId } : {}),
+		pageId,
+		markdown: str(row.markdown),
+		isApproved: row.isApproved === true,
+		isPending: row.isPending === true,
+		isDeleted: row.isDeleted === true,
+		createdTime: str(row.createdTime),
+		editedTime: str(row.editedTime),
+		userCreated: str(row.userCreated),
+		...(authorName ? { authorName } : {}),
+		url: str(row.url),
+	};
+};
+
+/**
+ * Parse a Comentario or Commento export, dispatching on the declared version.
+ *
+ * The version is read before anything else, because the two shapes share no
+ * field names at all — a v1 parser handed a v3 file produces an export full of
+ * empty strings rather than an error.
+ */
+export const parseComentarioExport = (input: string): ComentarioExport => {
+	if (input.length > MAX_IMPORT_BYTES) {
+		throw new Error(
+			`comentario export too large: ${input.length} > ${MAX_IMPORT_BYTES}`,
+		);
+	}
+
+	let root: unknown;
+	try {
+		root = JSON.parse(input);
+	} catch {
+		// The parser's own message quotes a slice of the input on some engines,
+		// and an export carries IPs and comment bodies. Replace, never append.
+		throw new Error("comentario export: not valid JSON");
+	}
+	if (!isObject(root)) {
+		throw new Error("comentario export: top level is not a JSON object");
+	}
+
+	const version = root.version;
+	if (typeof version !== "number" || !SUPPORTED_VERSIONS.has(version)) {
+		throw new Error(
+			`comentario export: version ${JSON.stringify(version)} is not a format this importer has been read against (expected 1 or 3)`,
+		);
+	}
+
+	if (version === 1) {
+		return {
+			version: 1,
+			comments: arr(root.comments).map(readV1Comment),
+			commenters: arr(root.commenters).map((r, i) => {
+				const commenterHex = str(r.commenterHex);
+				if (!commenterHex) {
+					throw new Error(
+						`commento v1 export: commenters[${i}] has no commenterHex`,
+					);
+				}
+				return { commenterHex, email: str(r.email), name: str(r.name) };
+			}),
+		};
+	}
+
+	return {
+		version: 3,
+		pages: arr(root.pages).map(readV3Page),
+		comments: arr(root.comments).map(readV3Comment),
+		commenters: arr(root.commenters).map((r, i) => {
+			const id = str(r.id);
+			if (!id) {
+				throw new Error(`comentario v3 export: commenters[${i}] has no id`);
+			}
+			return { id, email: str(r.email), name: str(r.name) };
+		}),
+	};
+};
+
+/**
+ * The page URL a v3 comment's permalink points at.
+ *
+ * `comment.url` is `https://host/path#comentario-<uuid>`, so dropping the
+ * fragment leaves the page. Returns null for anything that will not parse,
+ * which keeps a malformed url from becoming a malformed link.
+ */
+const v3PageLink = (commentUrl: string): string | null => {
+	if (!commentUrl) return null;
+	try {
+		const u = new URL(commentUrl);
+		u.hash = "";
+		return u.toString();
+	} catch {
+		return null;
+	}
+};
+
+const v1Status = (c: ComentarioV1Comment): SourceStatus => {
+	// Upstream's three-way test, verbatim. A real export's `deleted` is always
+	// false and its body is the tombstone; a hand-made one may set the flag.
+	if (c.deleted || c.markdown === "" || c.markdown === "[deleted]") {
+		return "deleted";
+	}
+	if (c.state === "approved") return "approved";
+	if (c.state === "unapproved") return "pending";
+	// Commento's "flagged", and anything a later build added.
+	return "spam";
+};
+
+const v3Status = (c: ComentarioV3Comment): SourceStatus => {
+	if (c.isDeleted) return "deleted";
+	if (c.isPending) return "pending";
+	if (c.isApproved) return "approved";
+	// Not approved and not pending is a comment a moderator rejected.
+	return "spam";
+};
+
+/**
+ * Render the identifiers a multi-domain export was refused for.
+ *
+ * The refusal tells an operator to re-run with `--domain=`, which is only
+ * actionable if they know what to pass — and for v3 they cannot work it
+ * out, because a `domainId` is a UUID that appears nowhere but inside the
+ * file. Naming them is the difference between a wall and a next step.
+ *
+ * Safe to put in an error that reaches an admin response body, unlike the
+ * record content every other throw here withholds: these are the
+ * operator's own site identifiers, not commenter data. Capped and sorted
+ * anyway, so a file with a thousand domains produces a message and not a
+ * dump.
+ */
+const listIdentifiers = (values: Set<string>): string => {
+	const sorted = [...values].sort();
+	const shown = sorted.slice(0, 10);
+	return shown.join(", ") + (sorted.length > shown.length ? ", …" : "");
+};
+
+const toV1Export = (
+	exp: Extract<ComentarioExport, { version: 1 }>,
+	domain: string | null,
+): SourceExport => {
+	const rows = domain
+		? exp.comments.filter((c) => c.host === domain)
+		: exp.comments;
+
+	const hosts = new Set(rows.map((c) => c.host));
+	if (hosts.size > 1) {
+		throw new Error(
+			`commento v1 export: ${hosts.size} distinct hosts in one file — Garrul slugs are single-site, so import one host at a time (pass a domain to select one): ${listIdentifiers(hosts)}`,
+		);
+	}
+
+	const byHex = new Map(exp.commenters.map((c) => [c.commenterHex, c]));
+
+	// v1 has no page records. Group on the path and take the earliest comment
+	// on it as the page's creation time — Commento exports nothing better.
+	const threads = new Map<string, SourceThread>();
+	for (const c of rows) {
+		const path = v1PagePath(c);
+		const at = parseTimeOr(c.creationDate, Date.now());
+		const existing = threads.get(path);
+		if (!existing) {
+			threads.set(path, {
+				source_id: path,
+				// v1 records no scheme. https is assumed; `safePostUrl` in the
+				// core still decides what may reach `posts.url`.
+				link: c.host ? `https://${c.host}${path}` : null,
+				// Commento exports no page titles at all.
+				title: null,
+				created_at: at,
+				// No read-only flag in v1 either. Absent, not false: the core
+				// must not read silence as "open".
+			});
+			continue;
+		}
+		if (at < existing.created_at) existing.created_at = at;
+	}
+
+	const comments: SourceComment[] = rows.map((c) => {
+		const anonymous = V1_ANONYMOUS_HEXES.has(c.commenterHex);
+		const commenter = byHex.get(c.commenterHex);
+		const author: SourceAuthor = {
+			name: commenter?.name || "anonymous",
+			email: commenter?.email || null,
+			is_anonymous: anonymous,
+			// Anonymous shares one sentinel hex forum-wide, so keying on it
+			// would collapse every anonymous commenter onto one ghost. Fall
+			// through to the core's name+email seed instead.
+			...(anonymous || !c.commenterHex ? {} : { source_id: c.commenterHex }),
+		};
+		return {
+			source_id: c.commentHex,
+			thread_source_id: v1PagePath(c),
+			// "root" is the sentinel. An unknown hex is left alone: the core
+			// already re-roots a comment whose parent it never saw.
+			parent_source_id:
+				c.parentHex && c.parentHex !== V1_ROOT_PARENT ? c.parentHex : null,
+			created_at: parseTimeOr(c.creationDate, Date.now()),
+			status: v1Status(c),
+			// v1 has no edit timestamp.
+			edited_at: null,
+			body_md: c.markdown,
+			author,
+		};
+	});
+
+	return { threads: [...threads.values()], comments };
+};
+
+const toV3Export = (
+	exp: Extract<ComentarioExport, { version: 3 }>,
+	domain: string | null,
+): SourceExport => {
+	const pages = domain
+		? exp.pages.filter((p) => p.domainId === domain)
+		: exp.pages;
+
+	const domains = new Set(pages.map((p) => p.domainId));
+	if (domains.size > 1) {
+		throw new Error(
+			`comentario v3 export: ${domains.size} distinct domains in one file — Garrul slugs are single-site, so import one domain at a time (pass a domainId to select one): ${listIdentifiers(domains)}`,
+		);
+	}
+
+	const pageById = new Map(pages.map((p) => [p.id, p]));
+	const rows = exp.comments.filter((c) => pageById.has(c.pageId));
+	const byId = new Map(exp.commenters.map((c) => [c.id, c]));
+
+	// The host lives only on a comment permalink, so a page's link is recovered
+	// from the first comment on it that has a parseable one.
+	const linkByPage = new Map<string, string>();
+	for (const c of rows) {
+		if (linkByPage.has(c.pageId)) continue;
+		const link = v3PageLink(c.url);
+		if (link) linkByPage.set(c.pageId, link);
+	}
+
+	// Only pages that actually carry comments are emitted. A v3 export lists
+	// every page the widget has ever been mounted on, including ones with zero
+	// comments; importing those creates empty `posts` rows for pages Garrul
+	// would create on demand anyway, and inflates `pages_total` past what the
+	// operator can see in the widget.
+	const withComments = new Set(rows.map((c) => c.pageId));
+	const threads: SourceThread[] = pages
+		.filter((p) => withComments.has(p.id))
+		.map((p) => ({
+			source_id: p.id,
+			link: linkByPage.get(p.id) ?? null,
+			title: p.title ?? null,
+			created_at: parseTimeOr(p.createdTime, Date.now()),
+			// v3 does record this one, and `isReadonly` is always present.
+			closed: p.isReadonly,
+		}));
+
+	const comments: SourceComment[] = rows.map((c) => {
+		const anonymous = !c.userCreated || c.userCreated === V3_ANONYMOUS_ID;
+		const commenter = byId.get(c.userCreated);
+		const author: SourceAuthor = {
+			// An unregistered author's name is on the comment, not in
+			// `commenters[]`, which is why the sentinel id must not be the key.
+			name: commenter?.name || c.authorName || "anonymous",
+			email: commenter?.email || null,
+			is_anonymous: anonymous,
+			...(anonymous ? {} : { source_id: c.userCreated }),
+		};
+		const created = parseTimeOr(c.createdTime, Date.now());
+		return {
+			source_id: c.id,
+			thread_source_id: c.pageId,
+			parent_source_id: c.parentId ?? null,
+			created_at: created,
+			status: v3Status(c),
+			// Go's zero time already became null in `parseTime`; the core drops
+			// anything not strictly after `created_at`.
+			edited_at: parseTime(c.editedTime),
+			body_md: c.markdown,
+			author,
+		};
+	});
+
+	return { threads, comments };
+};
+
+export type ComentarioAdapterOptions = {
+	/**
+	 * Narrow a multi-domain export to one site: a `domainId` UUID for v3, a
+	 * host for v1. Without it a file carrying more than one is refused rather
+	 * than flattened, because two sites' `/about` pages would silently become
+	 * one Garrul page.
+	 */
+	domain?: string | null;
+};
+
+export const comentarioAdapter = (
+	opts: ComentarioAdapterOptions = {},
+): ImportAdapter => {
+	const domain = opts.domain ?? null;
+	return {
+		// One tag for both versions: they are one lineage, an operator migrating
+		// off Commento is migrating off the same product, and the tag is part of
+		// the `(import_source, import_id)` idempotency key, so it can never be
+		// re-cut once this has shipped.
+		source: "comentario",
+		slugFallbackPrefix: "comentario-",
+		parse(input: string): SourceExport {
+			const exp = parseComentarioExport(input);
+			return exp.version === 1
+				? toV1Export(exp, domain)
+				: toV3Export(exp, domain);
+		},
+	};
+};
+
+export const COMENTARIO_ADAPTER: ImportAdapter = comentarioAdapter();
+
+export const runComentarioImport = (
+	db: D1Database,
+	input: string,
+	secret: string,
+	opts: ImportOptions & ComentarioAdapterOptions = {},
+): Promise<ImportPlan> =>
+	runImport(db, comentarioAdapter({ domain: opts.domain ?? null }), input, secret, opts);

--- a/src/lib/import/comentario.ts
+++ b/src/lib/import/comentario.ts
@@ -459,10 +459,48 @@ const listIdentifiers = (values: Set<string>): string => {
 	return shown.join(", ") + (sorted.length > shown.length ? ", …" : "");
 };
 
+/**
+ * Refuse a domain filter that names nothing in the file.
+ *
+ * The filter is how an operator answers a multi-domain refusal, and the
+ * value they have to retype is a hostname or — for v3 — a UUID they only
+ * ever saw in an error message. Get it wrong and the filter selects no
+ * records at all, which is not an error anywhere downstream: the core
+ * imports an empty export happily and the run reports success having
+ * moved nothing. The operator's next move is then to go looking for a
+ * bug in the importer rather than a typo in their own argument.
+ *
+ * Named identifiers are safe in a message that reaches an admin response
+ * body for the same reason `listIdentifiers` is — they are the operator's
+ * own sites, not commenter data — and so is the rejected value, which the
+ * operator typed.
+ */
+const requireKnownDomain = (
+	message: string,
+	domain: string,
+	available: Set<string>,
+): void => {
+	if (available.has(domain)) return;
+	throw new Error(
+		available.size === 0
+			? `${message} "${domain}", and the file names none at all — nothing would be imported.`
+			: `${message} "${domain}" — nothing would be imported. This file has: ${listIdentifiers(available)}`,
+	);
+};
+
 const toV1Export = (
 	exp: Extract<ComentarioExport, { version: 1 }>,
 	domain: string | null,
 ): SourceExport => {
+	// Truthiness, not `!== null`: the filter below reads an empty value as "no
+	// filter", and `--domain=` on the CLI produces exactly that.
+	if (domain) {
+		requireKnownDomain(
+			"commento v1 export: no comment on host",
+			domain,
+			new Set(exp.comments.map((c) => c.host)),
+		);
+	}
 	const rows = domain
 		? exp.comments.filter((c) => c.host === domain)
 		: exp.comments;
@@ -541,6 +579,15 @@ const toV3Export = (
 	exp: Extract<ComentarioExport, { version: 3 }>,
 	domain: string | null,
 ): SourceExport => {
+	// Truthiness, not `!== null`: the filter below reads an empty value as "no
+	// filter", and `--domain=` on the CLI produces exactly that.
+	if (domain) {
+		requireKnownDomain(
+			"comentario v3 export: no page with domainId",
+			domain,
+			new Set(exp.pages.map((p) => p.domainId)),
+		);
+	}
 	const pages = domain
 		? exp.pages.filter((p) => p.domainId === domain)
 		: exp.pages;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -172,6 +172,7 @@ import {
 	MAX_IMPORT_BYTES,
 	decodeImportInput,
 } from "../lib/import/core";
+import { runComentarioImport } from "../lib/import/comentario";
 import { runDisqusImport } from "../lib/import/disqus";
 import { runRemark42Import } from "../lib/import/remark42";
 import { rerenderBatch, rerenderStats } from "../db/rerender";
@@ -2624,6 +2625,88 @@ admin.post("/api/ops/import-remark42", async (c) => {
 		// The adapter's messages carry a line number and never a line, which
 		// is what makes it safe to hand one back in a response body — a
 		// Remark42 export carries display names and hashed IPs.
+		return c.json({ error: `import_failed:${(err as Error).message}` }, 400);
+	}
+});
+
+// -------------------------- Comentario import ------------------------------
+//
+// Admin-only, same shape as the two routes above, and separate from them
+// for the same reason: the format sniff and the wrong-file error code are
+// exactly what an operator notices, and folding three sources into one
+// route means returning one source's error code for another's file.
+//
+// One route covers both Comentario v3 and legacy Commento v1 — that is an
+// adapter-level distinction, resolved by the document's own `version`
+// field, not an operator-level one. An operator leaving Commento and an
+// operator leaving Comentario are leaving the same product.
+
+admin.post("/api/ops/import-comentario", async (c) => {
+	const user = await requireAdmin(c);
+	if (user instanceof Response) return user;
+
+	const contentLength = Number(c.req.header("content-length") ?? "0");
+	if (contentLength > MAX_IMPORT_BYTES) {
+		return c.json({ error: "too_large" }, 413);
+	}
+	const buf = await c.req.arrayBuffer();
+	if (buf.byteLength === 0) return c.json({ error: "empty_body" }, 400);
+	if (buf.byteLength > MAX_IMPORT_BYTES) {
+		return c.json({ error: "too_large" }, 413);
+	}
+	// Comentario's admin UI offers the export gzipped, so sniff the magic
+	// bytes before the format check below — otherwise every `.gz` is
+	// rejected as not-JSON.
+	let doc: string;
+	try {
+		doc = await decodeImportInput(buf);
+	} catch (err) {
+		if (err instanceof ImportTooLargeError) {
+			return c.json({ error: "too_large" }, 413);
+		}
+		return c.json({ error: "not_comentario_export" }, 400);
+	}
+	// Cheap shape check only. Both versions are a single JSON object whose
+	// first key is `version`; the adapter does the real validation and its
+	// errors name a record position rather than a record, so letting it
+	// speak is safe. This exists so an operator who picks a `.csv` gets a
+	// clear answer instead of a parser message.
+	const head = doc.slice(0, 4096).trimStart();
+	if (!head.startsWith("{") || !head.includes('"version"')) {
+		return c.json({ error: "not_comentario_export" }, 400);
+	}
+
+	const dryRun = c.req.header("x-dry-run") === "1";
+	const includeDeleted = c.req.header("x-include-deleted") === "1";
+	const includeSpam = c.req.header("x-include-spam") === "1";
+	// Both products are multi-site and neither namespaces its page paths by
+	// site, so a two-domain export is refused rather than flattened. This is
+	// the operator's way to say which domain they meant — a `domainId` UUID
+	// for v3, a bare host for v1.
+	const domain = c.req.header("x-import-domain")?.trim() || null;
+
+	const secret = c.env.IP_HASH_SECRET;
+	if (!secret) return c.json({ error: "ip_hash_secret_missing" }, 500);
+
+	try {
+		const plan = await runComentarioImport(c.env.DB, doc, secret, {
+			dry_run: dryRun,
+			include_deleted: includeDeleted,
+			include_spam: includeSpam,
+			domain,
+		});
+		await adminInsertAudit(c.env.DB, {
+			admin_id: user.id,
+			action: "import.comentario",
+			target_kind: "system",
+			target_id: null,
+			meta: { dry_run: dryRun, ...plan },
+		});
+		return c.json({ ok: true, dry_run: dryRun, plan });
+	} catch (err) {
+		// Safe to hand back: the adapter's messages name a record index and
+		// never a record, and a Comentario export carries display names and
+		// email addresses.
 		return c.json({ error: `import_failed:${(err as Error).message}` }, 400);
 	}
 });

--- a/tests/admin-import-endpoint.test.ts
+++ b/tests/admin-import-endpoint.test.ts
@@ -16,11 +16,12 @@
  *   - Rows actually land, so the whole chain — decode, parse, adapter,
  *     core, D1 — is wired together rather than merely type-compatible.
  *
- * Both source endpoints are exercised here rather than in a file each,
+ * Every source endpoint is exercised here rather than in a file each,
  * because the three properties above are properties of the *route shape*,
- * not of either adapter: they were established once for Disqus and a second
- * endpoint that quietly got the order wrong would look identical from the
- * outside. One harness, two sources, so the same six questions get asked.
+ * not of any one adapter: they were established once for Disqus and a
+ * later endpoint that quietly got the order wrong would look identical
+ * from the outside. One harness, every source, so the same questions get
+ * asked each time one is added.
  */
 import { Hono } from "hono";
 import { readFileSync, readdirSync } from "node:fs";
@@ -170,6 +171,7 @@ const uploadTo =
 
 const upload = uploadTo("disqus", "application/xml");
 const uploadJsonl = uploadTo("remark42", "application/x-ndjson");
+const uploadJson = uploadTo("comentario", "application/json");
 
 const commentCount = (): number =>
 	(
@@ -351,5 +353,190 @@ describe("POST /admin/api/ops/import-remark42", () => {
 		const body = (await res.json()) as { error: string };
 		expect(body.error).toContain("line 2");
 		expect(body.error).not.toContain("not json");
+	});
+});
+
+// A minimal Comentario v3 document. Identity-free: invented names on
+// example.com, and UUIDs that are structurally valid but plainly fake.
+const COMENTARIO = JSON.stringify({
+	version: 3,
+	pages: [
+		{
+			id: "p0000000-0000-4000-8000-000000000001",
+			domainId: "d0000000-0000-4000-8000-000000000001",
+			path: "/hello",
+			title: "Hello",
+			isReadonly: false,
+			createdTime: "2026-01-01T00:00:00Z",
+		},
+	],
+	comments: [
+		{
+			id: "c0000000-0000-4000-8000-000000000001",
+			pageId: "p0000000-0000-4000-8000-000000000001",
+			markdown: "first",
+			html: "<p>first</p>",
+			url: "https://example.com/hello#comentario-c0000000-0000-4000-8000-000000000001",
+			userCreated: "u0000000-0000-4000-8000-000000000001",
+			createdTime: "2026-01-01T00:00:00Z",
+			editedTime: "0001-01-01T00:00:00Z",
+			isApproved: true,
+			isPending: false,
+			isDeleted: false,
+		},
+	],
+	commenters: [
+		{
+			id: "u0000000-0000-4000-8000-000000000001",
+			name: "Ada",
+			email: "ada@example.com",
+			createdTime: "2026-01-01T00:00:00Z",
+		},
+	],
+});
+
+describe("POST /admin/api/ops/import-comentario", () => {
+	it("imports a plain JSON upload", async () => {
+		const res = await uploadJson(COMENTARIO);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			plan: { new_comments: number; new_pages: number };
+		};
+		expect(body.plan.new_comments).toBe(1);
+		expect(body.plan.new_pages).toBe(1);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("imports a gzipped export identically", async () => {
+		// Comentario's admin UI offers the download gzipped, so this is the
+		// file an operator actually has. A decode placed after the format
+		// sniff would reject exactly that one.
+		const res = await uploadJson(await gzip(COMENTARIO));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { plan: { new_comments: number } };
+		expect(body.plan.new_comments).toBe(1);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("answers 413 for a decompression bomb rather than inflating it", async () => {
+		const bomb = await gzip("A".repeat(MAX_IMPORT_BYTES + 1024));
+		expect(bomb.byteLength).toBeLessThan(1024 * 1024);
+		const res = await uploadJson(bomb);
+		expect(res.status).toBe(413);
+		expect(await res.json()).toEqual({ error: "too_large" });
+		expect(commentCount()).toBe(0);
+	});
+
+	it("rejects a file that is neither gzip nor a Comentario export", async () => {
+		const res = await uploadJson("just some notes");
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "not_comentario_export" });
+	});
+
+	it("rejects a Disqus export sent to the Comentario endpoint", async () => {
+		// Three upload targets behind one card is three chances to pick the
+		// wrong one, and the sniff has to name the mismatch rather than hand
+		// XML to a JSON parser.
+		const res = await uploadJson(XML);
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "not_comentario_export" });
+	});
+
+	it("is idempotent across a plain and a gzipped upload of the same file", async () => {
+		expect((await uploadJson(COMENTARIO)).status).toBe(200);
+		const res = await uploadJson(await gzip(COMENTARIO));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { plan: { new_comments: number } };
+		expect(body.plan.new_comments).toBe(0);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("writes nothing on a dry run", async () => {
+		const res = await uploadJson(COMENTARIO, { "x-dry-run": "1" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			dry_run: boolean;
+			plan: { new_comments: number };
+		};
+		expect(body.dry_run).toBe(true);
+		expect(body.plan.new_comments).toBe(1);
+		expect(commentCount()).toBe(0);
+	});
+
+	it("refuses a two-domain export, and names the domains rather than a body", async () => {
+		const doc = JSON.parse(COMENTARIO);
+		doc.pages.push({
+			...doc.pages[0],
+			id: "p0000000-0000-4000-8000-000000000002",
+			domainId: "d0000000-0000-4000-8000-000000000002",
+			path: "/other",
+		});
+		const res = await uploadJson(JSON.stringify(doc));
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("2 distinct domains");
+		expect(body.error).not.toContain("first");
+		expect(commentCount()).toBe(0);
+	});
+
+	it("imports one domain of a two-domain export when the header names it", async () => {
+		// The escape hatch the refusal above points at. Without it an
+		// operator with a multi-domain export cannot use this card at all.
+		const doc = JSON.parse(COMENTARIO);
+		doc.pages.push({
+			...doc.pages[0],
+			id: "p0000000-0000-4000-8000-000000000002",
+			domainId: "d0000000-0000-4000-8000-000000000002",
+			path: "/other",
+		});
+		const res = await uploadJson(JSON.stringify(doc), {
+			"x-import-domain": "d0000000-0000-4000-8000-000000000001",
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { plan: { new_pages: number } };
+		expect(body.plan.new_pages).toBe(1);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("reads a legacy Commento v1 document through the same endpoint", async () => {
+		// The version field picks the reader, so both products' exports go to
+		// one route. An operator leaving Commento should not have to know it
+		// is a different format underneath.
+		const v1 = JSON.stringify({
+			version: 1,
+			comments: [
+				{
+					commentHex: "aa11",
+					commenterHex: "bb22",
+					host: "example.com",
+					path: "/hello",
+					url: "",
+					markdown: "first",
+					parentHex: "root",
+					state: "approved",
+					deleted: false,
+					creationDate: "2026-01-01T00:00:00Z",
+				},
+			],
+			commenters: [
+				{ commenterHex: "bb22", name: "Ada", email: "ada@example.com" },
+			],
+		});
+		const res = await uploadJson(v1);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { plan: { new_comments: number } };
+		expect(body.plan.new_comments).toBe(1);
+		expect(commentCount()).toBe(1);
+	});
+
+	it("reports a bad record by position, never by content", async () => {
+		const secret = "a-body-that-must-not-come-back";
+		const res = await uploadJson(
+			`{"version":1,"comments":[{"markdown":"${secret}"}]}`,
+		);
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("comments[0]");
+		expect(body.error).not.toContain(secret);
 	});
 });

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -1220,6 +1220,44 @@ describe("global keyboard shortcuts", () => {
 	});
 });
 
+/**
+ * Evaluate the import card's Alpine `x-data` object.
+ *
+ * The component is a JavaScript object literal living inside a template
+ * literal inside a TypeScript file, so nothing in the build ever parses it
+ * — a typo in a getter is invisible until a browser selects that source.
+ * Pulling it out and running it is the cheapest way to make the build see
+ * it. Only the state and the getters are exercised; `run()` needs a real
+ * fetch and is covered by the endpoint suite instead.
+ */
+type CardData = {
+	source: string;
+	domain: string;
+	spec: { cli: string; domainFlag: boolean; accept: string; contentType: string };
+	endpoint: string;
+	contentType: string;
+	accept: string;
+};
+
+const evalCardData = (html: string): CardData => {
+	// The operator page has several Alpine components; anchor on the one
+	// that owns the source table rather than on the first `x-data` in the
+	// document.
+	const table = html.indexOf("sources: {");
+	expect(table).toBeGreaterThan(-1);
+	const start = html.lastIndexOf('x-data="{', table);
+	expect(start).toBeGreaterThan(-1);
+	const open = html.indexOf("{", start);
+	// The attribute is delimited by the double quote that opens it, and the
+	// body contains only single-quoted strings, so the next `"` ends it.
+	const end = html.indexOf('"', open);
+	const body = html.slice(open, end);
+	// The card is authored as an attribute value, so its `&&` arrives
+	// HTML-escaped; undo that before parsing it as code.
+	const src = body.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+	return new Function(`return (${src})`)() as CardData;
+};
+
 describe("renderOperator — the import card", () => {
 	const html = renderOperator({
 		rerender: {
@@ -1238,10 +1276,42 @@ describe("renderOperator — the import card", () => {
 	// literal, so nothing else in the build would notice a typo in one, and
 	// the symptom would be an import that 404s or that posts XML to the JSONL
 	// route. Assert the pieces the getters are assembled from.
-	it("offers both sources", () => {
+	it("offers every source", () => {
 		expect(html).toContain('x-model="source"');
 		expect(html).toContain('value="disqus"');
 		expect(html).toContain('value="remark42"');
+		expect(html).toContain('value="comentario"');
+	});
+
+	// The <option> list and the `sources` lookup are two lists that have to
+	// agree, and nothing at build time checks that they do. An option with no
+	// table entry makes `spec` undefined, and the card throws on every getter
+	// the moment it is selected — a failure that only shows up in a browser,
+	// on one dropdown value.
+	//
+	// So rather than asserting that the source text contains the right
+	// substrings, evaluate the component's own data object and drive its
+	// getters, once per option the <select> offers. That is the closest this
+	// suite can get to selecting each entry by hand: string assertions pass
+	// happily on a table whose getters throw.
+	it("resolves every getter for every source it offers", () => {
+		const options = [...html.matchAll(/<option value="([^"]+)"/g)].map(
+			(m) => m[1],
+		);
+		expect(options).toEqual(["disqus", "remark42", "comentario"]);
+
+		const data = evalCardData(html);
+		for (const source of options) {
+			data.source = source;
+			expect(data.spec, source).toBeDefined();
+			expect(data.endpoint).toBe(`/admin/api/ops/import-${source}`);
+			// A content type and a file filter that are merely present are
+			// not enough — an empty accept silently accepts everything.
+			expect(data.contentType).toMatch(/^[a-z]+\/[a-z0-9.+-]+$/);
+			expect(data.accept.length).toBeGreaterThan(0);
+			expect(data.spec.cli).toContain(`npm run import-${source}`);
+			expect(typeof data.spec.domainFlag).toBe("boolean");
+		}
 	});
 
 	it("builds the endpoint from the selected source", () => {
@@ -1256,5 +1326,16 @@ describe("renderOperator — the import card", () => {
 	it("names the backup file a Remark42 operator already has", () => {
 		expect(html).toContain("import-remark42");
 		expect(html).toContain("userbackup");
+	});
+
+	// Only Comentario takes one, and it is not decoration: a multi-domain
+	// export is refused outright, so without this field that operator has no
+	// way through the admin UI at all.
+	it("exposes the domain field, and only for the source that reads it", () => {
+		expect(html).toContain('x-model="domain"');
+		expect(html).toContain('x-show="spec.domainFlag"');
+		expect(html).toContain("domainFlag: true");
+		expect(html).toContain("domainFlag: false");
+		expect(html).toContain("x-import-domain");
 	});
 });

--- a/tests/admin-render.test.ts
+++ b/tests/admin-render.test.ts
@@ -1239,6 +1239,14 @@ type CardData = {
 	accept: string;
 };
 
+const ENTITIES: Record<string, string> = {
+	amp: "&",
+	lt: "<",
+	gt: ">",
+	quot: '"',
+	"#39": "'",
+};
+
 const evalCardData = (html: string): CardData => {
 	// The operator page has several Alpine components; anchor on the one
 	// that owns the source table rather than on the first `x-data` in the
@@ -1253,8 +1261,14 @@ const evalCardData = (html: string): CardData => {
 	const end = html.indexOf('"', open);
 	const body = html.slice(open, end);
 	// The card is authored as an attribute value, so its `&&` arrives
-	// HTML-escaped; undo that before parsing it as code.
-	const src = body.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+	// HTML-escaped; undo that before parsing it as code. One pass over all
+	// the entities, not one pass each: chained replaces decode their own
+	// output, so `&amp;lt;` — the escaped *text* `&lt;` — would come back as
+	// a live `<`.
+	const src = body.replace(
+		/&(amp|lt|gt|quot|#39);/g,
+		(_, e: string) => ENTITIES[e] as string,
+	);
 	return new Function(`return (${src})`)() as CardData;
 };
 
@@ -1296,7 +1310,7 @@ describe("renderOperator — the import card", () => {
 	// happily on a table whose getters throw.
 	it("resolves every getter for every source it offers", () => {
 		const options = [...html.matchAll(/<option value="([^"]+)"/g)].map(
-			(m) => m[1],
+			(m) => m[1] as string,
 		);
 		expect(options).toEqual(["disqus", "remark42", "comentario"]);
 

--- a/tests/comentario-import.test.ts
+++ b/tests/comentario-import.test.ts
@@ -385,6 +385,19 @@ describe("COMENTARIO_ADAPTER — Commento v1", () => {
 		},
 	);
 
+	// A third spelling of "nobody", and the one a malformed export produces.
+	// `commenters[]` rejects an empty hex, so it can never name an author;
+	// reading it as registered emitted a commenter called "anonymous" that
+	// claimed not to be one.
+	it("reads a missing commenterHex as anonymous, not as a registered author", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([v1Comment({ commenterHex: "" })], []),
+		);
+		expect(out.comments[0]!.author.is_anonymous).toBe(true);
+		expect(out.comments[0]!.author.source_id).toBeUndefined();
+		expect(out.comments[0]!.author.name).toBe("anonymous");
+	});
+
 	it("passes markdown through and never reads the html field", () => {
 		const out = COMENTARIO_ADAPTER.parse(
 			v1([v1Comment({ markdown: "**bold**", html: "<p>WRONG</p>" })]),

--- a/tests/comentario-import.test.ts
+++ b/tests/comentario-import.test.ts
@@ -1,0 +1,770 @@
+/**
+ * Comentario / Commento importer tests cover:
+ *
+ *   1. Version dispatch — v1 and v3 share no field names, so a file is
+ *      routed on its declared `version` and any other value is refused
+ *      rather than parsed into a document full of empty strings.
+ *   2. The v1 deletion trap — a Commento export never selects `deleted`,
+ *      so the flag is always false and the rewritten `[deleted]` body is
+ *      the only surviving signal. All three of the flag, an empty body
+ *      and the sentinel mean deleted.
+ *   3. Page reconstruction — v3 has real page records, v1 has none and
+ *      groups on host+path, where the path lives under `path` or `url`
+ *      depending on which product wrote the file.
+ *   4. Identity — a registered author keys on the source id, an
+ *      anonymous one deliberately does not: v1 gives every anonymous
+ *      commenter one sentinel hex forum-wide, and v3 keeps the
+ *      unregistered author's real name on the comment as `authorName`.
+ *   5. Go's zero time — both formats emit `0001-01-01T00:00:00Z` for an
+ *      unset timestamp, which parses cleanly, so it has to be rejected
+ *      by value or every comment imports as edited in the year 1.
+ *   6. Single-site safety — an export carrying two domains is refused
+ *      rather than flattened, because two sites' `/about` would collide
+ *      onto one Garrul slug in silence.
+ *
+ * Fixtures are hand-written and identity-free. The shapes were measured
+ * against a real Comentario v3 export and against upstream's own v1
+ * documentation and importer source; the bytes here are ours.
+ *
+ * No Miniflare. Hand-rolled D1 stub with capture, same as the Disqus and
+ * Remark42 suites.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	COMENTARIO_ADAPTER,
+	comentarioAdapter,
+	parseComentarioExport,
+	runComentarioImport,
+} from "../src/lib/import/comentario";
+import { asD1 } from "./helpers/d1";
+
+type Captured = { sql: string; binds: unknown[] };
+
+// Every SELECT misses, so every insert proceeds.
+const makeFreshDb = () => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => ({
+		_binds: [] as unknown[],
+		bind(...args: unknown[]) {
+			this._binds = args;
+			return this;
+		},
+		async first() {
+			captured.push({ sql, binds: this._binds });
+			return null;
+		},
+		async all() {
+			captured.push({ sql, binds: this._binds });
+			return { results: [] };
+		},
+		async run() {
+			captured.push({ sql, binds: this._binds });
+			return { meta: { changes: 1 } };
+		},
+	});
+	return { db: asD1({ prepare: (sql: string) => chain(sql) }), captured };
+};
+
+// A stub where every existence check hits, so a re-run inserts nothing.
+const makeAlreadyImportedDb = () => {
+	const captured: Captured[] = [];
+	const chain = (sql: string) => ({
+		_binds: [] as unknown[],
+		bind(...args: unknown[]) {
+			this._binds = args;
+			return this;
+		},
+		async first() {
+			captured.push({ sql, binds: this._binds });
+			if (sql.includes("FROM comments WHERE import_source")) {
+				return { id: "01HX0000000000000000000001" };
+			}
+			if (sql.includes("FROM posts WHERE slug")) return { slug: "hello" };
+			if (sql.includes("FROM users WHERE provider")) {
+				return { id: "01HU0000000000000000000001" };
+			}
+			return null;
+		},
+		async all() {
+			captured.push({ sql, binds: this._binds });
+			return { results: [] };
+		},
+		async run() {
+			captured.push({ sql, binds: this._binds });
+			return { meta: { changes: 1 } };
+		},
+	});
+	return { db: asD1({ prepare: (sql: string) => chain(sql) }), captured };
+};
+
+const inserts = (captured: Captured[], table: string) =>
+	captured.filter((c) => c.sql.startsWith(`INSERT INTO ${table}`));
+
+const GO_ZERO = "0001-01-01T00:00:00.000Z";
+const V1_ANON_HEX = "0".repeat(64);
+const V3_ANON_ID = "00000000-0000-0000-0000-000000000000";
+
+// ------------------------------- v1 builders -------------------------------
+
+const v1Comment = (over: Record<string, unknown> = {}) => ({
+	commentHex: "aa11",
+	commenterHex: "bb22",
+	creationDate: "2026-08-28T23:19:42.144Z",
+	deleted: false,
+	direction: 0,
+	host: "example.com",
+	html: "",
+	markdown: "hello",
+	parentHex: "root",
+	path: "/hello",
+	url: "",
+	score: 0,
+	state: "approved",
+	...over,
+});
+
+const v1Commenter = (over: Record<string, unknown> = {}) => ({
+	commenterHex: "bb22",
+	email: "ada@example.com",
+	isModerator: false,
+	joinDate: "2026-08-01T00:00:00.000Z",
+	name: "Ada",
+	...over,
+});
+
+const v1 = (
+	comments: Record<string, unknown>[],
+	commenters: Record<string, unknown>[] = [v1Commenter()],
+) => JSON.stringify({ version: 1, comments, commenters });
+
+// ------------------------------- v3 builders -------------------------------
+
+const v3Page = (over: Record<string, unknown> = {}) => ({
+	countComments: 1,
+	countViews: 2,
+	createdTime: "2026-08-23T02:50:54.041Z",
+	domainId: "d0000000-0000-4000-8000-000000000001",
+	id: "p0000000-0000-4000-8000-000000000001",
+	isReadonly: false,
+	path: "/hello",
+	title: "Hello World",
+	...over,
+});
+
+const v3Comment = (over: Record<string, unknown> = {}) => ({
+	createdTime: "2026-08-28T23:19:42.144Z",
+	deletedTime: GO_ZERO,
+	editedTime: GO_ZERO,
+	moderatedTime: GO_ZERO,
+	html: "<p>hello</p>",
+	id: "c0000000-0000-4000-8000-000000000001",
+	isApproved: true,
+	isDeleted: false,
+	isPending: false,
+	isSticky: false,
+	markdown: "hello",
+	pageId: "p0000000-0000-4000-8000-000000000001",
+	score: 0,
+	url: "https://example.com/hello#comentario-c0000000-0000-4000-8000-000000000001",
+	userCreated: "u0000000-0000-4000-8000-000000000001",
+	...over,
+});
+
+const v3Commenter = (over: Record<string, unknown> = {}) => ({
+	colourIndex: 1,
+	createdTime: "2026-08-01T00:00:00.000Z",
+	email: "ada@example.com",
+	hasAvatar: false,
+	id: "u0000000-0000-4000-8000-000000000001",
+	isCommenter: true,
+	isModerator: false,
+	name: "Ada",
+	...over,
+});
+
+const v3 = (
+	comments: Record<string, unknown>[],
+	pages: Record<string, unknown>[] = [v3Page()],
+	commenters: Record<string, unknown>[] = [v3Commenter()],
+) => JSON.stringify({ version: 3, pages, comments, commenters });
+
+// -------------------------- parseComentarioExport --------------------------
+
+describe("parseComentarioExport", () => {
+	it("dispatches on the declared version", () => {
+		expect(parseComentarioExport(v1([v1Comment()])).version).toBe(1);
+		expect(parseComentarioExport(v3([v3Comment()])).version).toBe(3);
+	});
+
+	// v2 was the fork's transitional line and never had its own export format,
+	// so anything but 1 or 3 is refused rather than guessed at.
+	it("refuses a version it has not been read against", () => {
+		expect(() => parseComentarioExport(JSON.stringify({ version: 481 }))).toThrow(
+			/version 481 is not a format/,
+		);
+		expect(() => parseComentarioExport(JSON.stringify({ version: 2 }))).toThrow(
+			/expected 1 or 3/,
+		);
+	});
+
+	it("refuses a file with no version at all", () => {
+		expect(() => parseComentarioExport(JSON.stringify({ comments: [] }))).toThrow(
+			/is not a format/,
+		);
+	});
+
+	it("refuses input that is not a JSON object", () => {
+		expect(() => parseComentarioExport("not json")).toThrow(/not valid JSON/);
+		expect(() => parseComentarioExport("[]")).toThrow(/not a JSON object/);
+	});
+
+	// Upstream's own empty-export fixture is literally `{"version":1}` — the
+	// arrays are omitted, not empty.
+	it("treats missing arrays as an empty export", () => {
+		const p1 = parseComentarioExport(JSON.stringify({ version: 1 }));
+		expect(p1.version === 1 && p1.comments).toEqual([]);
+		const p3 = parseComentarioExport(JSON.stringify({ version: 3 }));
+		expect(p3.version === 3 && p3.pages).toEqual([]);
+	});
+
+	it("rejects a v1 comment with no commentHex", () => {
+		expect(() =>
+			parseComentarioExport(v1([v1Comment({ commentHex: "" })])),
+		).toThrow(/comments\[0\] has no commentHex/);
+	});
+
+	it("rejects a v1 comment with neither path nor url", () => {
+		expect(() =>
+			parseComentarioExport(v1([v1Comment({ path: "", url: "" })])),
+		).toThrow(/comments\[0\] has neither path nor url/);
+	});
+
+	it("rejects a v3 comment with no pageId", () => {
+		expect(() =>
+			parseComentarioExport(v3([v3Comment({ pageId: "" })])),
+		).toThrow(/comments\[0\] has no pageId/);
+	});
+
+	// A malformed export is exactly the case where the content is unclassified
+	// and may carry an authorIP or a private body, so an error names the record
+	// position and never the record.
+	it("never puts record content in a parse error", () => {
+		const secret = "topsecret-body-that-must-not-leak";
+		let msg = "";
+		try {
+			parseComentarioExport(`{"version":1,"comments":[{"markdown":"${secret}"}]}`);
+		} catch (e) {
+			msg = (e as Error).message;
+		}
+		expect(msg).toMatch(/comments\[0\]/);
+		expect(msg).not.toContain(secret);
+	});
+
+	it("does not echo the input when the JSON itself is malformed", () => {
+		const secret = "another-secret-body";
+		let msg = "";
+		try {
+			parseComentarioExport(`{"version":1,"comments":["${secret}"`);
+		} catch (e) {
+			msg = (e as Error).message;
+		}
+		expect(msg).toBe("comentario export: not valid JSON");
+		expect(msg).not.toContain(secret);
+	});
+});
+
+// ------------------------------ v1 normalising -----------------------------
+
+describe("COMENTARIO_ADAPTER — Commento v1", () => {
+	it("reconstructs a page from host and path, since v1 has no page records", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([
+				v1Comment({ commentHex: "a", creationDate: "2026-08-28T10:00:00.000Z" }),
+				v1Comment({ commentHex: "b", creationDate: "2026-08-28T09:00:00.000Z" }),
+			]),
+		);
+		expect(out.threads).toHaveLength(1);
+		expect(out.threads[0]!.source_id).toBe("/hello");
+		expect(out.threads[0]!.link).toBe("https://example.com/hello");
+		// Commento exports no page titles at all.
+		expect(out.threads[0]!.title).toBeNull();
+		// The earliest comment on the page dates it — there is nothing better.
+		expect(new Date(out.threads[0]!.created_at).toISOString()).toBe(
+			"2026-08-28T09:00:00.000Z",
+		);
+	});
+
+	// Upstream: "Commento filed the path under `url`, whereas Comentario used
+	// `path`". Getting this wrong slugs every thread wrong, silently.
+	it("falls back to url when path is empty, and forces one leading slash", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([v1Comment({ path: "", url: "posts/one" })]),
+		);
+		expect(out.threads[0]!.source_id).toBe("/posts/one");
+		expect(out.comments[0]!.thread_source_id).toBe("/posts/one");
+	});
+
+	it("collapses repeated leading slashes rather than making a second page", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([
+				v1Comment({ commentHex: "a", path: "/hello" }),
+				v1Comment({ commentHex: "b", path: "///hello" }),
+			]),
+		);
+		expect(out.threads).toHaveLength(1);
+	});
+
+	// "root" is a word here, not an empty string — the mistake costs the whole
+	// thread shape, because every root comment would claim a parent named root.
+	it("maps the literal root sentinel to a null parent", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([
+				v1Comment({ commentHex: "a", parentHex: "root" }),
+				v1Comment({ commentHex: "b", parentHex: "a" }),
+			]),
+		);
+		expect(out.comments[0]!.parent_source_id).toBeNull();
+		expect(out.comments[1]!.parent_source_id).toBe("a");
+	});
+
+	it("maps Commento's state vocabulary onto Garrul's", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([
+				v1Comment({ commentHex: "a", state: "approved" }),
+				v1Comment({ commentHex: "b", state: "unapproved" }),
+				v1Comment({ commentHex: "c", state: "flagged" }),
+			]),
+		);
+		expect(out.comments.map((c) => c.status)).toEqual([
+			"approved",
+			"pending",
+			"spam",
+		]);
+	});
+
+	// The trap: a Commento export's SQL never selects `deleted`, so the flag is
+	// always false even for comments that really were deleted. The rewritten
+	// body is the only signal left, and upstream treats all three as deletion.
+	it("treats the flag, an empty body and the [deleted] sentinel as deleted", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([
+				v1Comment({ commentHex: "a", deleted: true }),
+				v1Comment({ commentHex: "b", markdown: "" }),
+				v1Comment({ commentHex: "c", markdown: "[deleted]" }),
+				v1Comment({ commentHex: "d", markdown: "still here" }),
+			]),
+		);
+		expect(out.comments.map((c) => c.status)).toEqual([
+			"deleted",
+			"deleted",
+			"deleted",
+			"approved",
+		]);
+	});
+
+	it("keys a registered author on the source hex", () => {
+		const out = COMENTARIO_ADAPTER.parse(v1([v1Comment()]));
+		expect(out.comments[0]!.author.source_id).toBe("bb22");
+		expect(out.comments[0]!.author.is_anonymous).toBe(false);
+		expect(out.comments[0]!.author.name).toBe("Ada");
+		expect(out.comments[0]!.author.email).toBe("ada@example.com");
+	});
+
+	// Both spellings collapse every anonymous commenter in the forum onto one
+	// sentinel, so keying on it would merge them into a single ghost. The core's
+	// name+email seed keeps them apart instead.
+	it.each([V1_ANON_HEX, "anonymous"])(
+		"does not key an anonymous author on the %s sentinel",
+		(hex) => {
+			const out = COMENTARIO_ADAPTER.parse(
+				v1([v1Comment({ commenterHex: hex })], []),
+			);
+			expect(out.comments[0]!.author.source_id).toBeUndefined();
+			expect(out.comments[0]!.author.is_anonymous).toBe(true);
+			expect(out.comments[0]!.author.name).toBe("anonymous");
+		},
+	);
+
+	it("passes markdown through and never reads the html field", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v1([v1Comment({ markdown: "**bold**", html: "<p>WRONG</p>" })]),
+		);
+		expect(out.comments[0]!.body_md).toBe("**bold**");
+	});
+
+	it("has no edit timestamp to carry", () => {
+		const out = COMENTARIO_ADAPTER.parse(v1([v1Comment()]));
+		expect(out.comments[0]!.edited_at).toBeNull();
+	});
+
+	// Garrul slugs are single-site. Flattening two hosts would silently merge
+	// two different sites' pages that happen to share a path.
+	it("refuses an export carrying more than one host, and names them", () => {
+		// The refusal points at --domain=, which is only actionable if the
+		// operator is told what to pass.
+		expect(() =>
+			COMENTARIO_ADAPTER.parse(
+				v1([
+					v1Comment({ commentHex: "a", host: "one.example" }),
+					v1Comment({ commentHex: "b", host: "two.example" }),
+				]),
+			),
+		).toThrow(/2 distinct hosts in one file.*one\.example, two\.example/);
+	});
+
+	it("narrows a multi-host export when a domain is supplied", () => {
+		const out = comentarioAdapter({ domain: "one.example" }).parse(
+			v1([
+				v1Comment({ commentHex: "a", host: "one.example" }),
+				v1Comment({ commentHex: "b", host: "two.example" }),
+			]),
+		);
+		expect(out.comments).toHaveLength(1);
+		expect(out.comments[0]!.source_id).toBe("a");
+	});
+});
+
+// ------------------------------ v3 normalising -----------------------------
+
+describe("COMENTARIO_ADAPTER — Comentario v3", () => {
+	it("takes pages from the page records", () => {
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment()]));
+		expect(out.threads).toHaveLength(1);
+		expect(out.threads[0]!.title).toBe("Hello World");
+		expect(out.threads[0]!.closed).toBe(false);
+		expect(new Date(out.threads[0]!.created_at).toISOString()).toBe(
+			"2026-08-23T02:50:54.041Z",
+		);
+	});
+
+	it("carries the read-only flag onto the page", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([v3Comment()], [v3Page({ isReadonly: true })]),
+		);
+		expect(out.threads[0]!.closed).toBe(true);
+	});
+
+	it("leaves an absent page title null rather than inventing one", () => {
+		const page = v3Page();
+		delete (page as Record<string, unknown>).title;
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment()], [page]));
+		expect(out.threads[0]!.title).toBeNull();
+	});
+
+	// A v3 export has no domain record at all: pages carry a `domainId` UUID
+	// and the only place a real host ever appears is the comment permalink.
+	it("recovers the page link from a comment permalink, minus the fragment", () => {
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment()]));
+		expect(out.threads[0]!.link).toBe("https://example.com/hello");
+	});
+
+	it("leaves the link null when no comment carries a parseable url", () => {
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment({ url: "" })]));
+		expect(out.threads[0]!.link).toBeNull();
+	});
+
+	// A v3 export lists every page the widget was ever mounted on. Importing the
+	// empty ones creates `posts` rows Garrul would have created on demand and
+	// inflates pages_total past anything the operator can see.
+	it("does not emit a page that carries no comments", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3(
+				[v3Comment()],
+				[
+					v3Page(),
+					v3Page({
+						id: "p0000000-0000-4000-8000-000000000002",
+						path: "/empty",
+						countComments: 0,
+					}),
+				],
+			),
+		);
+		expect(out.threads).toHaveLength(1);
+		expect(out.threads[0]!.source_id).toBe("p0000000-0000-4000-8000-000000000001");
+	});
+
+	it("treats an absent parentId as root", () => {
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment()]));
+		expect(out.comments[0]!.parent_source_id).toBeNull();
+	});
+
+	it("carries a parentId when the comment is a reply", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([
+				v3Comment(),
+				v3Comment({
+					id: "c0000000-0000-4000-8000-000000000002",
+					parentId: "c0000000-0000-4000-8000-000000000001",
+				}),
+			]),
+		);
+		expect(out.comments[1]!.parent_source_id).toBe(
+			"c0000000-0000-4000-8000-000000000001",
+		);
+	});
+
+	it("maps the three moderation booleans onto Garrul's statuses", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([
+				v3Comment({ id: "c1", isApproved: true }),
+				v3Comment({ id: "c2", isApproved: false, isPending: true }),
+				v3Comment({ id: "c3", isDeleted: true }),
+				// Neither approved nor pending is a comment a moderator rejected.
+				v3Comment({ id: "c4", isApproved: false, isPending: false }),
+			]),
+		);
+		expect(out.comments.map((c) => c.status)).toEqual([
+			"approved",
+			"pending",
+			"deleted",
+			"spam",
+		]);
+	});
+
+	// Go's zero time parses cleanly, so it has to be rejected by value. Left
+	// alone it marks every imported comment as edited in the year 1.
+	it("reads Go's zero time as unset, not as an edit", () => {
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment({ editedTime: GO_ZERO })]));
+		expect(out.comments[0]!.edited_at).toBeNull();
+	});
+
+	it("keeps a real edit timestamp", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([v3Comment({ editedTime: "2026-08-29T01:02:03.000Z" })]),
+		);
+		expect(new Date(out.comments[0]!.edited_at!).toISOString()).toBe(
+			"2026-08-29T01:02:03.000Z",
+		);
+	});
+
+	it("keys a registered author on the commenter uuid", () => {
+		const out = COMENTARIO_ADAPTER.parse(v3([v3Comment()]));
+		expect(out.comments[0]!.author.source_id).toBe(
+			"u0000000-0000-4000-8000-000000000001",
+		);
+		expect(out.comments[0]!.author.is_anonymous).toBe(false);
+	});
+
+	// The unregistered author's real name is on the comment, not in
+	// commenters[]. Keying on the zero-uuid sentinel would throw it away and
+	// merge every unregistered author onto one ghost.
+	it("takes an unregistered author's name from the comment, and does not key on the sentinel", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([v3Comment({ userCreated: V3_ANON_ID, authorName: "Grace" })]),
+		);
+		expect(out.comments[0]!.author.name).toBe("Grace");
+		expect(out.comments[0]!.author.source_id).toBeUndefined();
+		expect(out.comments[0]!.author.is_anonymous).toBe(true);
+		expect(out.comments[0]!.author.email).toBeNull();
+	});
+
+	it("keeps two differently-named unregistered authors apart", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([
+				v3Comment({ id: "c1", userCreated: V3_ANON_ID, authorName: "Grace" }),
+				v3Comment({ id: "c2", userCreated: V3_ANON_ID, authorName: "Alan" }),
+			]),
+		);
+		expect(out.comments.map((c) => c.author.name)).toEqual(["Grace", "Alan"]);
+	});
+
+	it("passes markdown through and never reads the html field", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([v3Comment({ markdown: "_it_", html: "<p>WRONG</p>" })]),
+		);
+		expect(out.comments[0]!.body_md).toBe("_it_");
+	});
+
+	it("drops a comment whose page is not in the export", () => {
+		const out = COMENTARIO_ADAPTER.parse(
+			v3([v3Comment({ pageId: "p0000000-0000-4000-8000-000000000009" })]),
+		);
+		expect(out.comments).toHaveLength(0);
+		expect(out.threads).toHaveLength(0);
+	});
+
+	it("refuses an export carrying more than one domain", () => {
+		expect(() =>
+			COMENTARIO_ADAPTER.parse(
+				v3(
+					[v3Comment()],
+					[
+						v3Page(),
+						v3Page({
+							id: "p0000000-0000-4000-8000-000000000002",
+							domainId: "d0000000-0000-4000-8000-000000000002",
+						}),
+					],
+				),
+			),
+		).toThrow(
+			/2 distinct domains in one file.*d0000000-0000-4000-8000-000000000001, d0000000-0000-4000-8000-000000000002/,
+		);
+	});
+
+	// A v3 domainId appears nowhere but inside the file, so without this the
+	// operator has no way to discover the value the message tells them to
+	// pass. The list is capped so a pathological file is not a dump.
+	it("caps the list of identifiers it names", () => {
+		const pages = Array.from({ length: 30 }, (_, i) =>
+			v3Page({
+				id: `p0000000-0000-4000-8000-0000000000${String(i).padStart(2, "0")}`,
+				domainId: `d0000000-0000-4000-8000-0000000000${String(i).padStart(2, "0")}`,
+			}),
+		);
+		let msg = "";
+		try {
+			COMENTARIO_ADAPTER.parse(v3([v3Comment()], pages));
+		} catch (e) {
+			msg = (e as Error).message;
+		}
+		expect(msg).toContain("30 distinct domains");
+		// The list is the tail after the last colon; the prose before it has
+		// commas of its own.
+		const listed = msg.slice(msg.lastIndexOf(": ") + 2).split(", ");
+		expect(listed).toHaveLength(11); // 10 identifiers plus the ellipsis
+		expect(listed.at(-1)).toBe("…");
+	});
+
+	it("narrows a multi-domain export when a domainId is supplied", () => {
+		const out = comentarioAdapter({
+			domain: "d0000000-0000-4000-8000-000000000001",
+		}).parse(
+			v3(
+				[v3Comment()],
+				[
+					v3Page(),
+					v3Page({
+						id: "p0000000-0000-4000-8000-000000000002",
+						domainId: "d0000000-0000-4000-8000-000000000002",
+					}),
+				],
+			),
+		);
+		expect(out.threads).toHaveLength(1);
+	});
+});
+
+// ------------------------------ adapter identity ---------------------------
+
+describe("COMENTARIO_ADAPTER identity", () => {
+	// The tag is half of the (import_source, import_id) idempotency key, so it
+	// can never be re-cut once this has shipped — including across the two
+	// versions, which are one product lineage and one migration story.
+	it("tags both versions with one source", () => {
+		expect(COMENTARIO_ADAPTER.source).toBe("comentario");
+		expect(comentarioAdapter({ domain: "x" }).source).toBe("comentario");
+	});
+
+	it("has its own slug fallback prefix", () => {
+		expect(COMENTARIO_ADAPTER.slugFallbackPrefix).toBe("comentario-");
+	});
+});
+
+// ------------------------------- runImport ---------------------------------
+
+describe("runComentarioImport", () => {
+	it("imports a v3 export end to end", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runComentarioImport(db, v3([v3Comment()]), "secret");
+		expect(plan.pages_total).toBe(1);
+		expect(plan.comments_total).toBe(1);
+		expect(plan.new_comments).toBe(1);
+		expect(inserts(captured, "comments")).toHaveLength(1);
+	});
+
+	it("imports a v1 export end to end", async () => {
+		const { db, captured } = makeFreshDb();
+		const plan = await runComentarioImport(db, v1([v1Comment()]), "secret");
+		expect(plan.pages_total).toBe(1);
+		expect(plan.new_comments).toBe(1);
+		expect(inserts(captured, "comments")).toHaveLength(1);
+	});
+
+	// Idempotency is the core's, via the partial unique index on
+	// (import_source, import_id). Pinned here because the source tag is this
+	// adapter's contribution to that key.
+	it("inserts nothing on a re-run of the same export", async () => {
+		const { db, captured } = makeAlreadyImportedDb();
+		const plan = await runComentarioImport(db, v3([v3Comment()]), "secret");
+		expect(plan.new_comments).toBe(0);
+		expect(inserts(captured, "comments")).toHaveLength(0);
+	});
+
+	it("two commenters sharing a display name stay two ghosts", async () => {
+		const { db } = makeFreshDb();
+		const plan = await runComentarioImport(
+			db,
+			v3(
+				[
+					v3Comment({ id: "c1", userCreated: "u0000000-0000-4000-8000-00000000000a" }),
+					v3Comment({ id: "c2", userCreated: "u0000000-0000-4000-8000-00000000000b" }),
+				],
+				[v3Page()],
+				[
+					v3Commenter({ id: "u0000000-0000-4000-8000-00000000000a", name: "Sam", email: "" }),
+					v3Commenter({ id: "u0000000-0000-4000-8000-00000000000b", name: "Sam", email: "" }),
+				],
+			),
+			"secret",
+		);
+		expect(plan.new_users).toBe(2);
+	});
+
+	it("one commenter under two names stays one ghost", async () => {
+		const { db } = makeFreshDb();
+		const plan = await runComentarioImport(
+			db,
+			v3(
+				[
+					v3Comment({ id: "c1" }),
+					v3Comment({ id: "c2" }),
+				],
+				[v3Page()],
+				[v3Commenter()],
+			),
+			"secret",
+		);
+		expect(plan.new_users).toBe(1);
+	});
+
+	// `pending` is never gated: a comment awaiting moderation is work the
+	// operator has not done, not junk. Deleted and spam are.
+	it("keeps pending comments and drops deleted and rejected ones by default", async () => {
+		const { db } = makeFreshDb();
+		const plan = await runComentarioImport(
+			db,
+			v3([
+				v3Comment({ id: "c1" }),
+				v3Comment({ id: "c2", isApproved: false, isPending: true }),
+				v3Comment({ id: "c3", isDeleted: true }),
+				v3Comment({ id: "c4", isApproved: false, isPending: false }),
+			]),
+			"secret",
+		);
+		expect(plan.skipped_deleted).toBe(1);
+		expect(plan.skipped_spam).toBe(1);
+		expect(plan.new_comments).toBe(2);
+	});
+
+	it("passes the domain filter through to the adapter", async () => {
+		const { db } = makeFreshDb();
+		const plan = await runComentarioImport(
+			db,
+			v3(
+				[v3Comment()],
+				[
+					v3Page(),
+					v3Page({
+						id: "p0000000-0000-4000-8000-000000000002",
+						domainId: "d0000000-0000-4000-8000-000000000002",
+					}),
+				],
+			),
+			"secret",
+			{ domain: "d0000000-0000-4000-8000-000000000001" },
+		);
+		expect(plan.pages_total).toBe(1);
+	});
+});

--- a/tests/comentario-import.test.ts
+++ b/tests/comentario-import.test.ts
@@ -435,6 +435,31 @@ describe("COMENTARIO_ADAPTER — Commento v1", () => {
 		expect(out.comments).toHaveLength(1);
 		expect(out.comments[0]!.source_id).toBe("a");
 	});
+
+	// A filter that selects nothing is not an error anywhere downstream — the
+	// core imports an empty export and the run reports success — so a typo in
+	// the value the refusal told the operator to pass looks like a working
+	// import that moved zero rows.
+	it("refuses a host filter that names nothing, and names what would work", () => {
+		expect(() =>
+			comentarioAdapter({ domain: "typo.example" }).parse(
+				v1([
+					v1Comment({ commentHex: "a", host: "one.example" }),
+					v1Comment({ commentHex: "b", host: "two.example" }),
+				]),
+			),
+		).toThrow(/no comment on host "typo\.example".*one\.example, two\.example/);
+	});
+
+	// `--domain=` with nothing after it reaches the adapter as an empty
+	// string. That is an operator saying "every domain", not a filter that
+	// matches nothing, so it must not trip the refusal above.
+	it("reads an empty domain as no filter at all", () => {
+		const out = comentarioAdapter({ domain: "" }).parse(
+			v1([v1Comment({ commentHex: "a", host: "one.example" })]),
+		);
+		expect(out.comments).toHaveLength(1);
+	});
 });
 
 // ------------------------------ v3 normalising -----------------------------
@@ -656,6 +681,16 @@ describe("COMENTARIO_ADAPTER — Comentario v3", () => {
 			),
 		);
 		expect(out.threads).toHaveLength(1);
+	});
+
+	it("refuses a domainId filter that names nothing", () => {
+		expect(() =>
+			comentarioAdapter({
+				domain: "d0000000-0000-4000-8000-000000000009",
+			}).parse(v3([v3Comment()], [v3Page()])),
+		).toThrow(
+			/no page with domainId "d0000000-0000-4000-8000-000000000009".*d0000000-0000-4000-8000-000000000001/,
+		);
 	});
 });
 

--- a/tests/import-cli.test.ts
+++ b/tests/import-cli.test.ts
@@ -1,0 +1,209 @@
+/**
+ * scripts/import-cli.ts — the SQL assembly behind `npm run import-<source>`.
+ *
+ * This code had no tests while it was three inline copies, which is the
+ * wrong way round: it is the only place in the project that builds SQL by
+ * string substitution rather than by binding, over values parsed out of an
+ * untrusted export. It does that because `wrangler d1 execute` takes only
+ * `--command` and `--file` — there is no parameter-binding flag, so the SQL
+ * text is the entire interface to D1 from a CLI.
+ *
+ * What is pinned here is therefore the boundary: a value either reaches D1
+ * as exactly itself, or the run stops. Approximately-right SQL is the one
+ * outcome that must not be reachable, because it is the one that writes
+ * wrong rows and reports success.
+ *
+ * Not covered: `wranglerD1`, which shells out to a real wrangler, and
+ * `parseImportArgs` / `requireSecret`, which call process.exit.
+ */
+import { describe, expect, it } from "vitest";
+import { BindError, inline, parseRows, resolve } from "../scripts/import-cli";
+
+describe("inline", () => {
+	it("renders null and undefined as SQL NULL", () => {
+		expect(inline(null, 1)).toBe("NULL");
+		expect(inline(undefined, 1)).toBe("NULL");
+	});
+
+	it("renders a finite number bare", () => {
+		expect(inline(0, 1)).toBe("0");
+		expect(inline(-1.5, 1)).toBe("-1.5");
+		expect(inline(1767225600000, 1)).toBe("1767225600000");
+	});
+
+	// String(NaN) is `NaN` and String(Infinity) is `Infinity` — bare
+	// identifiers to SQLite, not values, so the statement either errors or
+	// resolves to something else entirely.
+	it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+		"refuses the non-finite number %p",
+		(n) => {
+			expect(() => inline(n, 3)).toThrow(BindError);
+			expect(() => inline(n, 3)).toThrow(/bind 3: non-finite/);
+		},
+	);
+
+	it("quotes a plain string", () => {
+		expect(inline("hello", 1)).toBe("'hello'");
+	});
+
+	// The whole escape: SQLite doubles a quote and recognizes no backslash
+	// escapes, so a backslash is data and `''` closes the hole completely.
+	it("escapes a quote by doubling it", () => {
+		expect(inline("it's", 1)).toBe("'it''s'");
+		expect(inline("''", 1)).toBe("''''''");
+	});
+
+	it("leaves a backslash alone, because SQLite has no backslash escape", () => {
+		expect(inline("a\\'b", 1)).toBe("'a\\''b'");
+	});
+
+	// The classic injection attempt, and the reason the doubling above has to
+	// be exactly right: the quote closes, the payload becomes a second
+	// statement. Doubled, it is one literal containing a semicolon — which
+	// wrangler's quote-aware splitter will not break on either.
+	it("neutralises a statement-terminating payload", () => {
+		const out = inline("x'; DROP TABLE comments; --", 1);
+		expect(out).toBe("'x''; DROP TABLE comments; --'");
+		// One opening quote, one closing quote, everything between doubled.
+		expect(out.startsWith("'")).toBe(true);
+		expect(out.endsWith("'")).toBe(true);
+		expect((out.slice(1, -1).match(/'/g) ?? []).length % 2).toBe(0);
+	});
+
+	// argv is NUL-terminated, so a NUL truncates the SQL on its way to
+	// wrangler — silently, and at a position the value's author picks.
+	// Truncation is worse than refusal: the prefix is still valid SQL.
+	it("refuses a NUL byte rather than letting it truncate the statement", () => {
+		expect(() => inline("a\u0000b", 7)).toThrow(BindError);
+		expect(() => inline("a\u0000b", 7)).toThrow(/bind 7: NUL byte/);
+	});
+
+	// These used to reach String() and produce `true`, `[object Object]` and
+	// worse — all of them syntactically fine, none of them the value.
+	it.each([
+		[true, "boolean"],
+		[{ a: 1 }, "object"],
+		[[1, 2], "object"],
+		[() => {}, "function"],
+		[1n, "bigint"],
+	])("refuses %p rather than stringifying it", (v, kind) => {
+		expect(() => inline(v, 2)).toThrow(BindError);
+		expect(() => inline(v, 2)).toThrow(new RegExp(`unsupported type ${kind}`));
+	});
+
+	it("names the bind position in every error, and never the value", () => {
+		const secret = "unmistakable-secret-value";
+		let msg = "";
+		try {
+			inline({ body: secret }, 4);
+		} catch (e) {
+			msg = (e as Error).message;
+		}
+		expect(msg).toContain("bind 4");
+		expect(msg).not.toContain(secret);
+	});
+});
+
+describe("resolve", () => {
+	it("substitutes placeholders left to right", () => {
+		expect(resolve("SELECT ?, ?, ?", ["a", 1, null])).toBe(
+			"SELECT 'a', 1, NULL",
+		);
+	});
+
+	// `String.replace` does not rescan its own output. If it did, a `?` inside
+	// a comment body would consume the next bind and every value after it
+	// would land in the wrong column.
+	it("does not let a ? inside a value consume the next bind", () => {
+		expect(resolve("INSERT VALUES (?, ?)", ["really?", "next"])).toBe(
+			"INSERT VALUES ('really?', 'next')",
+		);
+	});
+
+	// Both directions are bugs, and the surplus-placeholder one used to be
+	// invisible: it read `undefined`, became NULL, and wrote a row with a
+	// hole in it instead of failing.
+	it("refuses more placeholders than binds", () => {
+		expect(() => resolve("SELECT ?, ?", ["only"])).toThrow(
+			/2 placeholder\(s\), 1 bound value\(s\)/,
+		);
+	});
+
+	it("refuses more binds than placeholders", () => {
+		expect(() => resolve("SELECT ?", ["a", "b"])).toThrow(
+			/1 placeholder\(s\), 2 bound value\(s\)/,
+		);
+	});
+
+	// The mismatch message quotes the SQL, which is ours, but it is clamped
+	// so an inlined value from an earlier resolve can't ride along at length.
+	it("clamps the SQL it quotes in a mismatch message", () => {
+		const sql = `SELECT ${"x".repeat(400)} ?`;
+		let msg = "";
+		try {
+			resolve(sql, []);
+		} catch (e) {
+			msg = (e as Error).message;
+		}
+		expect(msg.length).toBeLessThan(260);
+	});
+
+	it("handles a statement with no placeholders and no binds", () => {
+		expect(resolve("SELECT 1", [])).toBe("SELECT 1");
+	});
+});
+
+describe("parseRows", () => {
+	const banner = "🚣 1 command executed successfully.\n";
+
+	it("unwraps the rows out of the envelope", () => {
+		const out = `${banner}[\n  { "results": [{ "id": "x" }], "success": true }\n]`;
+		expect(parseRows(out)).toEqual([{ id: "x" }]);
+	});
+
+	// The bug this function exists to prevent: returning the envelope *as*
+	// the rows. An empty result set is one truthy object, so every existence
+	// probe reports "already imported" and the run inserts nothing while
+	// printing DONE with all-zero counters.
+	it("reads an empty result set as no rows, not as one truthy row", () => {
+		const out = `${banner}[\n  { "results": [], "success": true, "meta": { "duration": 0 } }\n]`;
+		expect(parseRows(out)).toEqual([]);
+	});
+
+	it("skips the banner and anchors on the envelope", () => {
+		const noisy = `some [bracketed] prose\n${banner}[{"results":[{"n":1}]}]`;
+		expect(parseRows(noisy)).toEqual([{ n: 1 }]);
+	});
+
+	it("concatenates the rows of a multi-statement envelope", () => {
+		const out = `${banner}[{"results":[{"a":1}]},{"results":[{"b":2}]}]`;
+		expect(parseRows(out)).toEqual([{ a: 1 }, { b: 2 }]);
+	});
+
+	it("treats an element with no results as contributing nothing", () => {
+		const out = `${banner}[{"success":true},{"results":[{"a":1}]}]`;
+		expect(parseRows(out)).toEqual([{ a: 1 }]);
+	});
+
+	// "No rows" means "go ahead and insert" to every caller, so guessing it
+	// on a parse failure is how a silently-broken import looks. A loud
+	// failure is recoverable; a no-op that claims success is not.
+	it("throws rather than guessing [] when there is no envelope", () => {
+		expect(() => parseRows("🚣 done, nothing else")).toThrow(
+			/could not find a JSON result envelope/,
+		);
+	});
+
+	it("throws when the envelope is not valid JSON", () => {
+		expect(() => parseRows(`${banner}[{"results":`)).toThrow(
+			/could not parse wrangler output as JSON/,
+		);
+	});
+
+	it("throws when the envelope is not an array", () => {
+		expect(() => parseRows(`${banner}[1,2]\n`)).not.toThrow();
+		expect(() => parseRows(`${banner}\n[{"results":{"a":1}}]`)).toThrow(
+			/non-array `results`/,
+		);
+	});
+});


### PR DESCRIPTION
Closes #106.

Adds the third importer adapter: **Comentario** (active, v3) and **Commento** (its dead ancestor, v1), read by one adapter behind one source tag.

## Why one adapter

Comentario is a fork of Commento and still reads Commento's own export format — both products write a single JSON document whose `version` field says which shape it is. An operator leaving one is leaving the same product, so the source tag is shared: a v1 file and a later v3 file from the same instance deduplicate against each other under `(import_source, import_id)` rather than importing every comment twice.

Commento is unmaintained and its export path needs SMTP, so it was never installed in the export lab. v1 is therefore covered by hand-written synthetic fixtures built from the upstream Go structs and upstream's own test data. v3 is validated against a real banked export.

## Multi-domain exports are refused, not flattened

Both products are multi-site, and neither export namespaces its page paths by site. Two domains' `/about` would collide onto one Garrul slug with nothing left to say which comments came from where, so the adapter stops and the operator runs it once per domain (`--domain=`, or `x-import-domain` on the endpoint).

The refusal names the identifiers it found, which matters more than it looks: a **v3 export carries no hostnames at all** — pages reference a `domainId` UUID and the only place a real host appears is inside a comment permalink — so without the error printing them, the value to pass exists nowhere the operator can look up.

## The v1 quirk that costs comments

Commento's `deleted` column marks a comment's *body* as redacted while the row stays visible in the thread. Read as row deletion it silently drops threads the source still renders, so the adapter maps it to a redacted body, not to `deleted`.

Neither product ships a spam classifier, so what the adapter marks `spam` — and what `--include-spam` gates — is a comment a human moderator rejected (v3) or flagged (v1), not a machine verdict.

## Shared CLI shim (`scripts/import-cli.ts`)

Every `npm run import-<source>` was the same program with a different adapter bolted on. That was two copies; Comentario would have made three, of code that builds SQL by string substitution over untrusted export values — `wrangler d1 execute` takes only `--command`/`--file`, so there is no binding flag and the SQL text is the whole interface to D1 from a CLI.

The copies had already drifted where it counts: `import-disqus` printed the raw error object on failure, which for a parse error quotes the input it choked on, and an export carries display names and email addresses. `import-remark42` printed only the message. The hardened one is now the only one.

`inline`/`resolve`/`parseRows` also pick up their first tests — 30 of them, on a boundary that had zero coverage while it was inline copies. What they pin is that a value reaches D1 as exactly itself or the run stops: quote doubling, a refused NUL (argv is NUL-terminated, so it truncates the statement at a position the value's author picks), non-finite numbers, both placeholder/bind mismatch directions, and `parseRows` reading an empty result set as no rows rather than as one truthy row — the last of which would make every existence probe report "already imported" and print DONE with all-zero counters.

## Admin endpoint and operator card

`POST /admin/api/ops/import-comentario` matches its siblings: admin-gated, capped at `MAX_IMPORT_BYTES` on the decompressed side, gzip-decoded *before* the format sniff. The domain selector is only ever compared with `===` against values already inside the export — it reaches no SQL, no log line, no audit meta.

The card's two-way ternaries did not survive a third source; content type, accept list, CLI hint and the domain field are now one row per source, so a fourth adapter is one entry instead of four edits in lockstep. That card is an Alpine component inside a template literal, so nothing in the build parses it. The render test now pulls the data object back out of the emitted HTML and **executes** it, driving every getter against every option.

## Verification

- 2259 tests / 130 files pass; lint, typecheck, `manifest:check`, build all clean.
- Bundle 20.26 KB gz of the 30 KB ceiling (unchanged — no widget code here).
- `identity:check` clean; every fixture is hand-written and identity-free.
- Smoke-run against a real banked v3 export: 1 thread, 6 comments, all `approved`, 6 roots, every row carrying a source id.
