### PR TITLE
fix: three findings from the 2026-09 external security review

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -325,7 +325,15 @@ ignores them behaves exactly as before.
   is the host page's real publish time when the embed supplies `data-published`
   (stored as `posts.published_at`); without it Garrul falls back to first-comment
   time, which is later than real publish, so set `data-published` if you rely on
-  `AUTO_CLOSE_DAYS`. A closed thread hides the composer (the widget shows a
+  `AUTO_CLOSE_DAYS`. The anchor is **set once, by whichever request first creates
+  the post row, and never changes** — `data-published` arrives on an
+  unauthenticated comment POST, and an old enough value closes the thread
+  permanently with no repair path short of direct D1 SQL, so a later request is
+  not allowed to supply or move it. The practical consequence: if a reaction, a
+  page vote or an admin pre-close created the row before the first comment, that
+  slug keeps the first-engagement anchor even once `data-published` starts
+  arriving. It closes later than you asked, never earlier. A closed thread hides
+  the composer (the widget shows a
   reason-specific notice) and the POST endpoint rejects new comments **and
   replies** with `403 err.thread_closed` — existing comments, reactions, and
   votes stay live. Per-post manual close (below) overrides nothing here; it's a

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -907,6 +907,7 @@ tracked by the `_migrations` table. Current set:
 - `0021_moderator_notifications.sql` — `moderator_notifications`, the queue behind moderator email (seeds its own `moderator:*` budget rows)
 - `0022_reaction_kind_fire.sql` — renames the `like` reaction to `fire`
 - `0023_moderator_notes.sql` — `moderator_notes`, internal moderator context on one comment or one account. Never rendered to readers, and the note *body* never reaches `audit_log`
+- `0024_subscriptions_token_index.sql` — `subscriptions(token)`; the unsubscribe-link lookup was a full table scan on two endpoints that take no session and no rate limit, so a loop of random tokens read the whole table per request
 
 Run with `npm run migrate` (local Miniflare) or
 `npm run migrate -- --remote` (production D1). Idempotent. Never edit a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ Every attribute the widget reads from the `#garrul` host element
 | `data-api`   | no       | Worker origin override. Defaults to the origin of the script tag (`<script src>`). Set this explicitly when loading `embed.js` via a bundler or async import (anywhere `document.currentScript` may be null at execution time). |
 | `data-title` | no       | Post title; sent on first comment create, surfaces in admin and notification emails.        |
 | `data-url`   | no       | Canonical permalink; sent on first comment create, used in RSS and notification emails.     |
-| `data-published` | no   | Article publish time (epoch ms or ISO 8601); sent on first comment create. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit and Garrul falls back to the first-comment time, which closes the thread a bit later than intended. Only relevant if the operator enabled `AUTO_CLOSE_DAYS`. |
+| `data-published` | no   | Article publish time (epoch ms or ISO 8601); sent on first comment create. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit and Garrul falls back to the first-comment time, which closes the thread a bit later than intended. Only relevant if the operator enabled `AUTO_CLOSE_DAYS`. Recorded only by the request that creates the post row and immutable after that — it comes in on an unauthenticated POST and an old value closes the thread for good, so it is never accepted from a later request. If a reaction or page vote created the row first, the slug keeps the first-engagement anchor. |
 | `data-lang`  | no       | BCP-47 tag pinning the widget's interface language (see "Language" below). Unrecognized tags fall back to English rather than erroring. |
 
 The host element MUST have `id="garrul"`; the widget looks it up by ID

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1066,6 +1066,16 @@ Cookies set by Garrul:
 
 - `__Host-garrul_sess` — session lookup ID. `HttpOnly; Secure;
   SameSite=None; Partitioned; Path=/`. No tracking cookies are set.
+- `__Host-garrul_oauth_b_<8 hex>` — per-flow OAuth binding cookie, set
+  only while a sign-in popup is open and cleared by the callback.
+  `HttpOnly; Secure; SameSite=Lax; Path=/`, 600-second Max-Age. It holds
+  the signed flow state (provider, return origin, PKCE verifier), no
+  identity. The `__Host-` prefix is what binds the flow to the browser
+  that started it: the signature proves Garrul issued the state, not who
+  holds it, so an unprefixed name let any sibling host under the
+  operator's eTLD+1 plant its own state/cookie pair (RFC 6749 §10.12
+  login CSRF). `ENV=dev` drops the prefix, because plain-HTTP
+  `wrangler dev` cannot satisfy `Secure`.
 
 For the operator-facing privacy posture (retention policy, deletion
 flow, Cloudflare/Resend subprocessor disclosure, GDPR/COPPA notes),

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -394,7 +394,8 @@
     "0020_subscriptions_locale.sql",
     "0021_moderator_notifications.sql",
     "0022_reaction_kind_fire.sql",
