### PR TITLE
chore(release): 2.26.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "2.26.0",
+      "version": "2.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.26.0",
+  "version": "2.26.1",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 3,


### PR DESCRIPTION
Version bump for 2.26.1. Content shipped in #138.

Security fixes only — the three actionable findings from the external review of 2.26.0:

- `subscriptions.token` is indexed (migration `0024`) and `getSubscriptionByToken` rejects anything that is not 64 lowercase hex before touching D1. The lookup backs two endpoints with no session and, for the RFC 8058 one-click POST, no rate limit; it was a full table scan per request, and D1 bills rows read.
- The OAuth binding cookie is now `__Host-`-prefixed in production, so a sibling subdomain can no longer plant a state/cookie pair and land a victim on the attacker's session. `buildShortCookie` derives `Secure` and `Path=/` from the name, because the prefix is all-or-nothing.
- `posts.published_at` is INSERT-only, so the auto-close anchor cannot be poisoned by a later comment, and `upsertPost` runs after the parent checks so a rejected reply writes no metadata.

One migration, no new env vars, no endpoint changes. Upgrading is `npm run upgrade`, `npm run migrate` and a deploy.

Operator-visible behavior change: an OAuth login started in the 600 seconds before the deploy fails once with `invalid state`, because the binding cookie was renamed and there is deliberately no legacy-name fallback.
