### PR TITLE
feat(reactions)!: remove the deprecated `like` wire alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,15 +415,12 @@ and a sort selector above the list. Neither needs any host-page wiring:
   the up-vote sitting directly below it) and `wow` was added. Migration
   0022 rewrites stored rows in both `reactions` and `page_reactions`, so
   anything reading `reactions.like` off `/api/v1/counts` or a tree
-  response sees `reactions.fire` after upgrading. Both POST routes still
-  accept `like` on the wire for one release and store it as `fire`, so a
-  reader holding a cached pre-2.10.0 bundle keeps working. That
-  compatibility runs both ways: a POST in the deprecated spelling gets
-  its answer echoed in the same spelling, so the response carries both
-  `fire` and a `like` key with the identical count. Without the echo the
-  old bundle would look up a key that is no longer there and blank the
-  cell it just incremented. Emoji are native unicode — the widget ships
-  no icon artwork.
+  response sees `reactions.fire` after upgrading. Both POST routes
+  accepted `like` on the wire as a deprecated alias during a transition
+  window; **removed in v2.24.0** — a POST with `kind: "like"` now
+  answers `400 invalid_kind`. A script pinned to the old spelling must
+  send `fire` instead. Emoji are native unicode — the widget ships no
+  icon artwork.
 - **Comment reactions patch in place** (since v2.9.0). Toggling an emoji
   on a comment (`POST /api/v1/reactions` `{comment_id, kind}`) no longer
   re-fetches and re-renders the
@@ -431,11 +428,7 @@ and a sort selector above the list. Neither needs any host-page wiring:
   `reactions` is `{kind: count}` for that one comment, and the widget
   updates just that row. Scroll position, open reply composers and typed
   drafts survive a reaction now. Zero-count kinds are absent from
-  `reactions`, matching the list payload — with one exception: the
-  deprecated-spelling echo above always carries a value, so a POST for
-  `like` that removes the last reaction answers `{"like": 0}`. Old
-  bundles drop non-positive counts on merge, which is exactly how they
-  clear the cell.
+  `reactions`, matching the list payload.
 - **Sorting** defaults to `new` (newest top-level threads first). `top`
   orders top-level threads by net score (`score_up - score_down`,
   newer-first on ties); replies inside a thread always stay

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -482,6 +482,16 @@
         "Safe to defer — old comments render as before in the meantime — but they will not pick up the sanitizer hardening until you do."
       ],
       "addedIn": "2.0.0"
+    },
+    {
+      "id": "like-reaction-alias-removed",
+      "summary": "The deprecated `like` reaction wire alias (kept since the v2.10.0 rename to `fire`) is removed. `POST /api/v1/reactions` and `POST /api/v1/page-engagement/reactions` now answer HTTP 400 `invalid_kind` to `kind: \"like\"`. The bundled widget has sent `fire` since v2.10.0, so only third-party scripts pinned to the old spelling are affected.",
+      "manualSteps": [
+        "Nothing to run for a standard install — cached pre-2.10.0 widget bundles expired long ago (embed.js caches for at most ~25 hours).",
+        "If any of your own scripts POST reactions with `kind: \"like\"` (the endpoints are documented in AGENTS.md), change them to send `fire` before upgrading.",
+        "Rollback is redeploying the prior tag: no migrations and no secrets are involved."
+      ],
+      "addedIn": "2.24.0"
     }
   ]
 }

--- a/src/routes/api.page-engagement.ts
+++ b/src/routes/api.page-engagement.ts
@@ -34,11 +34,7 @@ import { loadFlags } from "../lib/settings";
 import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
 // Shared with the comment-level route and the widget — see ../widget/reactions.
-import {
-	REACTION_KIND_SET,
-	normalizeReactionKind,
-	withDeprecatedAlias,
-} from "../widget/reactions";
+import { REACTION_KIND_SET } from "../widget/reactions";
 
 const pageEngagement = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
