### PR TITLE
fix(upgrade): refuse to plan against a deployment wrangler cannot read

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1869,10 +1869,10 @@ npm run upgrade -- --version v0.2.0   # target a specific tag
 
 The 12 steps (each prints `→ name… OK`):
 
-1. **Preflight** — `wrangler --version` ≥ 4, clean working tree (unless `--allow-dirty`)
+1. **Preflight** — `wrangler --version` ≥ 4, clean working tree (unless `--allow-dirty`), and a Cloudflare login (`wrangler whoami`; note it exits 0 even when logged out, so the output is checked). A logged-out wrangler stops the run here with the fix printed (`npx wrangler login`, or `CLOUDFLARE_API_TOKEN` for CI) and nothing is fetched or changed
 2. **Resolve target** — `--version vX.Y.Z` or GitHub latest release; exit 0 if already there
 3. **Fetch manifests** — local from disk, remote from `raw.githubusercontent.com`; refuses if `target.minPreviousVersion > current`
-4. **Drift detection** (read-only): secrets via `wrangler secret list`; `[vars]`, KV and D1 by parsing `wrangler.toml`; migrations via `SELECT name FROM _migrations`; renderer via `CURRENT_RENDERER_VERSION` vs `target.renderer.version`. Also compares each `[vars]` *value* against the placeholder the target ships — see *Unedited placeholders* below
+4. **Drift detection** (read-only): secrets via `wrangler secret list`; `[vars]`, KV and D1 by parsing `wrangler.toml`; migrations via `SELECT name FROM _migrations`; renderer via `CURRENT_RENDERER_VERSION` vs `target.renderer.version`. Also compares each `[vars]` *value* against the placeholder the target ships — see *Unedited placeholders* below. If either live read fails (expired token, wrong `name`/`account_id`/`database_id`, network), the run stops and prints wrangler's error rather than planning against an empty deployment; the one read failure treated as "zero applied" is a D1 database with no `_migrations` table, which is a genuine fresh install. As a second guard, a plan on a configured install that lists *every* migration pending and *every* required secret missing is flagged as a likely misread before the confirm prompt
 5. **Print plan** grouped as config drift / migrations / breaking changes
 6. **Confirm** (`Proceed? [y/N]`) unless `--yes`
 7. **Checkout** the target tag, then verify the `release-manifest.json` in

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,8 +4,48 @@
 
 ### `wrangler deploy` says "Authentication error"
 
-Run `wrangler login` once on this machine. The token lives in
-`~/.wrangler/config/default.toml`.
+Run `wrangler login` once on this machine. The token lives under
+wrangler's config directory (`~/.config/.wrangler/config/default.toml`
+on Linux; older installs used `~/.wrangler/config/default.toml`).
+OAuth logins expire; the fix for an expired one is the same
+`wrangler login`. In CI, or anywhere a browser login is not possible,
+export `CLOUDFLARE_API_TOKEN` with a token that has *Workers
+Scripts:Edit* and *D1:Edit* on the account instead.
+
+### `npm run upgrade` says every secret is missing and every migration is pending
+
+A plan that lists **all** required secrets as missing and **all**
+migrations (`0001_init.sql` onward) as pending on an install that has
+been running fine is not describing your deployment. It means the
+upgrade could not read it. Current versions stop in preflight with:
+
+```
+✘ Wrangler is not logged in to Cloudflare.
+
+  wrangler said: You are not authenticated. Please run `wrangler login`.
+```
+
+and prints the fix. Older versions silently treated the failed reads as
+"nothing there" and produced the brand-new-install plan above.
+
+Do **not** answer `y` to such a plan. It would re-prompt you for
+secrets that already exist and, once wrangler *is* logged in, the
+re-run of every migration is harmless (they are idempotent) but slow.
+
+Causes, in order of likelihood:
+
+1. **wrangler is logged out.** OAuth tokens expire. `npx wrangler whoami`
+   says `You are not authenticated` (and exits 0, so scripts that only
+   check the exit code miss it). Fix: `npx wrangler login`.
+2. **`CLOUDFLARE_API_TOKEN` is set but wrong or expired.** It takes
+   precedence over a saved login. Fix the variable or unset it.
+3. **`wrangler.toml` points at the wrong deployment.** A second
+   checkout with a stale `name`, `account_id` or D1 `database_id`
+   reads a Worker or database that has nothing in it. Compare the
+   values against the checkout that deploys this instance.
+
+Once fixed, `npm run upgrade -- --dry-run` should show only the drift
+the new version actually introduces.
 
 ### Migration fails on a fresh D1: "table foo already exists"
 

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -11,6 +11,13 @@
  * Interactive flow prints the GitHub release notes (when available) and
  * the drift plan, then asks for confirmation. `--yes` skips that prompt.
  *
+ * Preflight requires a Cloudflare login (`wrangler whoami`) before anything
+ * is fetched or read. The drift plan is built from live reads of the Worker's
+ * secrets and the D1 `_migrations` table; if either read fails the run stops
+ * with the wrangler error instead of treating the deployment as empty. The
+ * one exception is a D1 database with no `_migrations` table at all, which is
+ * a fresh install and legitimately has zero applied migrations.
+ *
  * Flags:
  *   --dry-run            Print the plan and exit; no side effects.
  *   --yes                Skip confirmations. Missing secrets become hard errors.
@@ -52,9 +59,11 @@ import {
 	diffRenderer,
 	hasMutations,
 	blocksAutoApply,
+	looksLikeLostInstall,
 	type Plan,
 } from "./upgrade/drift";
 import * as wranglerModule from "./upgrade/wrangler";
