### PR TITLE
chore(release): 2.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "2.24.0",
+      "version": "2.24.1",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.24.0",
+  "version": "2.24.1",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 2,


### PR DESCRIPTION
Patch release. Contents since v2.24.0: #128 (optional `GITHUB_TOKEN` / `GH_TOKEN` for `npm run upgrade` release lookups, rate-limit-aware 403 message). Version bump plus regenerated `release-manifest.json` only; no new env vars, no migrations.