@@ -121,11 +117,7 @@ pageEngagement.post("/reactions", async (c) => {
 
 	const slug = validateSlug(body.slug ?? "");
 	if (!slug) return c.json({ error: t("err.post.invalid") }, 400);
-	// Normalize before the membership test, never instead of it: unknown kinds
-	// come back unchanged and are rejected below. The pre-normalization spelling
-	// is kept because the response has to answer in it — see withDeprecatedAlias.
-	const requestedKind = (body.kind ?? "").trim();
-	const kind = normalizeReactionKind(requestedKind);
+	const kind = (body.kind ?? "").trim();
 	if (!REACTION_KIND_SET.has(kind))
 		return c.json({ error: "invalid_kind" }, 400);
 
@@ -159,7 +151,7 @@ pageEngagement.post("/reactions", async (c) => {
 	return c.json({
 		ok: true,
 		added: result.added,
-		reactions: withDeprecatedAlias(totals, requestedKind),
+		reactions: totals,
 	});
 });
 

--- a/src/routes/api.reactions.ts
+++ b/src/routes/api.reactions.ts
@@ -24,11 +24,7 @@ import { FALLBACK_LOCALE, tFor } from "../i18n";
 import type { LocaleVars } from "../lib/locale";
 // The vocabulary is the widget's, imported rather than restated: a hand-copied
 // set here is a set that silently disagrees with the buttons the reader sees.
-import {
-	REACTION_KIND_SET,
-	normalizeReactionKind,
-	withDeprecatedAlias,
-} from "../widget/reactions";
+import { REACTION_KIND_SET } from "../widget/reactions";
 
 const reactions = new Hono<{ Bindings: Bindings; Variables: LocaleVars }>();
 
@@ -51,11 +47,7 @@ reactions.post("/", async (c) => {
 	if (!body) return c.json({ error: t("err.internal") }, 400);
 
 	const comment_id = (body.comment_id ?? "").trim();
-	// Normalize before the membership test, never instead of it: unknown kinds
-	// come back unchanged and are rejected below. The pre-normalization spelling
-	// is kept because the response has to answer in it — see withDeprecatedAlias.
-	const requestedKind = (body.kind ?? "").trim();
-	const kind = normalizeReactionKind(requestedKind);
+	const kind = (body.kind ?? "").trim();
 	if (!comment_id) return c.json({ error: t("err.not_found") }, 400);
 	if (!REACTION_KIND_SET.has(kind)) {
 		return c.json({ error: "invalid_kind" }, 400);
@@ -113,7 +105,7 @@ reactions.post("/", async (c) => {
 	return c.json({
 		ok: true,
 		added: result.added,
-		reactions: withDeprecatedAlias(totals, requestedKind),
+		reactions: totals,
 	});
 });
 

--- a/src/widget/reactions.ts
+++ b/src/widget/reactions.ts
@@ -64,65 +64,6 @@ export const REACTION_KIND_SET: ReadonlySet<string> = new Set(
 );
 
 /**
- * Kinds this build still accepts on the wire but no longer renders.
- *
- * `like` 👍 was renamed to `fire` 🔥 in v2.10.0 — 👍 sat directly above an
- * up-vote button and meant the same thing twice. Migration 0022 rewrites the
- * stored rows, but a deploy and a migration are two events with a gap between
- * them, and whichever lands second leaves a window: old code writing `like`
- * after the rewrite would create rows no build can display. Accepting the old
- * spelling and normalizing it on the way in closes the window in both
- * directions.
- *
- * Removable once no deployment can still be running a pre-2.10.0 bundle.
- *
- * A `Map` rather than an object literal because the input is a wire value: a
- * plain object resolves inherited keys, so `"constructor"` and `"toString"`
- * would come back as *functions* and `"__proto__"` as `Object.prototype`, all
- * still typed `string`. Nothing downstream is hurt by that today only because
- * both callers immediately reject on `REACTION_KIND_SET`, which is too thin a
- * thread to hang a type signature on.
- */
-const DEPRECATED_KINDS: ReadonlyMap<string, string> = new Map([
-	["like", "fire"],
-]);
-
-/**
- * Map a wire value to the kind to store. Unknown kinds pass through unchanged
- * for the caller's own membership check to reject — this must never be the
- * thing that decides whether a kind is allowed.
- */
-export const normalizeReactionKind = (kind: string): string =>
-	DEPRECATED_KINDS.get(kind) ?? kind;
-
-/**
- * Echo a totals map back under the spelling the caller actually asked for.
- *
- * Accepting `like` on the way in is only half the job: the totals a route
- * returns are keyed by the *stored* kind, so a pre-2.10.0 bundle POSTs `like`,
- * gets `{ fire: N }` back, finds no `like` entry, and paints that cell to 0 —
- * then hides the button outright for an anonymous reader, because zero-count
- * kinds are hidden from them. The reader watches the button they just pressed
- * disappear. The page bar's variant is worse: `0` next to `aria-pressed="true"`.
- *
- * So when normalization rewrote the kind, send the count under both spellings.
- * A current bundle never triggers this (it asks for `fire`, nothing is
- * rewritten, the response shape is byte-identical), and the alias is drawn from
- * `DEPRECATED_KINDS` rather than trusting the raw wire value, so this cannot
- * mint a key from arbitrary caller input.
- *
- * Goes away with `DEPRECATED_KINDS`.
- */
-export const withDeprecatedAlias = (
-	totals: Record<string, number>,
-	requested: string,
-): Record<string, number> => {
-	const stored = DEPRECATED_KINDS.get(requested);
-	if (stored === undefined) return totals;
-	return { ...totals, [requested]: totals[stored] ?? 0 };
-};
-
-/**
  * Fold a toggle response back into a comment's reaction list.
  *
  * `totals` is authoritative for counts (it is a fresh aggregate over the

--- a/tests/page-engagement.test.ts
+++ b/tests/page-engagement.test.ts
@@ -276,26 +276,20 @@ describe("page reactions — toggle/dedup", () => {
 		expect(res.status).toBe(400);
 	});
 
-	it("counts the deprecated `like` as `fire` and answers in both spellings", async () => {
-		// Same alias as the comment-level route: an old cached bundle keeps working
-		// and lands its row under the kind this build renders. The article bar and
-		// the comment rows share one vocabulary, so they have to share this too.
-		//
-		// This used to assert `reactions.like` was *absent*, which pinned the bug:
-		// the only client that asks in that spelling is also the only one that reads
-		// the count back by it, and `{ fire: 1 }` alone makes its bar render 0 under
-		// a button it has just marked aria-pressed="true".
+	it("rejects the retired `like` spelling with 400", async () => {
+		// `like` became `fire` in v2.10.0 and was accepted on the wire as a
+		// deprecated alias through v2.23.x; the alias is removed, so the old
+		// spelling fails the same membership check as any unknown kind.
 		const { app, env } = mkApp({ page_reactions_enabled: true });
 		const res = await post(app, env, "/reactions", { slug: "p", kind: "like" });
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { reactions: Record<string, number> };
-		expect(body.reactions.fire).toBe(1);
-		expect(body.reactions.like).toBe(1);
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("invalid_kind");
 	});
 
-	it("does not invent an alias key for a current kind", async () => {
-		// The alias is strictly for callers that asked in the old spelling; a
-		// current bundle must see the response shape it has always seen.
+	it("keys totals by the stored kind alone", async () => {
+		// Response-shape pin: `reactions` is exactly the aggregate over stored
+		// rows — no synthesized keys.
 		const { app, env } = mkApp({ page_reactions_enabled: true });
 		const res = await post(app, env, "/reactions", { slug: "p", kind: "fire" });
 		expect(res.status).toBe(200);

--- a/tests/reactions.test.ts
+++ b/tests/reactions.test.ts
@@ -19,13 +19,9 @@ import { installMockCaches, uninstallMockCaches } from "./helpers/mock-caches";
 const COMMENT_ID = "01HC000000000000000000ABCD";
 const GHOST_ID = "01HU000000000000000000";
 
-// `writes` collects every (sql, args) pair a test cares to inspect. Only the
-// deprecated-alias test uses it — the kind that gets *stored* is not visible in
-// the response, so it has to be read off the statement.
-const makeDb = (status: string, writes: { sql: string; args: unknown[] }[] = []) => ({
+const makeDb = (status: string) => ({
 	prepare: (sql: string) => ({
-		bind(...args: unknown[]) {
-			writes.push({ sql, args });
+		bind() {
 			return this;
 		},
 		async first() {
@@ -102,14 +98,11 @@ const makeKv = () => ({
 	async delete() {},
 });
 
-const mkApp = (
-	status = "approved",
-	writes: { sql: string; args: unknown[] }[] = [],
-) => {
+const mkApp = (status = "approved") => {
 	const app = new Hono<{ Bindings: Record<string, unknown> }>();
 	app.route("/r", reactions);
 	const env = {
-		DB: makeDb(status, writes),
+		DB: makeDb(status),
 		TREE_CACHE: makeKv(),
 		SESSIONS: makeKv(),
 		ANALYTICS: { writeDataPoint: () => {} },

--- a/tests/reactions.test.ts
+++ b/tests/reactions.test.ts
@@ -160,44 +160,17 @@ describe("POST /reactions — input validation", () => {
 		expect(body.error).toBe("invalid_kind");
 	});
 
-	it("accepts the deprecated `like` and stores it as `fire`", async () => {
-		// A reader holding a pre-2.10.0 bundle in cache still POSTs `like`.
-		// Rejecting it would break their buttons; storing it verbatim would land
-		// a row no build renders, which is exactly what migration 0022 cleaned up.
-		installMockCaches();
-		const writes: { sql: string; args: unknown[] }[] = [];
-		const { app, env } = mkApp("approved", writes);
+	it("rejects the retired `like` spelling with 400", async () => {
+		// `like` became `fire` in v2.10.0 and was accepted on the wire as a
+		// deprecated alias through v2.23.x. The alias is removed: pre-2.10.0
+		// bundles aged out of every cache long ago (embed.js is cached for at
+		// most ~25h), so a `like` today is a third-party script pinned to the
+		// old spelling — see the breakingChanges entry in release-manifest.json.
+		const { app, env } = mkApp();
 		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "like" });
-		expect(res.status).toBe(200);
-		const insert = writes.find((w) => w.sql.includes("INSERT INTO reactions"));
-		// (comment_id, user_id, kind, created_at) — see toggleReaction.
-		expect(insert?.args[2]).toBe("fire");
-	});
-
-	it("answers a deprecated `like` in both spellings", async () => {
-		// Storing it as `fire` is only half the alias. That old bundle patches its
-		// row with mergeReactionTotals(prev, totals, "like", true) — keyed on `fire`
-		// alone it finds nothing, paints the cell to 0, and (for an anonymous
-		// reader, who never sees zero-count kinds) hides the button that was just
-		// pressed. Both spellings carry the same count.
-		installMockCaches();
-		const { app, env } = mkApp("approved");
-		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "like" });
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { reactions: Record<string, number> };
-		expect(body.reactions.like).toBe(body.reactions.fire);
-		expect(body.reactions.like).toBeGreaterThan(0);
-	});
-
-	it("does not invent an alias key for a current kind", async () => {
-		// A current bundle asks for `fire`, nothing is rewritten, and it must see
-		// the response shape it has always seen.
-		installMockCaches();
-		const { app, env } = mkApp("approved");
-		const res = await post(app, env, { comment_id: COMMENT_ID, kind: "fire" });
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { reactions: Record<string, number> };
-		expect(body.reactions.like).toBeUndefined();
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("invalid_kind");
 	});
 
 	it("rejects a malformed JSON body with 400", async () => {

--- a/tests/widget-reactions.test.ts
+++ b/tests/widget-reactions.test.ts
@@ -12,7 +12,6 @@ import {
 	REACTION_KINDS,
 	REACTION_KIND_SET,
 	mergeReactionTotals,
-	normalizeReactionKind,
 } from "../src/widget/reactions";
 
 const prev = [
@@ -82,41 +81,10 @@ describe("the vocabulary", () => {
 
 	it("no longer offers `like`", () => {
 		// 👍 duplicated the up-vote directly below it; migration 0022 renamed the
-		// stored rows to `fire`. Re-adding it would resurrect the duplication and
-		// collide with the deprecated-alias mapping below.
+		// stored rows to `fire`. The wire alias that accepted `like` during the
+		// transition was removed in v2.24.0 — re-adding the kind would resurrect
+		// the duplication.
 		expect(REACTION_KIND_SET.has("like")).toBe(false);
 		expect(REACTION_KIND_SET.has("fire")).toBe(true);
-	});
-});
-
-describe("normalizeReactionKind", () => {
-	it("maps the deprecated `like` onto `fire`", () => {
-		// A pre-2.10.0 bundle in a reader's cache still POSTs `like`. Without this
-		// it would 400 — or, worse, land a row no build can render.
-		expect(normalizeReactionKind("like")).toBe("fire");
-	});
-
-	it("leaves a current kind alone", () => {
-		for (const r of REACTION_KINDS) {
-			expect(normalizeReactionKind(r.kind)).toBe(r.kind);
-		}
-	});
-
-	it("passes an unknown kind through unchanged", () => {
-		// Load-bearing: the routes reject on REACTION_KIND_SET *after* normalizing,
-		// so anything this invented would become a kind the API accepts.
-		expect(normalizeReactionKind("shrug")).toBe("shrug");
-		expect(REACTION_KIND_SET.has(normalizeReactionKind("shrug"))).toBe(false);
-	});
-
-	it("does not resolve inherited object keys", () => {
-		// The input is a wire value. A plain-object lookup answers for every key on
-		// Object.prototype, so these returned a function (or Object.prototype)
-		// while still typed `string` — a lie waiting for the first caller that
-		// trusts the return value instead of re-checking membership.
-		for (const key of ["constructor", "toString", "valueOf", "__proto__"]) {
-			expect(normalizeReactionKind(key)).toBe(key);
-			expect(typeof normalizeReactionKind(key)).toBe("string");
-		}
 	});
 });


### PR DESCRIPTION
Closes #83.

v2.10.0 renamed the `like` reaction to `fire` and kept `like` working on the wire for cached pre-2.10.0 bundles. Three weeks on, every cache TTL involved (24h shared + 1h browser) has long expired, so the transition code comes out.

## What changed
- `src/widget/reactions.ts`: removed `DEPRECATED_KINDS`, `normalizeReactionKind()`, `withDeprecatedAlias()`.
- `src/routes/api.reactions.ts`, `src/routes/api.page-engagement.ts`: `body.kind` goes straight to the `REACTION_KIND_SET` membership check; totals returned unwrapped.
- Tests inverted: `kind: "like"` now pins `400 invalid_kind` on both routes; the widget-side normalization suite is gone with the function.
- `release-manifest.json`: `breakingChanges` entry `like-reaction-alias-removed` with `addedIn: 2.24.0`, so `npm run upgrade` surfaces it.
- `AGENTS.md`: both alias mentions updated (docs-sync AGENTS gate satisfied).

## Breaking change
Any client still POSTing `kind: "like"` gets `400 invalid_kind` — that's third-party scripts pinned to the old spelling, not the bundled widget (it has sent `fire` since v2.10.0). Needs the callout in the v2.24.0 release body when it ships; if the next release ends up numbered differently, update `addedIn` to match.

Migration 0022 untouched (forward-only, already applied).

## Verification
`lint`, `typecheck`, `test` (2492 passed), `manifest:check`, `build`, `size` (67.5% of ceiling) all green.