+import { WranglerReadError } from "./upgrade/wrangler";
 import * as gitModule from "./upgrade/git";
 import { confirm } from "./upgrade/prompt";
 import { buildManifest } from "./upgrade/build-manifest";
@@ -213,7 +222,12 @@ const computePlan = (
 	const presentSecrets = wrangler.listSecrets();
 	// By binding, not by database_name: the operator names their own D1.
 	const targetDb = target.d1Databases[0]?.binding ?? "DB";
-	const applied = wrangler.queryAppliedMigrations(targetDb, true);
+	// No block in wrangler.toml means the database is about to be created by
+	// this run (plan.d1.missing); nothing can be applied on it yet, and asking
+	// wrangler about an unbound binding is an error, not an empty answer.
+	const applied = toml.d1Bindings.includes(targetDb)
+		? wrangler.queryAppliedMigrations(targetDb, true)
+		: [];
 
 	return {
 		secrets: diffSecrets(presentSecrets, target.secrets),
@@ -236,11 +250,81 @@ const computePlan = (
 	};
 };
 
+/**
+ * Printed when the plan cannot be trusted because wrangler could not read the
+ * live deployment. Every line is for an operator at a terminal: what went
+ * wrong, why the run stopped instead of showing a plan, and the two ways to
+ * fix it. The `detail` is wrangler's own text so the fix matches the cause.
+ */
+const printCannotReachCloudflare = (
+	headline: string,
+	detail: string,
+	opts: { maybeMisconfigured: boolean },
+): void => {
+	console.error("");
+	console.error(`✘ ${headline}`);
+	console.error("");
+	console.error(`  wrangler said: ${detail}`);
+	console.error("");
+	console.error(
+		"  The upgrade plan is a comparison against your live Worker — its",
+	);
+	console.error(
+		"  secrets and the migrations already applied to your D1 database.",
+	);
+	console.error(
+		"  Without that reading, every secret would show as missing and every",
+	);
+	console.error(
+		"  migration as pending, so nothing is shown rather than a wrong plan.",
+	);
+	console.error("");
+	console.error("  To fix it, do one of these and then re-run `npm run upgrade`:");
+	console.error("");
+	console.error("    • At a terminal:   npx wrangler login");
+	console.error("      (also the fix when a previous login has expired)");
+	console.error("    • In CI or a script:   export CLOUDFLARE_API_TOKEN=<token>");
+	console.error(
+		"      Token needs Workers Scripts:Edit and D1:Edit on this account.",
+	);
+	if (opts.maybeMisconfigured) {
+		console.error(
+			"    • Already logged in?  Check that `name`, `account_id` and the D1",
+		);
+		console.error(
+			"      `database_id` in wrangler.toml are the ones for this deployment.",
+		);
+	}
+	console.error("");
+	console.error(
+		"  Nothing was changed. Your Worker, database and secrets are as they were.",
+	);
+};
+
 const printPlan = (current: Manifest, target: Manifest, plan: Plan): void => {
 	console.log("");
 	console.log(`Plan: ${current.version} → ${target.version}`);
 	console.log("");
 
+	if (looksLikeLostInstall(plan, target)) {
+		console.log("⚠ This plan reads like a brand-new install, but it is not one:");
+		console.log(
+			"  wrangler.toml already names a D1 database, yet every required",
+		);
+		console.log(
+			"  secret shows as missing and every migration as pending. On an",
+		);
+		console.log(
+			"  instance that has been running, that usually means wrangler is",
+		);
+		console.log(
+			"  talking to the wrong account or Worker — check `npx wrangler whoami`",
+		);
+		console.log(
+			"  and the `name` / `account_id` in wrangler.toml before answering yes.",
+		);
+		console.log("");
+	}
 	if (plan.placeholders.length > 0) {
 		// First, not last: this is a "your instance is misconfigured right now"
 		// warning rather than anything about the upgrade, and burying it under
@@ -532,6 +616,25 @@ export const main = async (
 		stepFail("working tree is dirty (use --allow-dirty to override)");
 		process.exit(1);
 	}
+	// Before anything is fetched or compared: a logged-out wrangler used to
+	// sail through here and surface only as an all-missing plan five steps
+	// later, with nothing naming the real cause.
+	const auth = wrangler.checkAuth();
+	if (!auth.ok) {
+		stepFail(
+			auth.reason === "not_logged_in"
+				? "wrangler is not logged in to Cloudflare"
+				: "could not run `wrangler whoami`",
+		);
+		printCannotReachCloudflare(
+			auth.reason === "not_logged_in"
+				? "Wrangler is not logged in to Cloudflare."
+				: "Wrangler could not check who is logged in.",
+			auth.detail,
+			{ maybeMisconfigured: auth.reason !== "not_logged_in" },
+		);
+		process.exit(1);
+	}
 	stepOk();
 
 	step("Resolving target version…");
@@ -593,7 +696,19 @@ export const main = async (
 	}
 
 	step("Detecting drift…");
-	const plan = computePlan(local, target, wrangler);
+	let plan: Plan;
+	try {
+		plan = computePlan(local, target, wrangler);
+	} catch (err) {
+		if (!(err instanceof WranglerReadError)) throw err;
+		stepFail(`could not ${err.what}`);
+		// Preflight already proved a login exists, so a failure here is more
+		// likely a wrong Worker name or database id than a missing token.
+		printCannotReachCloudflare(`Wrangler could not ${err.what}.`, err.detail, {
+			maybeMisconfigured: true,
+		});
+		process.exit(1);
+	}
 	stepOk();
 
 	const blockers = blocksAutoApply(plan);

--- a/scripts/upgrade/drift.ts
+++ b/scripts/upgrade/drift.ts
@@ -280,3 +280,24 @@ export const blocksAutoApply = (plan: Plan): string[] => {
 	}
 	return reasons;
 };
+
+/**
+ * True when the plan says the install has nothing: every required secret
+ * missing and every migration pending, on a `wrangler.toml` that already
+ * names its D1 database. A genuinely fresh install has no D1 block yet
+ * (`setup.sh` creates it), so this shape is far more likely to be a read
+ * that quietly came back empty than an operator who created a database and
+ * then did nothing else. The reads throw on failure now, so this is a second
+ * line — it costs one comparison and turns "re-run 23 migrations" into a
+ * question the operator can answer before saying yes.
+ */
+export const looksLikeLostInstall = (plan: Plan, target: Manifest): boolean => {
+	if (plan.d1.missing.length > 0) return false;
+	const requiredSecrets = target.secrets.filter((s) => s.required).length;
+	return (
+		target.migrations.length > 0 &&
+		plan.migrations.pending.length === target.migrations.length &&
+		requiredSecrets > 0 &&
+		plan.secrets.missing.length === requiredSecrets
+	);
+};

--- a/scripts/upgrade/wrangler.ts
+++ b/scripts/upgrade/wrangler.ts
@@ -14,6 +14,24 @@ import type { TomlVars } from "./toml-vars";
 
 type RunOpts = { cwd?: string; inheritStdio?: boolean };
 
+/**
+ * A subprocess that exited non-zero. Carries both streams: `wrangler --json`
+ * commands put their error object on *stdout* and leave stderr empty, so a
+ * message built from stderr alone reads "exited with 1: " and nothing else.
+ */
+export class SubprocessError extends Error {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly status: number;
+	constructor(cmd: string, args: string[], status: number, stdout: string, stderr: string) {
+		super(`${cmd} ${args.join(" ")} exited with ${status}: ${stderr || stdout}`);
+		this.name = "SubprocessError";
+		this.stdout = stdout;
+		this.stderr = stderr;
+		this.status = status;
+	}
+}
+
 const run = (cmd: string, args: string[], opts: RunOpts = {}): string => {
 	const r = spawnSync(cmd, args, {
 		encoding: "utf8",
@@ -22,8 +40,12 @@ const run = (cmd: string, args: string[], opts: RunOpts = {}): string => {
 	});
 	if (r.error) throw r.error;
 	if (typeof r.status === "number" && r.status !== 0) {
-		throw new Error(
-			`${cmd} ${args.join(" ")} exited with ${r.status}: ${r.stderr ?? ""}`,
+		throw new SubprocessError(
+			cmd,
+			args,
+			r.status,
+			typeof r.stdout === "string" ? r.stdout : "",
+			typeof r.stderr === "string" ? r.stderr : "",
 		);
 	}
 	return typeof r.stdout === "string" ? r.stdout : "";
@@ -32,26 +54,113 @@ const run = (cmd: string, args: string[], opts: RunOpts = {}): string => {
 const wrangler = (args: string[], opts: RunOpts = {}): string =>
 	run("npx", ["wrangler", ...args], opts);
 
-export const listSecrets = (): string[] => {
-	try {
-		const out = wrangler(["secret", "list", "--format", "json"]);
-		const parsed: unknown = JSON.parse(out);
-		if (!Array.isArray(parsed)) return [];
-		return parsed
-			.map((row) => {
-				if (
-					typeof row === "object" &&
-					row !== null &&
-					typeof (row as { name?: unknown }).name === "string"
-				) {
-					return (row as { name: string }).name;
-				}
-				return null;
-			})
-			.filter((n): n is string => n !== null);
-	} catch {
-		return [];
+/** Terminal colour codes: wrangler colours its error output even when piped. */
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+/**
+ * The one line of a failed wrangler command worth showing an operator. Prefers
+ * the `error.text` of a `--json` error object (D1), then the first non-empty
+ * stderr line with wrangler's `✘ [ERROR]` prefix and colour codes removed.
+ */
+export const describeFailure = (err: unknown): string => {
+	if (err instanceof SubprocessError) {
+		try {
+			const parsed: unknown = JSON.parse(err.stdout);
+			const text = (parsed as { error?: { text?: unknown } })?.error?.text;
+			if (typeof text === "string" && text.trim()) return text.trim();
+		} catch {
+			// stdout was not JSON; fall through to stderr
+		}
+		const line = `${err.stderr}\n${err.stdout}`
+			.replace(ANSI_RE, "")
+			.split("\n")
+			.map((l) => l.replace(/^\s*✘?\s*\[ERROR\]\s*/, "").trim())
+			.find((l) => l.length > 0);
+		if (line) return line;
+		return `exited with ${err.status}`;
 	}
+	if (err instanceof Error) return err.message;
+	return String(err);
+};
+
+/**
+ * Raised when a *read* of live Cloudflare state fails. The upgrade plan is a
+ * diff against that state, so a failed read must stop the run — an empty
+ * answer would print "everything is missing" and offer to redo the install.
+ */
+export class WranglerReadError extends Error {
+	readonly what: string;
+	readonly detail: string;
+	constructor(what: string, cause: unknown) {
+		const detail = describeFailure(cause);
+		super(`could not ${what}: ${detail}`);
+		this.name = "WranglerReadError";
+		this.what = what;
+		this.detail = detail;
+	}
+}
+
+export type AuthStatus =
+	| { ok: true }
+	| { ok: false; reason: "not_logged_in" | "whoami_failed"; detail: string };
+
+/**
+ * `wrangler whoami` exits 0 whether or not there is a login, so the verdict
+ * has to come from its output. An expired OAuth token also lands here: the
+ * refresh happens lazily and a failed refresh leaves wrangler logged out.
+ */
+export const checkAuth = (): AuthStatus => {
+	let out: string;
+	try {
+		out = wrangler(["whoami"]);
+	} catch (err) {
+		return { ok: false, reason: "whoami_failed", detail: describeFailure(err) };
+	}
+	const line = out
+		.replace(ANSI_RE, "")
+		.split("\n")
+		.map((l) => l.trim())
+		.find((l) => /not authenticated/i.test(l));
+	if (line !== undefined) {
+		return { ok: false, reason: "not_logged_in", detail: line };
+	}
+	return { ok: true };
+};
+
+const names = (rows: unknown[]): string[] =>
+	rows
+		.map((row) => {
+			if (
+				typeof row === "object" &&
+				row !== null &&
+				typeof (row as { name?: unknown }).name === "string"
+			) {
+				return (row as { name: string }).name;
+			}
+			return null;
+		})
+		.filter((n): n is string => n !== null);
+
+export const listSecrets = (): string[] => {
+	let out: string;
+	try {
+		out = wrangler(["secret", "list", "--format", "json"]);
+	} catch (err) {
+		throw new WranglerReadError("list the Worker's secrets", err);
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(out);
+	} catch (err) {
+		throw new WranglerReadError("parse `wrangler secret list` output", err);
+	}
+	if (!Array.isArray(parsed)) {
+		throw new WranglerReadError(
+			"parse `wrangler secret list` output",
+			new Error("expected a JSON array"),
+		);
+	}
+	return names(parsed);
 };
 
 export type WranglerToml = {
@@ -172,16 +281,21 @@ export const putSecret = (name: string): void => {
 /**
  * `database` is a name *or* a binding — `wrangler d1 execute` accepts
  * either. Callers pass the binding: it is the half this repo owns, while
- * `database_name` is whatever the operator typed at setup. A wrong value
- * here does not throw, it falls into the `catch` and reports zero applied
- * migrations, which makes the upgrade plan offer to re-run all of them.
+ * `database_name` is whatever the operator typed at setup.
+ *
+ * Exactly one failure means "zero applied": a database that has no
+ * `_migrations` table yet, which is what a freshly created D1 looks like.
+ * Everything else — no login, wrong database, network — throws. Until
+ * v2.24 every failure returned `[]`, and an expired wrangler login produced a
+ * plan that offered to re-run all migrations and re-enter every secret.
  */
 export const queryAppliedMigrations = (
 	database: string,
 	remote: boolean,
 ): string[] => {
+	let out: string;
 	try {
-		const out = wrangler([
+		out = wrangler([
 			"d1",
 			"execute",
 			database,
@@ -190,32 +304,31 @@ export const queryAppliedMigrations = (
 			"--command",
 			"SELECT name FROM _migrations",
 		]);
-		const parsed: unknown = JSON.parse(out);
-		if (!Array.isArray(parsed)) return [];
-		const first = parsed[0] as unknown;
-		if (
-			typeof first !== "object" ||
-			first === null ||
-			!Array.isArray((first as { results?: unknown[] }).results)
-		) {
-			return [];
-		}
-		const rows = (first as { results: unknown[] }).results;
-		return rows
-			.map((r) => {
-				if (
-					typeof r === "object" &&
-					r !== null &&
-					typeof (r as { name?: unknown }).name === "string"
-				) {
-					return (r as { name: string }).name;
-				}
-				return null;
-			})
-			.filter((n): n is string => n !== null);
-	} catch {
-		return [];
+	} catch (err) {
+		if (/no such table: _migrations/i.test(describeFailure(err))) return [];
+		throw new WranglerReadError(
+			`read applied migrations from D1 binding ${database}`,
+			err,
+		);
 	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(out);
+	} catch (err) {
+		throw new WranglerReadError("parse `wrangler d1 execute` output", err);
+	}
+	const first = Array.isArray(parsed) ? (parsed[0] as unknown) : undefined;
+	if (
+		typeof first !== "object" ||
+		first === null ||
+		!Array.isArray((first as { results?: unknown[] }).results)
+	) {
+		throw new WranglerReadError(
+			"parse `wrangler d1 execute` output",
+			new Error("expected [{ results: [...] }]"),
+		);
+	}
+	return names((first as { results: unknown[] }).results);
 };
 
 export const npmRun = (script: string, extraArgs: string[] = []): void => {

--- a/tests/upgrade-drift.test.ts
+++ b/tests/upgrade-drift.test.ts
@@ -15,6 +15,7 @@ import {
 	diffRenderer,
 	hasMutations,
 	blocksAutoApply,
+	looksLikeLostInstall,
 	type Plan,
 } from "../scripts/upgrade/drift";
 import type {
@@ -472,5 +473,64 @@ describe("hasMutations + blocksAutoApply", () => {
 
 	it("blocksAutoApply empty otherwise", () => {
 		expect(blocksAutoApply(empty())).toHaveLength(0);
+	});
+});
+
+describe("looksLikeLostInstall", () => {
+	const target = {
+		secrets: [secret("A"), secret("B"), secret("OPT", false)],
+		migrations: ["0001.sql", "0002.sql"],
+	} as unknown as Manifest;
+	const base = (over: Partial<Plan> = {}): Plan =>
+		({
+			secrets: { missing: [secret("A"), secret("B")], extra: [] },
+			d1: { missing: [], extra: [] },
+			migrations: { pending: ["0001.sql", "0002.sql"], diverged: [] },
+			...over,
+		}) as unknown as Plan;
+
+	it("fires when a configured D1 shows every required secret missing and every migration pending", () => {
+		expect(looksLikeLostInstall(base(), target)).toBe(true);
+	});
+
+	it("stays quiet on a fresh install whose D1 is still to be created", () => {
+		const plan = base({
+			d1: {
+				missing: [{ binding: "DB", databaseName: "x", required: true }],
+				extra: [],
+			},
+		});
+		expect(looksLikeLostInstall(plan, target)).toBe(false);
+	});
+
+	it("stays quiet when any secret is present", () => {
+		expect(
+			looksLikeLostInstall(
+				base({ secrets: { missing: [secret("B")], extra: [] } }),
+				target,
+			),
+		).toBe(false);
+	});
+
+	it("stays quiet when any migration is applied", () => {
+		expect(
+			looksLikeLostInstall(
+				base({ migrations: { pending: ["0002.sql"], diverged: [] } }),
+				target,
+			),
+		).toBe(false);
+	});
+
+	it("needs something to compare against", () => {
+		const empty = { secrets: [], migrations: [] } as unknown as Manifest;
+		expect(
+			looksLikeLostInstall(
+				base({
+					secrets: { missing: [], extra: [] },
+					migrations: { pending: [], diverged: [] },
+				}),
+				empty,
+			),
+		).toBe(false);
 	});
 });

--- a/tests/upgrade-dry-run.test.ts
+++ b/tests/upgrade-dry-run.test.ts
@@ -6,6 +6,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { main } from "../scripts/upgrade";
 import type * as wranglerModule from "../scripts/upgrade/wrangler";
+import {
+	SubprocessError,
+	WranglerReadError,
+	describeFailure,
+} from "../scripts/upgrade/wrangler";
 import type * as gitModule from "../scripts/upgrade/git";
 import type { Manifest } from "../scripts/upgrade/manifest";
 
@@ -67,6 +72,12 @@ const fakeTargetManifest: Manifest = {
 };
 
 const makeWranglerMock = (): typeof wranglerModule => ({
+	// Error classes and the pure formatter are the real ones: main() does an
+	// `instanceof WranglerReadError`, so a mocked class would never match.
+	SubprocessError,
+	WranglerReadError,
+	describeFailure,
+	checkAuth: vi.fn(() => ({ ok: true }) as wranglerModule.AuthStatus),
 	listSecrets: vi.fn(() => ["JWT_SECRET"]),
 	parseWranglerToml: vi.fn(() => ({
 		kvBindings: ["RATE_LIMITS"],
@@ -403,5 +414,175 @@ describe("upgrade dry-run", () => {
 				fetchTargetManifest,
 			}),
 		).rejects.toThrow(/--version requires a tag argument/);
+	});
+});
+
+/**
+ * The 2.23.0 incident: an expired `wrangler login` made every live read fail,
+ * every failure was swallowed as "nothing there", and the operator was shown
+ * a plan to re-enter four secrets and re-run all 23 migrations. These pin the
+ * three layers that now stand in the way: preflight refuses to start, a read
+ * failure during drift detection stops the run with the cause, and a plan
+ * that still comes out all-missing on a configured install carries a warning.
+ */
+describe("upgrade refuses to plan against a deployment it cannot read", () => {
+	let wranglerMock: typeof wranglerModule;
+	let gitMock: typeof gitModule;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errSpy: ReturnType<typeof vi.spyOn>;
+	let stdoutSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+
+	const deps = () => ({
+		wrangler: wranglerMock,
+		git: gitMock,
+		fetchLatest,
+		fetchReleaseForTag,
+		fetchTargetManifest,
+		loadLocal,
+	});
+	const joined = (spy: ReturnType<typeof vi.spyOn>): string =>
+		spy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+
+	beforeEach(() => {
+		wranglerMock = makeWranglerMock();
+		gitMock = makeGitMock();
+		fetchLatest.mockClear();
+		fetchTargetManifest.mockClear();
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		stdoutSpy = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
+		// main() calls process.exit(1) on a refusal; throwing here lets the
+		// test observe the refusal and prove nothing ran after it.
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(((code) => {
+			throw new Error(`process.exit(${code})`);
+		}) as (code?: number | string | null) => never);
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		errSpy.mockRestore();
+		stdoutSpy.mockRestore();
+		exitSpy.mockRestore();
+	});
+
+	it("stops in preflight when wrangler is not logged in, before any fetch", async () => {
+		vi.mocked(wranglerMock.checkAuth).mockReturnValue({
+			ok: false,
+			reason: "not_logged_in",
+			detail: "wrangler whoami: You are not authenticated.",
+		});
+
+		await expect(main(["--dry-run"], deps())).rejects.toThrow(
+			/process\.exit\(1\)/,
+		);
+
+		expect(fetchLatest).not.toHaveBeenCalled();
+		expect(fetchTargetManifest).not.toHaveBeenCalled();
+		expect(wranglerMock.listSecrets).not.toHaveBeenCalled();
+		expect(wranglerMock.queryAppliedMigrations).not.toHaveBeenCalled();
+
+		const err = joined(errSpy);
+		expect(err).toMatch(/Wrangler is not logged in to Cloudflare/);
+		expect(err).toMatch(/npx wrangler login/);
+		expect(err).toMatch(/CLOUDFLARE_API_TOKEN/);
+		expect(err).toMatch(/Nothing was changed/);
+		// No plan of any kind was printed.
+		expect(joined(logSpy)).not.toMatch(/Plan:/);
+	});
+
+	it("names the wrangler failure when whoami itself cannot run", async () => {
+		vi.mocked(wranglerMock.checkAuth).mockReturnValue({
+			ok: false,
+			reason: "whoami_failed",
+			detail: "getaddrinfo ENOTFOUND api.cloudflare.com",
+		});
+
+		await expect(main(["--dry-run"], deps())).rejects.toThrow(
+			/process\.exit\(1\)/,
+		);
+		const err = joined(errSpy);
+		expect(err).toMatch(/could not check who is logged in/);
+		expect(err).toMatch(/ENOTFOUND api\.cloudflare\.com/);
+	});
+
+	it("stops during drift detection when a live read fails, with wrangler's own text", async () => {
+		vi.mocked(wranglerMock.listSecrets).mockImplementation(() => {
+			throw new WranglerReadError(
+				"list the Worker's secrets",
+				new SubprocessError(
+					"npx",
+					["wrangler", "secret", "list"],
+					1,
+					"",
+					"✘ [ERROR] A request to the Cloudflare API (/accounts/x/workers/scripts/garrul/secrets) failed. workers.api.error.script_not_found [code: 10007]",
+				),
+			);
+		});
+
+		await expect(main(["--dry-run"], deps())).rejects.toThrow(
+			/process\.exit\(1\)/,
+		);
+
+		const err = joined(errSpy);
+		expect(err).toMatch(/could not list the Worker's secrets/);
+		expect(err).toMatch(/script_not_found/);
+		expect(err).toMatch(/Already logged in\?/);
+		expect(joined(logSpy)).not.toMatch(/Missing required secrets/);
+	});
+
+	it("lets a non-wrangler error out of drift detection untouched", async () => {
+		vi.mocked(wranglerMock.listSecrets).mockImplementation(() => {
+			throw new TypeError("boom");
+		});
+		await expect(main(["--dry-run"], deps())).rejects.toThrow(/boom/);
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not query D1 for a binding wrangler.toml does not have yet", async () => {
+		// A first-ever run: setup.sh has not created the database, so there is
+		// nothing to read and asking wrangler about the binding would fail.
+		(wranglerMock.parseWranglerToml as ReturnType<typeof vi.fn>).mockReturnValue({
+			kvBindings: ["RATE_LIMITS"],
+			d1Bindings: [],
+			analyticsBindings: [],
+			varNames: ["ENV"],
+			vars: { ENV: "production" },
+			raw: "",
+		});
+		vi.mocked(wranglerMock.queryAppliedMigrations).mockImplementation(() => {
+			throw new Error("should not be called");
+		});
+
+		await main(["--dry-run"], deps());
+
+		expect(wranglerMock.queryAppliedMigrations).not.toHaveBeenCalled();
+		const out = joined(logSpy);
+		expect(out).toMatch(/Missing D1 databases/);
+		expect(out).toMatch(/Pending migrations: 3/);
+		// All-missing on a *fresh* install is the expected shape, not suspicious.
+		expect(out).not.toMatch(/reads like a brand-new install/);
+	});
+
+	it("warns when a configured install reads as entirely missing", async () => {
+		vi.mocked(wranglerMock.listSecrets).mockReturnValue([]);
+		vi.mocked(wranglerMock.queryAppliedMigrations).mockReturnValue([]);
+
+		await main(["--dry-run"], deps());
+
+		const out = joined(logSpy);
+		expect(out).toMatch(/reads like a brand-new install, but it is not one/);
+		expect(out).toMatch(/npx wrangler whoami/);
+		// The warning sits above the drift lists it is warning about.
+		expect(out.indexOf("brand-new install")).toBeLessThan(
+			out.indexOf("Missing required secrets"),
+		);
+	});
+
+	it("does not warn when only some drift is present", async () => {
+		await main(["--dry-run"], deps());
+		expect(joined(logSpy)).not.toMatch(/brand-new install/);
 	});
 });

--- a/tests/upgrade-wrangler-reads.test.ts
+++ b/tests/upgrade-wrangler-reads.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The wrangler subprocess seam's *read* functions, driven through a mocked
+ * spawnSync so the real output shapes can be replayed: `wrangler whoami`
+ * exits 0 whether or not there is a login, `secret list` fails on stderr,
+ * `d1 execute --json` fails with an error object on stdout and an empty
+ * stderr. The shapes below are copied from wrangler 4.123.0.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const spawnSync = vi.fn();
+vi.mock("node:child_process", () => ({ spawnSync: (...a: unknown[]) => spawnSync(...a) }));
+
+import {
+	checkAuth,
+	listSecrets,
+	queryAppliedMigrations,
+	describeFailure,
+	SubprocessError,
+	WranglerReadError,
+} from "../scripts/upgrade/wrangler";
+
+const NOT_AUTH =
+	"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.";
+
+const exits = (status: number, stdout = "", stderr = "") =>
+	spawnSync.mockReturnValueOnce({ status, stdout, stderr, error: undefined });
+
+const lastArgs = (): string[] =>
+	(spawnSync.mock.calls.at(-1) as [string, string[]])[1];
+
+beforeEach(() => {
+	spawnSync.mockReset();
+});
+
+describe("checkAuth", () => {
+	it("is ok for an OAuth login", () => {
+		exits(
+			0,
+			" ⛅️ wrangler 4.123.0\n───\nGetting User settings...\n👋 You are logged in with an OAuth Token, associated with the email someone@example.com.\n",
+		);
+		expect(checkAuth()).toEqual({ ok: true });
+		expect(lastArgs()).toEqual(["wrangler", "whoami"]);
+	});
+
+	it("is ok for an API token", () => {
+		exits(0, "👋 You are logged in with an API Token, associated with the email someone@example.com.\n");
+		expect(checkAuth()).toEqual({ ok: true });
+	});
+
+	it("reads a logged-out wrangler off stdout despite exit 0", () => {
+		exits(
+			0,
+			" ⛅️ wrangler 4.123.0\n───\nGetting User settings...\nYou are not authenticated. Please run `wrangler login`.\nTo deploy without logging in, run a command like `wrangler deploy --temporary` to use a temporary preview account.\n",
+		);
+		const r = checkAuth();
+		expect(r.ok).toBe(false);
+		if (!r.ok) {
+			expect(r.reason).toBe("not_logged_in");
+			expect(r.detail).toMatch(/not authenticated/);
+		}
+	});
+
+	it("sees through colour codes", () => {
+		exits(0, "\x1b[33mYou are not authenticated.\x1b[0m Please run `wrangler login`.\n");
+		expect(checkAuth().ok).toBe(false);
+	});
+
+	it("reports the failure when whoami itself exits non-zero", () => {
+		exits(1, "", "✘ [ERROR] getaddrinfo ENOTFOUND api.cloudflare.com\n");
+		const r = checkAuth();
+		expect(r.ok).toBe(false);
+		if (!r.ok) {
+			expect(r.reason).toBe("whoami_failed");
+			expect(r.detail).toBe("getaddrinfo ENOTFOUND api.cloudflare.com");
+		}
+	});
+
+	it("reports the failure when wrangler cannot be spawned", () => {
+		spawnSync.mockReturnValueOnce({
+			status: null,
+			stdout: "",
+			stderr: "",
+			error: new Error("spawnSync npx ENOENT"),
+		});
+		const r = checkAuth();
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.detail).toMatch(/ENOENT/);
+	});
+});
+
+describe("listSecrets", () => {
+	it("returns the secret names", () => {
+		exits(0, JSON.stringify([{ name: "JWT_SECRET", type: "secret_text" }, { name: "IP_HASH_SECRET", type: "secret_text" }]));
+		expect(listSecrets()).toEqual(["JWT_SECRET", "IP_HASH_SECRET"]);
+	});
+
+	it("returns [] for a Worker with no secrets", () => {
+		exits(0, "[]\n");
+		expect(listSecrets()).toEqual([]);
+	});
+
+	it("throws WranglerReadError instead of [] when logged out", () => {
+		exits(1, "\n", `\n\x1b[31m✘ \x1b[41;31m[\x1b[41;97mERROR\x1b[41;31m]\x1b[0m \x1b[1m${NOT_AUTH}\x1b[0m\n\n\n🪵  Logs were written to "/home/x/.wrangler/logs/wrangler-2026-09-04_01-21-59_882.log"\n`);
+		let caught: unknown;
+		try {
+			listSecrets();
+		} catch (e) {
+			caught = e;
+		}
+		expect(caught).toBeInstanceOf(WranglerReadError);
+		const err = caught as WranglerReadError;
+		expect(err.what).toBe("list the Worker's secrets");
+		expect(err.detail).toBe(NOT_AUTH);
+		expect(err.message).toMatch(/could not list the Worker's secrets: In a non-interactive/);
+	});
+
+	it("throws when the Worker does not exist", () => {
+		exits(1, "", "✘ [ERROR] A request to the Cloudflare API (/accounts/abc/workers/scripts/garrul/secrets) failed.\n\n  workers.api.error.script_not_found [code: 10007]\n");
+		expect(() => listSecrets()).toThrow(WranglerReadError);
+		expect(() => {
+			exits(1, "", "✘ [ERROR] A request to the Cloudflare API failed.\n");
+			listSecrets();
+		}).toThrow(/could not list the Worker's secrets: A request to the Cloudflare API failed\./);
+	});
+
+	it("throws on output that is not a JSON array", () => {
+		exits(0, "Getting secrets…\n");
+		expect(() => listSecrets()).toThrow(/parse `wrangler secret list` output/);
+		exits(0, JSON.stringify({ error: "nope" }));
+		expect(() => listSecrets()).toThrow(/expected a JSON array/);
+	});
+});
+
+describe("queryAppliedMigrations", () => {
+	it("returns the applied names", () => {
+		exits(0, JSON.stringify([{ results: [{ name: "0001_init.sql" }, { name: "0002_notifications.sql" }], success: true, meta: {} }]));
+		expect(queryAppliedMigrations("DB", true)).toEqual(["0001_init.sql", "0002_notifications.sql"]);
+		expect(lastArgs()).toEqual(["wrangler", "d1", "execute", "DB", "--remote", "--json", "--command", "SELECT name FROM _migrations"]);
+	});
+
+	it("returns [] for a fresh database with no _migrations table", () => {
+		exits(1, '\n{\n  "error": {\n    "text": "no such table: _migrations: SQLITE_ERROR"\n  }\n}\n', "");
+		expect(queryAppliedMigrations("DB", true)).toEqual([]);
+	});
+
+	it("throws WranglerReadError instead of [] when logged out", () => {
+		exits(1, `\n{\n  "error": {\n    "text": ${JSON.stringify(NOT_AUTH)}\n  }\n}\n`, "");
+		let caught: unknown;
+		try {
+			queryAppliedMigrations("DB", true);
+		} catch (e) {
+			caught = e;
+		}
+		expect(caught).toBeInstanceOf(WranglerReadError);
+		const err = caught as WranglerReadError;
+		expect(err.what).toBe("read applied migrations from D1 binding DB");
+		expect(err.detail).toBe(NOT_AUTH);
+	});
+
+	it("throws when the database does not exist", () => {
+		exits(1, '{"error":{"text":"Couldn\'t find a D1 DB with the name or binding \'DB\' in your wrangler.toml."}}', "");
+		expect(() => queryAppliedMigrations("DB", true)).toThrow(/Couldn't find a D1 DB/);
+	});
+
+	it("throws on output without a results array", () => {
+		exits(0, "[]");
+		expect(() => queryAppliedMigrations("DB", true)).toThrow(/expected \[\{ results/);
+		exits(0, "not json");
+		expect(() => queryAppliedMigrations("DB", true)).toThrow(/parse `wrangler d1 execute` output/);
+	});
+});
+
+describe("describeFailure", () => {
+	it("prefers the --json error text on stdout", () => {
+		const e = new SubprocessError("npx", ["wrangler"], 1, '{"error":{"text":"boom"}}', "ignored stderr");
+		expect(describeFailure(e)).toBe("boom");
+	});
+
+	it("falls back to the first meaningful stderr line, de-prefixed and de-coloured", () => {
+		const e = new SubprocessError("npx", ["wrangler"], 1, "", "\n\n\x1b[31m✘ \x1b[41;31m[\x1b[41;97mERROR\x1b[41;31m]\x1b[0m \x1b[1mSomething broke\x1b[0m\n\nmore\n");
+		expect(describeFailure(e)).toBe("Something broke");
+	});
+
+	it("falls back to stdout when stderr is empty and stdout is not JSON", () => {
+		const e = new SubprocessError("npx", ["wrangler"], 1, "plain text failure\n", "");
+		expect(describeFailure(e)).toBe("plain text failure");
+	});
+
+	it("reports the exit status when both streams are empty", () => {
+		expect(describeFailure(new SubprocessError("npx", ["wrangler"], 3, "", ""))).toBe("exited with 3");
+	});
+
+	it("passes plain Errors and non-Errors through", () => {
+		expect(describeFailure(new Error("x"))).toBe("x");
+		expect(describeFailure("y")).toBe("y");
+	});
+
+	it("SubprocessError's message carries stdout when stderr is empty", () => {
+		const e = new SubprocessError("npx", ["wrangler", "d1"], 1, '{"error":{"text":"boom"}}', "");
+		expect(e.message).toMatch(/npx wrangler d1 exited with 1: \{"error"/);
+	});
+});


### PR DESCRIPTION
## Summary

`npm run upgrade` on a machine whose wrangler OAuth login had expired produced a plan listing every required secret as missing and all 23 migrations as pending, on an install that has been running fine for months. The two live reads in `scripts/upgrade/wrangler.ts` caught every subprocess failure and returned `[]`, so an unauthenticated read looked exactly like an empty deployment. Nothing upstream could notice because `wrangler whoami` exits 0 even when logged out.

This PR makes the failure visible and tells the operator how to fix it, at three layers:

1. **Preflight auth check.** `wrangler whoami` runs before anything is fetched; its stdout is inspected for "not authenticated" (ANSI stripped). A logged-out wrangler stops the run with:

   ```
   ✘ Wrangler is not logged in to Cloudflare.

     wrangler said: You are not authenticated. Please run `wrangler login`.

     The upgrade plan is a comparison against your live Worker — its
     secrets and the migrations already applied to your D1 database.
     Without that reading, every secret would show as missing and every
     migration as pending, so nothing is shown rather than a wrong plan.

     To fix it, do one of these and then re-run `npm run upgrade`:

       • At a terminal:   npx wrangler login
         (also the fix when a previous login has expired)
       • In CI or a script:   export CLOUDFLARE_API_TOKEN=<token>
         Token needs Workers Scripts:Edit and D1:Edit on this account.

     Nothing was changed. Your Worker, database and secrets are as they were.
   ```

2. **Reads fail loudly.** `listSecrets()` and `queryAppliedMigrations()` throw `WranglerReadError` carrying wrangler's own message (the `--json` error text for d1, the de-coloured `✘ [ERROR]` line for `secret list`). The one failure still treated as "zero applied" is `no such table: _migrations`, which is a genuine fresh database. `main()` catches this at the drift step and prints the same block, plus a hint to check `name` / `account_id` / `database_id` since a login is known to exist at that point.

3. **Plan-shape guard.** `looksLikeLostInstall()` flags a plan with every migration pending and every required secret missing on an install whose D1 binding is configured; `printPlan` warns before the confirm prompt. Covers a valid login pointed at the wrong Worker or database.

Also: `computePlan` no longer queries a D1 binding that is absent from `wrangler.toml`.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (135 files / 2526 tests) all pass.
- New `tests/upgrade-wrangler-reads.test.ts` replays real wrangler 4.123.0 output shapes through a mocked `spawnSync`.
- `tests/upgrade-dry-run.test.ts` drives `main()` through logged-out preflight, whoami failure, failed secret read, failed migration read, and unconfigured binding.
- End-to-end: `npx tsx scripts/upgrade.ts --dry-run --allow-dirty` on the affected machine (wrangler logged out) now exits 1 with the block above instead of the bogus plan.

## Docs

- `docs/troubleshooting.md`: new entry for the all-missing plan symptom and its three causes; the "Authentication error" entry gets the current wrangler config path and the CI token route.
- `AGENTS-OPERATE.md` §12: steps 1 and 4 describe the preflight and the fail-loud reads.

No release is cut in this PR.
