### PR TITLE
ci: CodeQL advanced setup (security-extended, PR-blocking)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# CodeQL advanced setup. This file replaces GitHub's "default setup" so the
+# scan config is versioned and reviewable like the rest of CI.
+#
+# - `security-extended` trades some precision for broader security coverage;
+#   the default-setup scan this replaces ran the plain `default` suite.
+# - The `actions` language scans the workflows themselves (untrusted-input,
+#   injection, unpinned-action queries).
+# - PR merges block on new high/critical findings via the repo's code-scanning
+#   check-failure threshold plus a ruleset that requires these checks on main.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, matching the cadence the default setup ran on.
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to the Security tab
+      actions: read
+
+    strategy:
+      # One language failing should still report the other's verdict.
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      # Pinned to a commit SHA, not a tag — see the note in ci.yml.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/src/admin-ui/escape.ts
+++ b/src/admin-ui/escape.ts
@@ -24,8 +24,14 @@ export const jsLiteral = (s: string): string => escapeHtml(jsLiteralRaw(s));
 // a block that is escapeHtml'd as a whole further out (see the x-data blobs in
 // admin-ui/pages/*). Running escapeHtml twice would emit `&amp;quot;`, which
 // decodes to the text `&quot;` instead of a quote and breaks the expression.
+// Chained single-character replaces rather than one char-class regex with a
+// function replacer: the output is byte-identical, but CodeQL's
+// js/bad-code-sanitization query only models literal-replacement escaping, so
+// the function form gets every jsLiteral flow flagged as unsanitized.
 export const jsLiteralRaw = (s: string): string =>
-	JSON.stringify(s).replace(
-		/[<>/\u2028\u2029]/g,
-		(c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`,
-	);
+	JSON.stringify(s)
+		.replace(/</g, "\\u003c")
+		.replace(/>/g, "\\u003e")
+		.replace(/\//g, "\\u002f")
+		.replace(/\u2028/g, "\\u2028")
+		.replace(/\u2029/g, "\\u2029");


### PR DESCRIPTION
Replaces GitHub's CodeQL default setup with an in-repo advanced workflow, so the scan config is versioned and reviewable like the rest of CI.

- `security-extended` query suite (default setup ran the plain `default` suite)
- Languages: `javascript-typescript` + `actions` (scans the workflows themselves)
- Triggers: push/PR to `main` + weekly cron, matching the old cadence
- Minimal permissions; actions pinned to commit SHAs like the rest of CI
- Default setup disabled via the API alongside this PR (GitHub rejects advanced-configuration SARIF while it is on)

Follow-ups in this PR before merge: triage the two open `js/bad-code-sanitization` alerts on `src/admin-ui/pages/queue.ts:190`, and add a ruleset requiring the CodeQL checks on `main`.

Refs #95.