### PR TITLE
fix: resolve the security-extended findings surfaced by the new CodeQL setup

### DIFF
--- a/scripts/check-bundle-size.ts
+++ b/scripts/check-bundle-size.ts
@@ -16,7 +16,7 @@
  * Run after `npm run build:embed`. CI invokes it via `npm run size`.
  */
 import { gzipSync } from "node:zlib";
-import { readFileSync, statSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -26,16 +26,17 @@ const BUNDLE = join(ROOT, "dist/embed.js");
 
 const LIMIT_GZ_BYTES = 30 * 1024;
 
+// Read directly and report on failure — a stat-then-read pair is a TOCTOU
+// race (CodeQL js/file-system-race), and the read's own error covers it.
+let raw: Buffer;
 try {
-	statSync(BUNDLE);
+	raw = readFileSync(BUNDLE);
 } catch {
 	console.error(
 		`[size] ${BUNDLE} does not exist — run \`npm run build:embed\` first.`,
 	);
 	process.exit(1);
 }
-
-const raw = readFileSync(BUNDLE);
 const gz = gzipSync(raw, { level: 9 });
 
 const kb = (n: number) => (n / 1024).toFixed(2);

--- a/scripts/upgrade/wrangler.ts
+++ b/scripts/upgrade/wrangler.ts
@@ -7,7 +7,7 @@
  * passed in the args array can't break out into shell metacharacters.
  */
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from "node:fs";
+import { readFileSync, appendFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { parseTomlVars } from "./toml-vars";
 import type { TomlVars } from "./toml-vars";
@@ -245,11 +245,9 @@ export const appendUpgradeLog = (
 ): void => {
 	const path = join(repoRoot, ".garrul-upgrade-log.json");
 	const line = `${JSON.stringify({ ...entry, ts: Date.now() })}\n`;
-	if (existsSync(path)) {
-		appendFileSync(path, line);
-	} else {
-		writeFileSync(path, line);
-	}
+	// appendFileSync creates the file when it is missing, so no exists-check —
+	// the check/write pair was also a TOCTOU race (CodeQL js/file-system-race).
+	appendFileSync(path, line);
 };
 
 export const wranglerVersion = (): string | null => {

--- a/tests/import-core.test.ts
+++ b/tests/import-core.test.ts
@@ -767,7 +767,7 @@ describe("decodeImportInput", () => {
 		);
 		// An export carries names, emails and IPs. None of it belongs in an
 		// error string that reaches a log or an HTTP body.
-		await expect(decodeImportInput(u8)).rejects.not.toThrow(/example\.com/);
+		await expect(decodeImportInput(u8)).rejects.not.toThrow("example.com");
 	});
 
 	it("aborts a decompression bomb instead of inflating it", async () => {


### PR DESCRIPTION
Follow-up to #122. The security-extended suite surfaced six high-rated findings on main; three get code fixes here, three were dismissed with justification (two intentionally-unanchored scanner regexes in `check-fixture-identities.ts`, plus the two pre-existing `js/bad-code-sanitization` medium alerts whose `jsLiteral` sanitizer is sound but unmodeled by the query).

Fixes in this PR:
- `scripts/upgrade/wrangler.ts`: `appendFileSync` creates a missing file, so the `existsSync` branch was a pure TOCTOU race (`js/file-system-race`) — dropped
- `scripts/check-bundle-size.ts`: read directly and report on failure instead of stat-then-read (same race)
- `tests/import-core.test.ts`: string containment instead of an unanchored URL-shaped regex (`js/regex/missing-regexp-anchor`)

Verified: 2498 tests pass, lint/typecheck clean, `npm run size` runs the edited script end-to-end (20.26 KB gz, OK).