-    "0023_moderator_notes.sql"
+    "0023_moderator_notes.sql",
+    "0024_subscriptions_token_index.sql"
   ],
   "breakingChanges": [
     {

--- a/src/db/migrations/0024_subscriptions_token_index.sql
+++ b/src/db/migrations/0024_subscriptions_token_index.sql
@@ -1,0 +1,28 @@
+-- Index subscriptions by unsubscribe token.
+-- Forward-only. The migration runner records this as applied; never edit
+-- once shipped — make a 0025_*.sql instead.
+--
+-- `token` has had no index since 0001_init.sql, so every lookup in
+-- getSubscriptionByToken was a full table scan — including a lookup for a
+-- token that does not exist. That is reachable by anyone:
+--
+--   * GET /api/v1/subscribe/unsubscribe/:token is in CARVE_OUT_PATHS
+--     (lib/cors.ts), so it takes no session, no Origin and no rate limit.
+--   * POST .../one-click is in NO_ORIGIN_POST_PATHS for RFC 8058 and is
+--     deliberately not IP-limited, because a mail provider's shared egress
+--     would throttle legitimate unsubscribes.
+--
+-- The token's unguessability bounds what an attacker can *change*; it never
+-- bounded what a lookup *costs*. D1 bills rows read, so on a populated table
+-- a loop of random 64-hex tokens reads the whole table per request and burns
+-- the read budget for every other feature. Same reasoning as 0017's
+-- email index, which called out exactly this shape for the pending-cap count.
+--
+-- Not UNIQUE, deliberately. Collisions are cryptographically implausible
+-- (32 random bytes from crypto.getRandomValues, one writer), but a UNIQUE
+-- index would turn any duplicate that somehow exists on a live install into
+-- a migration that cannot apply — and this index does nothing to earn that
+-- risk. Uniqueness is not a property anything reads.
+
+CREATE INDEX IF NOT EXISTS idx_subs_token
+	ON subscriptions(token);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -139,9 +139,9 @@ export const upsertPost = async (
 	// title and url are first-writer-wins: COALESCE(existing, excluded). Both
 	// arrive on an unauthenticated POST /api/v1/comments at the same trust level
 	// as the comment body, and this upsert runs *before* spam evaluation, so a
-	// last-writer-wins update let anyone who could post a (even quarantined)
-	// comment repoint an established thread's title and canonical URL — which fan
-	// out into mail subjects, the Atom feed and webhook payloads. The cost is that
+	// last-writer-wins update let anyone who could post a comment — even one that
+	// lands quarantined — repoint an established thread's title and canonical URL,
+	// which fan out into mail subjects, the Atom feed and webhooks. The cost is that
 	// a genuinely renamed page keeps its original title; there is no admin edit
 	// path for it yet. closed is operator-controlled and never set here.
 	//

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1990,10 +1990,29 @@ export const upsertSubscription = async (
 	return row;
 };
 
+// The shape `randomToken()` in routes/api.subscriptions.ts has minted since
+// subscriptions shipped: 32 bytes from crypto.getRandomValues, lowercase hex.
+// It is the only writer of this column, and no importer touches it.
+const SUB_TOKEN_RE = /^[0-9a-f]{64}$/;
+
+/**
+ * Look up a subscription by its unsubscribe token.
+ *
+ * The shape check is free and cannot change behavior: `token` is TEXT with
+ * BINARY collation, so anything failing this regex could never have equalled a
+ * stored value — the query would return null after reading the table. Rejecting
+ * it here means the two unauthenticated callers (the CARVE_OUT GET and the
+ * RFC 8058 one-click POST, neither rate-limited) stop paying for a D1 read on
+ * junk input. Same choke-point pattern as `consumeHandoff` in lib/oauth.ts.
+ *
+ * Well-formed random tokens still reach the query — that is what 0024's
+ * `idx_subs_token` is for. The guard is the cheap half of the fix, not the fix.
+ */
 export const getSubscriptionByToken = async (
 	db: D1Database,
 	token: string,
 ): Promise<Subscription | null> => {
+	if (!SUB_TOKEN_RE.test(token)) return null;
 	return await db
 		.prepare(
 			`SELECT id, post_slug, email, token, created_at,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -136,24 +136,38 @@ export const upsertPost = async (
 	publishedAt: number | null = null,
 ): Promise<Post> => {
 	const now = Date.now();
-	// Every column here is write-once / first-writer-wins: COALESCE(existing,
-	// excluded). title and url arrive on an unauthenticated POST /api/v1/comments
-	// at the same trust level as the comment body, and this upsert runs *before*
-	// spam evaluation, so a last-writer-wins update let anyone who could post a
-	// (even quarantined) comment repoint an established thread's title and
-	// canonical URL — which fan out into mail subjects, the Atom feed and webhook
-	// payloads. published_at anchors age-based auto-close, so once set it must be
-	// immutable or a bogus date could force a thread closed. The cost is that a
-	// genuinely renamed page keeps its original title; there is no admin edit path
-	// for it yet. closed is operator-controlled and never set here.
+	// title and url are first-writer-wins: COALESCE(existing, excluded). Both
+	// arrive on an unauthenticated POST /api/v1/comments at the same trust level
+	// as the comment body, and this upsert runs *before* spam evaluation, so a
+	// last-writer-wins update let anyone who could post a (even quarantined)
+	// comment repoint an established thread's title and canonical URL — which fan
+	// out into mail subjects, the Atom feed and webhook payloads. The cost is that
+	// a genuinely renamed page keeps its original title; there is no admin edit
+	// path for it yet. closed is operator-controlled and never set here.
+	//
+	// published_at is stricter: INSERT-only, absent from DO UPDATE entirely. It
+	// anchors age-based auto-close, so a bogus old date forces a thread closed
+	// permanently — and unlike a repointed title there is no repair path short of
+	// direct D1 SQL. COALESCE looks like it covers that, but it only protects a
+	// value that is already *there*; a row whose published_at is NULL stayed
+	// writable by every later commenter, and NULL is the normal state (the two
+	// other callers — page-engagement and admin — pass no date at all, and most
+	// host pages never set `data-published`). So the column is fixed by whichever
+	// request creates the row and never moves again.
+	//
+	// The cost is real: a row created by a reaction, a page vote or an admin
+	// pre-close can no longer pick up a `data-published` anchor from a later
+	// comment, so age-based close on that slug measures from created_at (first
+	// engagement) instead. That is the pre-`data-published` behavior and it errs
+	// toward closing *later* than the operator asked, which is the safe
+	// direction — where the poisoned value errs toward closed forever.
 	await db
 		.prepare(
 			`INSERT INTO posts (slug, title, url, created_at, published_at)
 			 VALUES (?, ?, ?, ?, ?)
 			 ON CONFLICT(slug) DO UPDATE SET
 			   title        = COALESCE(posts.title, excluded.title),
-			   url          = COALESCE(posts.url,   excluded.url),
-			   published_at = COALESCE(posts.published_at, excluded.published_at)`,
+			   url          = COALESCE(posts.url,   excluded.url)`,
 		)
 		.bind(slug, title, url, now, publishedAt)
 		.run();

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -181,14 +181,25 @@ export const buildShortCookie = (
 	env: { ENV: string },
 	path = "/api/v1/auth",
 ): string => {
+	// A `__Host-` name is only honored by the browser when the write carries
+	// Secure, `Path=/`, and no Domain — otherwise the whole Set-Cookie is
+	// dropped, silently, and the flow it protects starts failing instead of the
+	// prefix protecting anything. So the prefix decides those attributes here
+	// rather than trusting each caller to pass a matching path: the invariant
+	// lives with the name, and a caller that asks for a narrower path on a
+	// `__Host-` cookie gets `/` regardless. Losing the /api/v1/auth scoping is
+	// the price of the prefix, and it is worth paying — the cookie is HttpOnly
+	// and lives 600 seconds, while an unprefixed name is plantable by any
+	// sibling subdomain (see OAUTH_BIND_COOKIE_PREFIX_PROD in routes/auth.ts).
+	const hostPrefixed = name.startsWith("__Host-");
 	const parts = [
 		`${name}=${value}`,
-		`Path=${path}`,
+		`Path=${hostPrefixed ? "/" : path}`,
 		`Max-Age=${maxAgeSeconds}`,
 		"HttpOnly",
 		"SameSite=Lax",
 	];
-	if (env.ENV !== "dev") {
+	if (hostPrefixed || env.ENV !== "dev") {
 		parts.push("Secure");
 	}
 	return parts.join("; ");

--- a/src/lib/thread.ts
+++ b/src/lib/thread.ts
@@ -25,6 +25,11 @@
  * anchor is what makes day-based closing accurate. With neither a meaningful
  * anchor nor published_at, day-based close still works off created_at, just
  * measured from first-comment time.
+ *
+ * That anchor is the one moderation-relevant value here that a *caller* can
+ * set, which is why upsertPost only ever writes it on INSERT: an old enough
+ * published_at puts the thread permanently past the cutoff, this resolver
+ * re-derives that on every request, and nothing but direct D1 SQL can undo it.
  */
 import type { Post } from "../db/queries";
 import type { ResolvedFlags, ResolvedNumbers } from "./settings";

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -633,24 +633,19 @@ comments.post("/", async (c) => {
 		return c.json({ error: t("err.thread_closed") }, 403);
 	}
 
-	// Make sure the post row exists so the FK on comments resolves. published_at
-	// is write-once in upsertPost (first-writer-wins), so this can establish a
-	// fresh thread's anchor but can never overwrite an established one.
-	await upsertPost(
-		c.env.DB,
-		slug,
-		// post_title is caller-supplied at the same trust level as the comment
-		// body but had no validation at all; see lib/post-title.ts for where it
-		// fans out to (mail subjects, Atom, Slack/Discord).
-		sanitizePostTitle(body.post_title),
-		postUrl,
-		parsePublishedAt(body.post_published),
-	);
-
 	// Parent must exist, live on the same post, and leave room under the
 	// nesting cap. Without the depth check an unbounded reply chain is
 	// insertable, which makes the slug's comment tree permanently
 	// un-renderable — see MAX_REPLY_DEPTH in src/lib/tree.ts.
+	//
+	// This runs BEFORE upsertPost for the same reason the thread gate above
+	// does: everything upsertPost writes is caller-supplied and permanent, so a
+	// request that is going to be rejected must not leave a trace. With the
+	// upsert first, a reply naming a nonexistent (or foreign, or too-deep)
+	// parent still got a 400 *and* stamped the post's title, url and
+	// published_at — the write survived its own rejection, which also meant an
+	// attacker could reach the upsert on any slug without ever passing the
+	// checks that gate a real comment.
 	let parent_id: string | null = null;
 	let depth = 1;
 	if (body.parent_id) {
@@ -665,6 +660,21 @@ comments.post("/", async (c) => {
 			return c.json({ error: t("err.parent.too_deep") }, 400);
 		}
 	}
+
+	// Make sure the post row exists so the FK on comments resolves. published_at
+	// is INSERT-only in upsertPost, so this can establish a fresh thread's anchor
+	// but can never move an existing row's — see the comment there for why
+	// first-writer-wins was not enough for that one column.
+	await upsertPost(
+		c.env.DB,
+		slug,
+		// post_title is caller-supplied at the same trust level as the comment
+		// body but had no validation at all; see lib/post-title.ts for where it
+		// fans out to (mail subjects, Atom, Slack/Discord).
+		sanitizePostTitle(body.post_title),
+		postUrl,
+		parsePublishedAt(body.post_published),
+	);
 
 	const userAgent = c.req.header("user-agent") ?? null;
 	const verdict = await evaluateSpam(

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -45,7 +45,31 @@ import { log } from "../lib/log";
 // only the most-recently-started flow could complete; the other tab's /callback
 // would always fail with "invalid state". The full state is compared inside the
 // signed payload, so the truncated name is only a bucket, never the check.
-const OAUTH_BIND_COOKIE_PREFIX = "garrul_oauth_b_";
+//
+// **`__Host-` in production, and that prefix is the security boundary, not
+// decoration.** A signature proves the server issued the payload; it says
+// nothing about *which browser* holds it. Without the prefix, an attacker who
+// controls any sibling subdomain (`other.example.com` when the Worker is
+// `comments.example.com`) can run their own /start, take the resulting valid
+// cookie, and plant it in a victim's browser as a `Domain=example.com;
+// Path=/api/v1/auth` cookie — host-only defaults on our own write do not stop a
+// sibling from setting a *different* cookie with the same name, and the random
+// per-flow suffix means it won't even collide with a flow the victim started.
+// Navigating the victim to the callback with the attacker's unused code then
+// passes every check and signs the victim into the attacker's account
+// (RFC 6749 §10.12 login CSRF). `__Host-` is the one cookie attribute set a
+// sibling cannot forge: browsers reject a `__Host-` write that carries a Domain
+// or a path other than `/`.
+//
+// Dev keeps the bare name because `__Host-` also requires Secure, which a
+// `wrangler dev` instance over plain HTTP cannot satisfy — same split as the
+// session cookie in lib/session.ts. There is deliberately **no** fallback to
+// the old unprefixed name in production: accepting it would leave the planting
+// path open, which is the whole point of the rename. The cost is that an OAuth
+// flow started in the 600 seconds before a deploy fails once with "invalid
+// state" and has to be retried.
+const OAUTH_BIND_COOKIE_PREFIX_PROD = "__Host-garrul_oauth_b_";
+const OAUTH_BIND_COOKIE_PREFIX_DEV = "garrul_oauth_b_";
 const OAUTH_BIND_TTL_SECONDS = 600;
 
 // `state` is always 48 lowercase hex chars (randomState in lib/oauth). Check
@@ -57,8 +81,8 @@ const OAUTH_BIND_TTL_SECONDS = 600;
 // catches a wrong state, but only after it has already been interpolated.
 const STATE_RE = /^[0-9a-f]{48}$/;
 
-const bindCookieName = (state: string): string =>
-	`${OAUTH_BIND_COOKIE_PREFIX}${state.slice(0, 8)}`;
+const bindCookieName = (env: { ENV: string }, state: string): string =>
+	`${env.ENV === "dev" ? OAUTH_BIND_COOKIE_PREFIX_DEV : OAUTH_BIND_COOKIE_PREFIX_PROD}${state.slice(0, 8)}`;
 
 const auth = new Hono<{ Bindings: Bindings }>();
 
@@ -125,11 +149,12 @@ auth.get("/:provider/start", async (c) => {
 	// The flow's entire state is a signed payload in a per-flow cookie — no
 	// server-side write, which is what stops this unauthenticated route from
 	// being an account-wide KV-quota exhaustion primitive (see issueState).
-	// The cookie is also what binds the flow to THIS browser: an attacker can
-	// mint state+code in their own session but cannot plant the matching
-	// cookie in a victim's browser, so they can't trick the victim into
-	// completing the callback and landing on the attacker's session
-	// (RFC 6749 §10.12 login-CSRF).
+	// The cookie is also what binds the flow to THIS browser, and the binding
+	// rests on the `__Host-` prefix rather than on the signature: an attacker
+	// can mint a state+cookie pair from their own /start, so what has to be
+	// impossible is *planting* that pair in a victim's browser. See
+	// OAUTH_BIND_COOKIE_PREFIX_PROD above for why an unprefixed name left that
+	// open to any sibling subdomain (RFC 6749 §10.12 login CSRF).
 	const { state, token } = await issueState(c.env.JWT_SECRET, {
 		provider,
 		return_origin,
@@ -139,7 +164,7 @@ auth.get("/:provider/start", async (c) => {
 	c.header(
 		"Set-Cookie",
 		buildShortCookie(
-			bindCookieName(state),
+			bindCookieName(c.env, state),
 			token,
 			OAUTH_BIND_TTL_SECONDS,
 			c.env,
@@ -228,7 +253,7 @@ auth.get("/:provider/callback", async (c) => {
 	// time — that the payload is bound to the `state` the provider echoed
 	// back. One generic error for every failure: don't tell the attacker
 	// which check tripped.
-	const cookieName = bindCookieName(state);
+	const cookieName = bindCookieName(c.env, state);
 	const stateToken = parseCookie(c.req.header("cookie"), cookieName);
 	const payload = stateToken
 		? await verifyState(c.env.JWT_SECRET, stateToken, { provider, state })

--- a/tests/auth-routes.test.ts
+++ b/tests/auth-routes.test.ts
@@ -160,6 +160,49 @@ describe("GET /:provider/callback — state shape", () => {
 			env as unknown as Record<string, unknown>,
 		);
 		expect(res.status).toBe(400);
-		expect(res.headers.get("set-cookie")).toContain("garrul_oauth_b_abababab=");
+		// The clear must name the same cookie /start set, prefix included — a
+		// mismatched name (or path) leaves the single-use flow cookie live.
+		expect(res.headers.get("set-cookie")).toContain(
+			"__Host-garrul_oauth_b_abababab=;",
+		);
+	});
+});
+
+/**
+ * The binding cookie's name is the whole defense. Its signature proves we
+ * issued the state, not which browser holds it, so an attacker who starts a
+ * flow himself can hand the victim his own state — the only thing stopping him
+ * pairing it with the matching cookie is that `__Host-` cannot be written by a
+ * sibling host under the operator's eTLD+1. `comments.<yourdomain>` is the
+ * documented layout, so a sibling is the expected case, not an exotic one.
+ */
+describe("GET /:provider/start — binding cookie name", () => {
+	const start = async (envOverride: Record<string, string> = {}) => {
+		const res = await app().request(
+			"/github/start",
+			{},
+			{
+				...(env as unknown as Record<string, unknown>),
+				GH_CLIENT_ID: "cid",
+				GH_CLIENT_SECRET: "csecret",
+				...envOverride,
+			} as Record<string, unknown>,
+		);
+		expect(res.status).toBe(302);
+		return res.headers.get("set-cookie") ?? "";
+	};
+
+	it("prefixes the cookie in production, with the attributes the prefix needs", async () => {
+		const sc = await start();
+		expect(sc).toContain("__Host-garrul_oauth_b_");
+		expect(sc).toMatch(/(^|; )Path=\/(;|$)/);
+		expect(sc).toMatch(/(^|; )Secure(;|$)/);
+		expect(sc).not.toMatch(/Domain=/);
+	});
+
+	it("drops the prefix in dev, where plain HTTP cannot satisfy Secure", async () => {
+		const sc = await start({ ENV: "dev" });
+		expect(sc.startsWith("garrul_oauth_b_")).toBe(true);
+		expect(sc).toContain("Path=/api/v1/auth");
 	});
 });

--- a/tests/post-title.test.ts
+++ b/tests/post-title.test.ts
@@ -251,11 +251,42 @@ describe("upsertPost is first-writer-wins (real SQLite)", () => {
 		expect(post!.url).toBe("https://a.example/hello");
 	});
 
-	it("keeps published_at write-once alongside them", async () => {
+	it("refuses to move a stored published_at", async () => {
 		await upsertPost(db, "hello", "T", null, 1_700_000_000_000);
 		await upsertPost(db, "hello", "T", null, 1);
 		const post = await getPost(db, "hello");
 		expect(post!.published_at).toBe(1_700_000_000_000);
+	});
+
+	it("refuses to fill a NULL published_at from a later write", async () => {
+		// The hole COALESCE left open. published_at anchors age-based auto-close,
+		// and NULL is the normal state — page-engagement and admin create rows
+		// with no date, and most host pages never send `data-published`. So
+		// first-writer-wins protected almost nothing: any later commenter could
+		// stamp epoch 1 on an established thread and, with auto_close_days set,
+		// close it permanently with no repair path short of direct D1 SQL.
+		await upsertPost(db, "hello", null, null);
+		await upsertPost(db, "hello", "T", null, 1);
+		expect((await getPost(db, "hello"))!.published_at).toBeNull();
+	});
+
+	it("accepts published_at from the write that creates the row", async () => {
+		// The feature still works where it can: a slug whose first touch is the
+		// comment POST gets the host page's real publish time as its anchor.
+		await upsertPost(db, "hello", "T", null, 1_700_000_000_000);
+		expect((await getPost(db, "hello"))!.published_at).toBe(1_700_000_000_000);
+	});
+
+	it("leaves a row created without a date anchored on created_at", async () => {
+		// The accepted cost: a reaction, page vote or admin pre-close creates the
+		// row, so a later `data-published` never lands and age-based close
+		// measures from first engagement. That closes *later* than the operator
+		// asked, which is the safe direction.
+		await upsertPost(db, "hello", null, null);
+		await upsertPost(db, "hello", "T", null, 1_700_000_000_000);
+		const post = await getPost(db, "hello");
+		expect(post!.published_at).toBeNull();
+		expect(post!.created_at).toBeGreaterThan(0);
 	});
 
 	it("does not create a second row for the same slug", async () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -9,6 +9,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+	buildShortCookie,
+	clearShortCookie,
 	destroySession,
 	issueSession,
 	readSession,
@@ -573,5 +575,82 @@ describe("revokeOtherSessions (sign out everywhere else)", () => {
 			cookieHeader: `__Host-garrul_sess=${otherSid}`,
 		});
 		expect(await readSession(replayCtx)).toBeNull();
+	});
+});
+
+/**
+ * The short-lived flow cookies (`buildShortCookie` / `clearShortCookie`).
+ *
+ * The OAuth binding cookie is what proves the browser finishing a callback is
+ * the browser that started the flow. Its signature proves only that *we* issued
+ * the state — so an unprefixed name is enough for any host under the operator's
+ * eTLD+1 to plant a state/cookie pair it minted itself, walk the victim into
+ * the callback, and land them on the attacker's session (login CSRF, RFC 6749
+ * §10.12). `__Host-` is the one attribute set a sibling cannot forge.
+ *
+ * The catch is that the prefix is all-or-nothing: a browser drops the whole
+ * Set-Cookie unless it carries Secure, `Path=/`, and no Domain. A caller-chosen
+ * `/api/v1/auth` path would silently break every production login instead of
+ * hardening it, so the builder derives those attributes from the name.
+ */
+describe("short flow cookies", () => {
+	const prod = { ENV: "prod" };
+	const dev = { ENV: "dev" };
+
+	it("forces the prefix's required attributes, overriding the caller's path", () => {
+		const sc = buildShortCookie("__Host-garrul_oauth_b_abababab", "v", 600, prod);
+		expect(sc.startsWith("__Host-garrul_oauth_b_abababab=v;")).toBe(true);
+		expect(sc).toMatch(/(^|; )Path=\/(;|$)/);
+		expect(sc).toMatch(/(^|; )Secure(;|$)/);
+		expect(sc).not.toMatch(/Domain=/);
+		expect(sc).not.toContain("/api/v1/auth");
+	});
+
+	it("ignores an explicit narrower path on a prefixed name", () => {
+		// The call sites pass no path today, but a future one must not be able to
+		// reintroduce the rejected shape by passing the old default back in.
+		const sc = buildShortCookie("__Host-x", "v", 600, prod, "/api/v1/auth");
+		expect(sc).toMatch(/(^|; )Path=\/(;|$)/);
+	});
+
+	it("keeps Secure on a prefixed cookie even in dev", () => {
+		// A prefixed name without Secure is a cookie the browser throws away, so
+		// the dev relaxation must not reach it. Dev instead picks the unprefixed
+		// name (see bindCookieName in routes/auth.ts).
+		expect(buildShortCookie("__Host-x", "v", 600, dev)).toMatch(
+			/(^|; )Secure(;|$)/,
+		);
+	});
+
+	it("leaves an unprefixed cookie scoped and dev-relaxed", () => {
+		const sc = buildShortCookie("garrul_oauth_b_abababab", "v", 600, dev);
+		expect(sc).toContain("Path=/api/v1/auth");
+		expect(sc).not.toMatch(/(^|; )Secure(;|$)/);
+	});
+
+	it("adds Secure to an unprefixed cookie outside dev", () => {
+		expect(buildShortCookie("garrul_oauth_b_x", "v", 600, prod)).toMatch(
+			/(^|; )Secure(;|$)/,
+		);
+	});
+
+	it("clears a prefixed cookie with the same attributes it was set with", () => {
+		// A Set-Cookie whose attributes don't match is a second cookie, not a
+		// deletion — the single-use flow cookie would survive its own callback.
+		const cleared = clearShortCookie("__Host-garrul_oauth_b_abababab", prod);
+		expect(cleared).toContain("__Host-garrul_oauth_b_abababab=;");
+		expect(cleared).toContain("Max-Age=0");
+		expect(cleared).toMatch(/(^|; )Path=\/(;|$)/);
+		expect(cleared).toMatch(/(^|; )Secure(;|$)/);
+	});
+
+	it("keeps every flow cookie HttpOnly and SameSite=Lax", () => {
+		for (const name of ["__Host-garrul_oauth_b_x", "garrul_oauth_b_x"]) {
+			for (const env of [prod, dev]) {
+				const sc = buildShortCookie(name, "v", 600, env);
+				expect(sc).toContain("HttpOnly");
+				expect(sc).toContain("SameSite=Lax");
+			}
+		}
 	});
 });

--- a/tests/subscriptions-index.test.ts
+++ b/tests/subscriptions-index.test.ts
@@ -1,5 +1,6 @@
 /**
- * Query-plan coverage for the email-keyed subscription lookups.
+ * Query-plan coverage for the indexed subscription lookups — email (0017) and
+ * unsubscribe token (0024).
  *
  * `countPendingSubscriptionsForEmail` runs once per unauthenticated POST
  * /api/v1/subscribe to enforce the per-email pending cap, and D1 bills rows
@@ -17,6 +18,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { getSubscriptionByToken } from "../src/db/queries";
 
 const MIGRATIONS_DIR = join(__dirname, "../src/db/migrations");
 
@@ -84,5 +86,75 @@ describe("subscriptions email index", () => {
 		expect(() =>
 			ins.run("s2", "post-b", "dup@example.com", "t2", now),
 		).not.toThrow();
+	});
+});
+
+describe("subscriptions token index", () => {
+	it("serves the unsubscribe-token lookup from the index, not a scan", () => {
+		// Verbatim projection and predicate from getSubscriptionByToken, which
+		// backs the unauthenticated CARVE_OUT GET and the un-rate-limited RFC
+		// 8058 one-click POST. Before 0024 this was `SCAN subscriptions` for
+		// every request, including one carrying a token that does not exist.
+		const detail = plan(
+			`SELECT id, post_slug, email, token, created_at,
+			        unsubscribed_at, last_notified_at,
+			        confirm_token, confirmed_at, locale
+			   FROM subscriptions WHERE token = 'deadbeef'`,
+		);
+		expect(detail).toContain("idx_subs_token");
+		expect(detail).not.toContain("SCAN subscriptions");
+	});
+
+	it("keeps one address able to hold many tokens", () => {
+		// idx_subs_token is deliberately not UNIQUE — see the migration header.
+		const now = Date.now();
+		const ins = sqlite.prepare(
+			`INSERT INTO subscriptions (id, post_slug, email, token, created_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+		);
+		ins.run("t-s1", "post-c", "many@example.com", "same-token", now);
+		expect(() =>
+			ins.run("t-s2", "post-d", "many@example.com", "same-token", now),
+		).not.toThrow();
+	});
+});
+
+describe("getSubscriptionByToken shape guard", () => {
+	// A D1 that fails the test if it is ever asked to prepare a statement. The
+	// point of the guard is that junk input costs no D1 read at all, and only a
+	// stub that refuses to be queried can prove that.
+	const refusingDb = {
+		prepare: () => {
+			throw new Error("getSubscriptionByToken queried D1 for a junk token");
+		},
+	} as unknown as D1Database;
+
+	const good = "a".repeat(64);
+
+	it.each([
+		["empty", ""],
+		["too short", "a".repeat(63)],
+		["too long", "a".repeat(65)],
+		["uppercase hex", "A".repeat(64)],
+		["non-hex", "z".repeat(64)],
+		["hex with a wildcard", `${"a".repeat(63)}%`],
+		["sql-ish", "' OR 1=1 --"],
+	])("returns null without querying: %s", async (_label, token) => {
+		await expect(getSubscriptionByToken(refusingDb, token)).resolves.toBeNull();
+	});
+
+	it("still queries for a well-formed token", async () => {
+		// The guard must not become the access control. A random 64-hex token is
+		// indistinguishable from a real one until D1 answers, which is why the
+		// index exists.
+		let asked = "";
+		const db = {
+			prepare: (sql: string) => {
+				asked = sql;
+				return { bind: () => ({ first: async () => null }) };
+			},
+		} as unknown as D1Database;
+		await expect(getSubscriptionByToken(db, good)).resolves.toBeNull();
+		expect(asked).toContain("FROM subscriptions WHERE token = ?");
 	});
 });

--- a/tests/subscriptions-unsubscribe.test.ts
+++ b/tests/subscriptions-unsubscribe.test.ts
@@ -52,7 +52,14 @@ const makeD1 = (db: DatabaseSync): any => ({
 
 const SLUG = "notify-me";
 const EMAIL = "reader@example.com";
-const TOKEN = "u".repeat(64);
+// Real unsubscribe tokens are 64 lowercase hex chars (randomToken in
+// routes/api.subscriptions.ts), and getSubscriptionByToken rejects anything
+// else before it reaches D1 — so a fixture has to be hex to exercise the
+// lookup at all. "u" was not, which made every token here unrepresentative.
+const TOKEN = "e".repeat(64);
+// Well-formed but never stored. The point of the unknown-token cases is the
+// response for a token that *could* exist, not for junk.
+const UNKNOWN_TOKEN = "d".repeat(64);
 const SUB_ID = "01HSUB0000000000000000";
 const SELF = "https://comments.example.com";
 const HOST_SITE = "https://blog.example.com";
@@ -181,7 +188,7 @@ describe("GET /subscribe/unsubscribe/:token", () => {
 	});
 
 	it("reports an unknown token without confirming whether it ever existed", async () => {
-		const res = await get("z".repeat(64));
+		const res = await get(UNKNOWN_TOKEN);
 		expect(res.status).toBe(200);
 		expect(await res.text()).toContain("Link expired or already used.");
 	});
@@ -292,7 +299,7 @@ describe("POST /subscribe/unsubscribe/:token/one-click (RFC 8058)", () => {
 	it("answers 200 for an unknown token without writing", async () => {
 		// A non-2xx reads to the mail client as "unsubscribe failed" and counts
 		// against sender reputation, for a reader who cannot act on it.
-		const res = await oneClick({ method: "POST" }, "z".repeat(64));
+		const res = await oneClick({ method: "POST" }, UNKNOWN_TOKEN);
 		expect(res.status).toBe(200);
 		expect(unsubscribedAt()).toBeNull();
 	});
@@ -438,7 +445,7 @@ describe("POST /subscribe/unsubscribe/:token/all", () => {
 	});
 
 	it("reports an unknown token without writing", async () => {
-		const res = await all(SELF, "z".repeat(64));
+		const res = await all(SELF, UNKNOWN_TOKEN);
 		expect(res.status).toBe(200);
 		expect(await res.text()).toContain("Link expired or already used.");
 		expect(unsubscribedAt()).toBeNull();

--- a/tests/thread-closure-api.test.ts
+++ b/tests/thread-closure-api.test.ts
@@ -209,6 +209,81 @@ describe("thread closure — POST gate", () => {
 			.get("frozen3") as { published_at: number | null };
 		expect(row.published_at).toBeNull();
 	});
+
+	it("does not let a later request fill a NULL published_at anchor", async () => {
+		// The hole first-writer-wins left: COALESCE only defends a value already
+		// stored, and NULL is the normal state — the row is created by whatever
+		// touches the slug first (a reaction, a page vote, an admin pre-close, or
+		// a comment from a host page that sends no `data-published`). So any
+		// later commenter could stamp an old date on an established thread and,
+		// with auto_close_days set, close it for good.
+		await post({ slug: "unanchored", body: "first comment" });
+		const res = await post({
+			slug: "unanchored",
+			body: "second comment",
+			post_published: 1_000_000_000_000,
+		});
+		expect(res.status).toBe(201);
+		const row = sqlite
+			.prepare("SELECT published_at FROM posts WHERE slug = ?")
+			.get("unanchored") as { published_at: number | null };
+		expect(row.published_at).toBeNull();
+	});
+
+	it("closes the poisoned thread when the anchor is accepted, proving the impact", async () => {
+		// Why the anchor is worth protecting at all: with auto_close_days set, an
+		// anchor old enough puts the thread past the cutoff, and closure is
+		// evaluated lazily on every later request — so the poison needs no
+		// follow-up. Set here through the one path that legitimately can (the
+		// row-creating write) to pin the consequence rather than assume it.
+		env = { ...env, AUTO_CLOSE_DAYS: "30" } as unknown as Bindings;
+		const created = await post({
+			slug: "aged",
+			body: "first comment",
+			post_published: 1_000_000_000_000, // ~year 2001
+		});
+		expect(created.status).toBe(201);
+		const res = await post({ slug: "aged", body: "second comment" });
+		expect(res.status).toBe(403);
+		expect((await res.json()) as { error: string }).toMatchObject({
+			error: expect.stringMatching(/closed/i),
+		});
+	});
+
+	it("writes no post metadata when the parent check rejects the request", async () => {
+		// upsertPost used to run before the parent lookup, so a reply naming a
+		// nonexistent parent got its 400 *and* left the title, url and
+		// published_at it carried behind — a permanent write from a request that
+		// never passed the checks that gate a real comment, on a slug that need
+		// not have existed at all.
+		const res = await post({
+			slug: "no-such-thread",
+			parent_id: "01HU999999999999999999",
+			body: "a reply to nothing",
+			post_title: "Attacker Title",
+			post_published: 1_000_000_000_000,
+		});
+		expect(res.status).toBe(400);
+		const row = sqlite
+			.prepare("SELECT slug FROM posts WHERE slug = ?")
+			.get("no-such-thread");
+		expect(row).toBeUndefined();
+	});
+
+	it("writes no post metadata when the parent belongs to another post", async () => {
+		const first = await post({ slug: "thread-a", body: "parent comment" });
+		const parent = (await first.json()) as { comment: { id: string } };
+		const res = await post({
+			slug: "thread-b",
+			parent_id: parent.comment.id,
+			body: "cross-thread reply",
+			post_title: "Attacker Title",
+		});
+		expect(res.status).toBe(400);
+		expect(
+			sqlite.prepare("SELECT slug FROM posts WHERE slug = ?").get("thread-b"),
+		).toBeUndefined();
+	});
 });
 
 describe("thread closure — GET payload", () => {


### PR DESCRIPTION
Fixes findings 1, 2 and 5 of the external review of v2.26.0. Findings 3 (refreshing the verified-email claim on OAuth login) and 4 (atomic consumption of the handoff and Telegram link tokens) are Low and went to the backlog instead — both are guarded today, and 4's fix costs a D1 or DO write on every popup sign-in.

Each fix landed in code that already carried a comment about the exact hazard. In all three the existing mitigation was real but did not reach the case found, which is why they read as regressions rather than omissions.

## 1. `subscriptions.token` was unindexed

`getSubscriptionByToken` backs two endpoints that take no session and, for the RFC 8058 one-click POST, no rate limit either. The column had no index, so every lookup was `SCAN subscriptions` — a loop of random tokens read the whole table per request, and D1 bills rows *read*. The tokens are unguessable, which bounds who can *unsubscribe* anyone; it does nothing about what a request *costs*.

- Migration `0024` adds `idx_subs_token`, deliberately not UNIQUE — token rotation and the `COALESCE` upsert mean two rows can legitimately share a value.
- `getSubscriptionByToken` now rejects anything that is not 64 lowercase hex before it reaches D1. The column has exactly one writer (`randomToken()`, unchanged since the endpoint shipped) and it is TEXT with BINARY collation, so a value the guard rejects could never have matched a stored one — the guard is behavior-preserving, and it mirrors the choke-point pattern `consumeHandoff` already uses.

Query-plan coverage via `node:sqlite` with every migration applied, so a future migration that drops the index fails the suite instead of shipping silently. Three test fixtures used 64-character non-hex tokens (`"u".repeat(64)`); those were never representative and are now hex.

## 2. The OAuth binding cookie had no cookie prefix

The per-flow cookie is what proves the browser completing a callback is the browser that started the flow. Its signature proves only that Garrul issued the state — not who holds it — so an attacker who runs `/start` himself has a valid state/cookie pair, and an unprefixed name is writable by any host under the operator's eTLD+1. On the documented `comments.<yourdomain>` layout that is a sibling subdomain, i.e. the expected deployment. Plant the pair, walk a victim through the callback, and they land on the attacker's session (RFC 6749 §10.12 login CSRF).

Production now uses `__Host-garrul_oauth_b_<8 hex>`, the one attribute set a sibling cannot forge. Dev keeps the bare name because plain-HTTP `wrangler dev` cannot satisfy `Secure`.

The load-bearing part is in `buildShortCookie`: the prefix is all-or-nothing — browsers drop the whole `Set-Cookie` unless it carries `Secure`, `Path=/` and no `Domain` — so those attributes are now derived from the name rather than taken from the caller's `path` argument. Without that, the existing `Path=/api/v1/auth` default would have made every production login fail rather than harden it. `clearShortCookie` inherits the same attributes, so the callback's clear still matches what `/start` set.

No legacy-name fallback: accepting the unprefixed cookie keeps the plantable path open. The cost is that a flow started in the 600 seconds before deploy fails once with `invalid state`.

## 5. The auto-close anchor was mutable, and written before validation

`posts.published_at` anchors age-based auto-close and arrives as `post_published` on an unauthenticated comment POST. An old enough value puts a thread permanently past the `AUTO_CLOSE_DAYS` cutoff; closure is re-derived lazily on every later request, so the poison needs no follow-up, and nothing short of direct D1 SQL undoes it.

`upsertPost` carried a `COALESCE(existing, excluded)` write-once rule that looks like it covers this, but `COALESCE` only defends a value already stored. NULL is the normal state — the other two callers (page-engagement, admin) create rows with no date — so first-writer-wins protected almost nothing. The column is now absent from `DO UPDATE` entirely: set on INSERT by whichever request creates the row, immutable after. `title` and `url` keep first-writer-wins; a repointed title is visible and repairable, a poisoned anchor is neither.

The accepted cost: a row created by a reaction, a page vote or an admin pre-close can no longer pick up a `data-published` anchor from a later comment, so that slug measures from first engagement. That is the pre-`data-published` behavior and it closes *later* than the operator asked — the safe direction.

Second half of the same finding: `upsertPost` ran *before* the parent checks, so a reply naming a nonexistent, foreign or too-deep parent got its 400 and still stamped the post's title, url and published_at — a permanent write from a request that never cleared the gates a real comment must, on a slug that need not have existed. It now runs after them, matching the reasoning already applied to the thread-closed gate directly above it.

## Verification

`lint`, `typecheck`, `manifest:check`, `build`, `size` and the full suite (138 files, 2627 tests) pass. Every new assertion was confirmed to fail against the pre-fix code, not just pass against the new code.

## Known residual

`published_at` is still supplied by the request that creates the post row, and that request can be an unauthenticated comment POST. A brand-new slug can therefore still be closed on its first comment, once, with no repair path. Closing that would need either an admin edit surface for the anchor or dropping caller-supplied publish times altogether — both are larger decisions than this PR.
