### PR TITLE
fix: chronological paging cursors on (created_at, id) (N1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,12 @@ and a sort selector above the list. Neither needs any host-page wiring:
   pagination. The widget omits `?sort=` on the mount request to mean "no
   preference"; the server resolves the default and **echoes the sort it
   used** back on the comments payload, which is what the control
-  displays and what `next_cursor` is a cursor into. It cannot be derived
+  displays and what `next_cursor` is a cursor into.
+  `next_cursor` is opaque to the widget. For `new`/`old` it is
+  `<created_at_ms>.<ulid>` (since v2.27.0; earlier servers emitted a
+  bare ULID, which the server still accepts by looking the row up once),
+  for `top` it is `<score>:<ulid>`.
+  It cannot be derived
   client-side: on the bootstrap path the setting arrives in the same
   response as the comments it orders. A stored `top` with voting off
   resolves to `new` rather than being rewritten, so re-enabling voting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,16 +385,14 @@ and a sort selector above the list. Neither needs any host-page wiring:
   pagination. The widget omits `?sort=` on the mount request to mean "no
   preference"; the server resolves the default and **echoes the sort it
   used** back on the comments payload, which is what the control
-  displays and what `next_cursor` is a cursor into.
-  `next_cursor` is opaque to the widget. For `new`/`old` it is
-  `<created_at_ms>.<ulid>` (since v2.27.0; earlier servers emitted a
-  bare ULID, which the server still accepts by looking the row up once),
-  for `top` it is `<score>:<ulid>`.
-  It cannot be derived
+  displays and what `next_cursor` is a cursor into. It cannot be derived
   client-side: on the bootstrap path the setting arrives in the same
   response as the comments it orders. A stored `top` with voting off
   resolves to `new` rather than being rewritten, so re-enabling voting
-  restores the operator's choice.
+  restores the operator's choice. `next_cursor` itself is opaque to the
+  widget: for `new`/`old` it is `<created_at_ms>.<ulid>` (since v2.27.0;
+  earlier servers emitted a bare ULID, which the server still accepts by
+  looking the row up once), for `top` it is `<score>:<ulid>`.
 
 - **Voting is instance-wide and server-controlled.** The widget reads
   `voting_enabled` / `downvotes_enabled` from `/api/v1/config` at boot;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -635,7 +635,7 @@ const visiblePredicate = (
  */
 export const TREE_ROW_LIMIT = 2000;
 
-export type ThreadRef = { id: string; score: number };
+export type ThreadRef = { id: string; score: number; created_at: number };
 
 /**
  * The sort orders a comment tree can be served in.
@@ -655,22 +655,22 @@ export const COMMENT_SORTS = ["new", "top", "old"] as const;
 export type CommentSort = (typeof COMMENT_SORTS)[number];
 
 /**
- * One page of top-level thread ids in the requested sort order, plus their net
- * score (the `top` cursor needs it).
+ * One page of top-level thread ids in the requested sort order, plus the two
+ * values a keyset cursor needs: net score (for `top`) and `created_at` (for
+ * `new`/`old`).
  *
- * `limit` should be pageSize + 1: the caller uses the extra row purely to learn
- * whether another page exists, and must not fetch its subtree.
+ * Chronological sorts order and cursor on `(created_at, id)`, never on id
+ * alone. Live writes mint time-prefixed ULIDs, so id order happens to track
+ * time order for them — but imports keep the source's historical `created_at`
+ * under a fresh ULID, and a bare-id cursor skips or repeats those rows. id is
+ * the tiebreaker for equal timestamps; the pair is a total order because ids
+ * are unique.
  *
- * Every sort pages on a total order so no thread can be skipped or repeated.
- * ULIDs are time-prefixed and unique, so id order tracks created_at order and
- * breaks same-millisecond ties — which is what lets both chronological sorts
- * page on id alone:
- *   - new: (created_at DESC, id DESC), cursor `id < ?`.
- *   - old: (created_at ASC, id ASC), cursor `id > ?` — the same cursor value as
- *     `new`, read in the opposite direction. Ordering and cursor direction have
- *     to be flipped together; flipping one alone silently skips or repeats
- *     threads instead of failing.
- *   - top: (score DESC, id DESC), cursor "ranked strictly after (score, id)".
+ * `top` orders on `(score DESC, id DESC)`; unchanged.
+ *
+ * Cursor semantics: return rows strictly after the cursor position in the
+ * requested order. The caller passes `limit = pageSize + 1` to learn whether a
+ * next page exists.
  */
 export const listThreadRefsForPost = async (
 	db: D1Database,
@@ -678,20 +678,31 @@ export const listThreadRefsForPost = async (
 	opts: {
 		sort: CommentSort;
 		limit: number;
-		cursor?: { score?: number; id: string } | null;
+		cursor?: { score?: number; created_at?: number; id: string } | null;
 		viewer_id?: string | null;
 	},
 ): Promise<ThreadRef[]> => {
 	const visible = visiblePredicate(opts.viewer_id ?? null);
-	const binds: unknown[] = [post_slug, ...visible.binds];
 	let cursorSql = "";
-	if (opts.cursor && opts.sort === "top" && opts.cursor.score !== undefined) {
-		cursorSql = `AND ((score_up - score_down) < ?
-		              OR ((score_up - score_down) = ? AND id < ?))`;
-		binds.push(opts.cursor.score, opts.cursor.score, opts.cursor.id);
-	} else if (opts.cursor) {
-		cursorSql = opts.sort === "old" ? "AND id > ?" : "AND id < ?";
-		binds.push(opts.cursor.id);
+	const cursorBinds: (string | number)[] = [];
+	if (opts.cursor) {
+		if (opts.sort === "top") {
+			const score = opts.cursor.score ?? 0;
+			cursorSql =
+				"AND ((score_up - score_down) < ? OR ((score_up - score_down) = ? AND id < ?))";
+			cursorBinds.push(score, score, opts.cursor.id);
+		} else if (typeof opts.cursor.created_at === "number") {
+			const ts = opts.cursor.created_at;
+			cursorSql =
+				opts.sort === "old"
+					? "AND (created_at > ? OR (created_at = ? AND id > ?))"
+					: "AND (created_at < ? OR (created_at = ? AND id < ?))";
+			cursorBinds.push(ts, ts, opts.cursor.id);
+		}
+		// A chronological cursor without created_at is not a position we can
+		// name; the route resolves legacy bare-id cursors before calling here
+		// (see getThreadCreatedAt), so this branch only guards a programming
+		// error and pages from the start.
 	}
 	const order =
 		opts.sort === "top"
@@ -699,20 +710,37 @@ export const listThreadRefsForPost = async (
 			: opts.sort === "old"
 				? "created_at ASC, id ASC"
 				: "created_at DESC, id DESC";
-	binds.push(opts.limit);
-
 	const result = await db
 		.prepare(
-			`SELECT id, (score_up - score_down) AS score
-			 FROM comments
-			 WHERE post_slug = ? AND parent_id IS NULL AND ${visible.sql}
-			   ${cursorSql}
-			 ORDER BY ${order}
-			 LIMIT ?`,
+			`SELECT id, (score_up - score_down) AS score, created_at
+			   FROM comments
+			  WHERE post_slug = ? AND parent_id IS NULL AND ${visible.sql} ${cursorSql}
+			  ORDER BY ${order}
+			  LIMIT ?`,
 		)
-		.bind(...binds)
+		.bind(post_slug, ...visible.binds, ...cursorBinds, opts.limit)
 		.all<ThreadRef>();
 	return result.results ?? [];
+};
+
+/**
+ * `created_at` of one top-level thread on a slug, or null when the id is not a
+ * top-level thread of that post. Used once per request to upgrade a legacy
+ * bare-ULID chronological cursor to the `(created_at, id)` pair. Scoped to the
+ * slug so a cursor minted on one thread cannot probe another.
+ */
+export const getThreadCreatedAt = async (
+	db: D1Database,
+	post_slug: string,
+	id: string,
+): Promise<number | null> => {
+	const row = await db
+		.prepare(
+			"SELECT created_at FROM comments WHERE id = ? AND post_slug = ? AND parent_id IS NULL",
+		)
+		.bind(id, post_slug)
+		.first<{ created_at: number }>();
+	return row ? row.created_at : null;
 };
 
 /**

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -1021,9 +1021,11 @@ export const buildTreePage = async (
 	// Chronological cursor: composite first; else a legacy bare ULID upgraded
 	// with one PK lookup. This runs before the cache key is built so the key is
 	// always the canonical composite spelling — a legacy spelling must not mint
-	// a second entry for the same page. An unresolvable legacy id (deleted
-	// thread, wrong slug, random probe) falls through to the first page, which
-	// is one fixed key rather than one key per probe.
+	// a second entry for the same page. The lookup filters on slug and
+	// top-level only, not status: a soft-deleted thread keeps its row, so its
+	// id still resolves and the reader keeps their place. An unresolvable id
+	// (wrong slug, a reply id, random probe) falls through to the first page,
+	// which is one fixed key rather than one key per probe.
 	let chrono: ChronoCursor | null = null;
 	if (sort !== "top" && beforeRaw) {
 		chrono = decodeChronoCursor(beforeRaw);

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -28,6 +28,7 @@ import {
 	getOrCreateGhost,
 	getComment,
 	getPost,
+	getThreadCreatedAt,
 	getUser,
 	getUserVotesOnPost,
 	insertComment,
@@ -855,16 +856,36 @@ export type ListPayload = {
 const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
 /**
- * Chronological-sort cursor: just the ULID of the last top-level thread on the
- * current page. The ULID (lexicographically-comparable, time-prefixed)
- * sidesteps the timestamp-collision edge case.
+ * Chronological-sort cursor: `<created_at_ms>.<ulid>` of the last top-level
+ * thread on the current page. The pair is the position; id alone is not,
+ * because imported threads carry a fresh ULID over a historical created_at,
+ * so id order and time order disagree for them (see listThreadRefsForPost).
  *
  * Shared by `new` and `old`, which differ only in which direction the query
- * reads it — `id < cursor` for DESC, `id > cursor` for ASC (see
- * listThreadRefsForPost). The encoding is identical because the position it
- * names is identical; only the sort decides which way "next" runs.
+ * reads it. The separator is `.` so it cannot be confused with the `top`
+ * cursor's `:`.
+ *
+ * Re-encoded from the decoded value before use (page cursor and cache key), so
+ * `0001003.X` and `1003.X` name one cache entry.
  */
-const decodeCursor = (raw: string | null): string | null => {
+type ChronoCursor = { created_at: number; id: string };
+const CHRONO_CURSOR_RE = /^(\d{1,13})\.([0-9A-HJKMNP-TV-Z]{26})$/;
+const decodeChronoCursor = (raw: string | null): ChronoCursor | null => {
+	if (!raw) return null;
+	const m = CHRONO_CURSOR_RE.exec(raw);
+	if (!m || m[1] === undefined || m[2] === undefined) return null;
+	const created_at = Number.parseInt(m[1], 10);
+	if (!Number.isSafeInteger(created_at)) return null;
+	return { created_at, id: m[2] };
+};
+const encodeChronoCursor = (c: ChronoCursor): string => `${c.created_at}.${c.id}`;
+
+/**
+ * Pre-2.27.0 chronological cursor: a bare ULID. Widgets loaded before the
+ * server upgraded may still hold one. The route resolves it to the pair with
+ * one PK lookup (getThreadCreatedAt) before touching the cache.
+ */
+const decodeLegacyCursor = (raw: string | null): string | null => {
 	if (!raw) return null;
 	return ULID_RE.test(raw) ? raw : null;
 };
@@ -996,12 +1017,24 @@ export const buildTreePage = async (
 ): Promise<TreePageResult> => {
 	const { slug, sort, beforeRaw, session, flags, numbers } = opts;
 
-	// Two cursor encodings, not three: the chronological sorts (`new`, `old`)
-	// both page by bare ULID, while `top` pages by a composite score:id (see
-	// decodeTopCursor). A cursor from the wrong family decodes to null → treated
-	// as the first page.
-	const cursor = sort === "top" ? null : decodeCursor(beforeRaw);
 	const topCursor = sort === "top" ? decodeTopCursor(beforeRaw) : null;
+	// Chronological cursor: composite first; else a legacy bare ULID upgraded
+	// with one PK lookup. This runs before the cache key is built so the key is
+	// always the canonical composite spelling — a legacy spelling must not mint
+	// a second entry for the same page. An unresolvable legacy id (deleted
+	// thread, wrong slug, random probe) falls through to the first page, which
+	// is one fixed key rather than one key per probe.
+	let chrono: ChronoCursor | null = null;
+	if (sort !== "top" && beforeRaw) {
+		chrono = decodeChronoCursor(beforeRaw);
+		if (!chrono) {
+			const legacyId = decodeLegacyCursor(beforeRaw);
+			if (legacyId) {
+				const createdAt = await getThreadCreatedAt(env.DB, slug, legacyId);
+				if (createdAt !== null) chrono = { created_at: createdAt, id: legacyId };
+			}
+		}
+	}
 
 	// Top-level threads per page, operator-tunable (DB > env > default 25),
 	// clamped to [1,200] in the settings layer. `numbers` is also used below to
@@ -1018,7 +1051,7 @@ export const buildTreePage = async (
 	// high on the public reader path, which dominates traffic.
 	//
 	// The cursor is part of the key rather than a reason to skip caching. It
-	// used to be the latter, and because `decodeCursor` only checked ULID
+	// used to be the latter, and because the old decoder only checked ULID
 	// *shape*, ANY well-formed ULID in `?before=` disabled the cache and sent
 	// the request to D1 — an unauthenticated, cache-bypassing read amplifier in
 	// front of an unbounded query. Only the canonically re-encoded cursor goes
@@ -1026,7 +1059,9 @@ export const buildTreePage = async (
 	// key of its own.
 	const cursorKey = topCursor
 		? `${topCursor.score}:${topCursor.id}`
-		: (cursor ?? null);
+		: chrono
+			? encodeChronoCursor(chrono)
+			: null;
 	const cacheReq = treeCacheKey(reqUrl, slug, sort, pageSize, cursorKey);
 	const cacheable = !session;
 	if (cacheable && !opts.skipCache) {
@@ -1054,7 +1089,7 @@ export const buildTreePage = async (
 		// One extra row, purely to learn whether a further page exists. Its
 		// subtree is deliberately NOT fetched.
 		limit: pageSize + 1,
-		cursor: topCursor ?? (cursor ? { id: cursor } : null),
+		cursor: topCursor ?? chrono,
 		viewer_id: viewerId,
 	});
 	const pageRefs = refs.slice(0, pageSize);
@@ -1119,7 +1154,7 @@ export const buildTreePage = async (
 	const next_cursor = more && lastRef
 		? sort === "top"
 			? `${lastRef.score}:${lastRef.id}`
-			: lastRef.id
+			: encodeChronoCursor({ created_at: lastRef.created_at, id: lastRef.id })
 		: null;
 
 	// Whether new comments are accepted, so the widget can show the composer or a
@@ -1142,11 +1177,14 @@ export const buildTreePage = async (
 		closed_reason: threadState.reason ?? null,
 	};
 
-	// An empty cursor page is deliberately NOT stored. A cursor is unvalidated
-	// against the data — any well-formed ULID decodes fine and simply matches no
-	// thread — so caching those would let one client mint unlimited distinct
-	// cache entries from a random-ULID loop. Real pages are bounded by the
-	// thread count.
+	// An empty cursor page is deliberately NOT stored. A well-formed composite
+	// cursor (or a legacy ULID that resolves to one) is unvalidated against the
+	// data and can simply match no thread, so caching those would let one
+	// client mint unlimited distinct cache entries from a random-cursor loop.
+	// An unresolvable legacy ULID never reaches this branch as a cursor page at
+	// all: it fell through to `chrono === null` above, so `cursorKey` is null
+	// and it is treated (and cached) as the first page instead. Real cursor
+	// pages are bounded by the thread count.
 	const storable = cacheable && (cursorKey === null || page.length > 0);
 	return { payload, store: storable ? cacheReq : null };
 };

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -869,7 +869,7 @@ const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
  * `0001003.X` and `1003.X` name one cache entry.
  */
 type ChronoCursor = { created_at: number; id: string };
-const CHRONO_CURSOR_RE = /^(\d{1,13})\.([0-9A-HJKMNP-TV-Z]{26})$/;
+const CHRONO_CURSOR_RE = /^(-?\d{1,13})\.([0-9A-HJKMNP-TV-Z]{26})$/;
 const decodeChronoCursor = (raw: string | null): ChronoCursor | null => {
 	if (!raw) return null;
 	const m = CHRONO_CURSOR_RE.exec(raw);

--- a/tests/comments-pagination.test.ts
+++ b/tests/comments-pagination.test.ts
@@ -168,6 +168,13 @@ const seedThreads = (n: number, scores: number[] = []) => {
 	}
 };
 
+/** One top-level thread with an explicit id index and created_at. */
+const seedThreadAt = (idIndex: number, createdAt: number) => {
+	sqlite
+		.prepare(INSERT_COMMENT)
+		.run(mkUlid(idIndex), SLUG, null, USER, `c${idIndex}`, `<p>c${idIndex}</p>`, createdAt, 1, 0);
+};
+
 /** `perThread` replies under each of the first `threadCount` threads. */
 const seedReplies = (threadCount: number, perThread: number) => {
 	const stmt = sqlite.prepare(INSERT_COMMENT);
@@ -628,10 +635,13 @@ describe("GET /comments — edge-cache hit/bypass", () => {
 		await get(env, `slug=${SLUG}&before=${mkUlid(1)}`); // oldest id → no rows
 		expect(mockCache.store.size).toBe(0);
 
-		// Sanity: the same request shape with real rows behind it IS cached.
+		// Sanity: the same request shape with real rows behind it IS cached, and
+		// the legacy bare-ULID spelling lands under the canonical composite key.
 		await get(env, `slug=${SLUG}&before=${mkUlid(3)}`);
 		expect(
-			mockCache.store.has(treeCacheKey(REQ_URL, SLUG, "new", 25, mkUlid(3)).url),
+			mockCache.store.has(
+				treeCacheKey(REQ_URL, SLUG, "new", 25, `1002.${mkUlid(3)}`).url,
+			),
 		).toBe(true);
 	});
 
@@ -652,5 +662,92 @@ describe("GET /comments — edge-cache hit/bypass", () => {
 				treeCacheKey(REQ_URL, SLUG, "top", 2, `8:${mkUlid(9)}`).url,
 			),
 		).toBe(true);
+	});
+});
+
+describe("chronological cursor format (created_at.ulid)", () => {
+	const CHRONO = /^\d{1,13}\.[0-9A-HJKMNP-TV-Z]{26}$/;
+
+	// Page size is the `comments_per_page` setting (no query param), so every
+	// test here sets it to 2 before building the env, the way the existing
+	// cursor tests set it to 10.
+	it("emits <created_at>.<ulid> for new and old", async () => {
+		seedThreads(5);
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		const first = await get(env, `slug=${SLUG}&sort=new`);
+		expect(first.next_cursor).toMatch(CHRONO);
+		// Page 1 of `new` ends on thread index 4 (created_at 1003).
+		expect(first.next_cursor).toBe(`1003.${mkUlid(4)}`);
+		const old = await get(env, `slug=${SLUG}&sort=old`);
+		expect(old.next_cursor).toBe(`1001.${mkUlid(2)}`);
+	});
+
+	it("pages misaligned rows by created_at with no skip or repeat", async () => {
+		// ids ascend 1..6, timestamps shuffled: the shape an import produces.
+		const stamps = [5, 1, 6, 2, 4, 3];
+		stamps.forEach((t, idx) => {
+			seedThreadAt(idx + 1, 2000 + t);
+		});
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		const seen: string[] = [];
+		let cursor: string | null = null;
+		for (let guard = 0; guard < 10; guard++) {
+			const page = await get(
+				env,
+				`slug=${SLUG}&sort=new${cursor ? `&before=${cursor}` : ""}`,
+			);
+			seen.push(...page.threads.map((t) => t.id));
+			cursor = page.next_cursor;
+			if (!cursor) break;
+		}
+		// created_at 6,5,4,3,2,1 → id indexes 3,1,5,6,4,2
+		expect(seen).toEqual([3, 1, 5, 6, 4, 2].map(mkUlid));
+	});
+
+	it("accepts a legacy bare-ULID cursor and caches it under the composite key", async () => {
+		seedThreads(5);
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		const viaLegacy = await get(env, `slug=${SLUG}&sort=new&before=${mkUlid(4)}`);
+		const viaComposite = await get(mkEnv(), `slug=${SLUG}&sort=new&before=1003.${mkUlid(4)}`);
+		expect(viaLegacy.threads.map((t) => t.id)).toEqual(viaComposite.threads.map((t) => t.id));
+		expect(viaLegacy.threads.map((t) => t.id)).toEqual([mkUlid(3), mkUlid(2)]);
+		expect(
+			mockCache.store.has(treeCacheKey(REQ_URL, SLUG, "new", 2, `1003.${mkUlid(4)}`).url),
+		).toBe(true);
+		expect(mockCache.store.has(treeCacheKey(REQ_URL, SLUG, "new", 2, mkUlid(4)).url)).toBe(
+			false,
+		);
+	});
+
+	it("treats a legacy cursor that names no thread as the first page, one cache key", async () => {
+		seedThreads(3);
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		const first = await get(env, `slug=${SLUG}&sort=new`);
+		mockCache.store.clear();
+		const probe = await get(env, `slug=${SLUG}&sort=new&before=${mkUlid(999)}`);
+		expect(probe.threads.map((t) => t.id)).toEqual(first.threads.map((t) => t.id));
+		expect(mockCache.store.size).toBe(1);
+		expect(mockCache.store.has(treeCacheKey(REQ_URL, SLUG, "new", 2).url)).toBe(true);
+	});
+
+	it("rejects a malformed composite cursor as no cursor", async () => {
+		seedThreads(3);
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		const first = await get(env, `slug=${SLUG}&sort=new`);
+		const bad = await get(env, `slug=${SLUG}&sort=new&before=abc.${mkUlid(2)}`);
+		expect(bad.threads.map((t) => t.id)).toEqual(first.threads.map((t) => t.id));
+	});
+
+	it("leaves the top cursor format unchanged", async () => {
+		seedThreads(4, [3, 1, 2, 0]);
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		const page = await get(env, `slug=${SLUG}&sort=top`);
+		expect(page.next_cursor).toBe(`2:${mkUlid(3)}`);
 	});
 });

--- a/tests/comments-pagination.test.ts
+++ b/tests/comments-pagination.test.ts
@@ -666,7 +666,7 @@ describe("GET /comments — edge-cache hit/bypass", () => {
 });
 
 describe("chronological cursor format (created_at.ulid)", () => {
-	const CHRONO = /^\d{1,13}\.[0-9A-HJKMNP-TV-Z]{26}$/;
+	const CHRONO = /^-?\d{1,13}\.[0-9A-HJKMNP-TV-Z]{26}$/;
 
 	// Page size is the `comments_per_page` setting (no query param), so every
 	// test here sets it to 2 before building the env, the way the existing
@@ -749,5 +749,22 @@ describe("chronological cursor format (created_at.ulid)", () => {
 		const env = mkEnv();
 		const page = await get(env, `slug=${SLUG}&sort=top`);
 		expect(page.next_cursor).toBe(`2:${mkUlid(3)}`);
+	});
+
+	it("accepts a negative created_at (pre-1970, import-only) in the before cursor", async () => {
+		seedThreadAt(1, -7200000);
+		seedThreadAt(2, -3600000);
+		seedThreadAt(3, 0);
+		setSetting("comments_per_page", "1");
+		const env = mkEnv();
+		const first = await get(env, `slug=${SLUG}&sort=old`);
+		expect(first.threads.map((t) => t.id)).toEqual([mkUlid(1)]);
+		expect(first.next_cursor).toBe(`-7200000.${mkUlid(1)}`);
+		const second = await get(
+			env,
+			`slug=${SLUG}&sort=old&before=-7200000.${mkUlid(1)}`,
+		);
+		// A regex that rejects the sign would silently fall back to page 1.
+		expect(second.threads.map((t) => t.id)).toEqual([mkUlid(2)]);
 	});
 });

--- a/tests/queries-comments-realdb.test.ts
+++ b/tests/queries-comments-realdb.test.ts
@@ -249,7 +249,9 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 		// Fresh ULIDs ascend 1..6 but the timestamps are shuffled, the shape an
 		// import produces. Expected order is by created_at DESC, not id DESC.
 		const stamps = [5, 1, 6, 2, 4, 3];
-		stamps.forEach((t, idx) => seedThread(idx + 1, { created_at: 1_700_000_000_000 + t }));
+		for (const [idx, t] of stamps.entries()) {
+			seedThread(idx + 1, { created_at: 1_700_000_000_000 + t });
+		}
 		const seen = await walk("new", 2);
 		// created_at 6,5,4,3,2,1 → ids 3,1,5,6,4,2
 		expect(seen).toEqual([3, 1, 5, 6, 4, 2].map(threadId));
@@ -257,7 +259,9 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 
 	it("pages 'old' by created_at when ids disagree with timestamps", async () => {
 		const stamps = [5, 1, 6, 2, 4, 3];
-		stamps.forEach((t, idx) => seedThread(idx + 1, { created_at: 1_700_000_000_000 + t }));
+		for (const [idx, t] of stamps.entries()) {
+			seedThread(idx + 1, { created_at: 1_700_000_000_000 + t });
+		}
 		const seen = await walk("old", 2);
 		// created_at 1,2,3,4,5,6 → ids 2,4,6,5,1,3
 		expect(seen).toEqual([2, 4, 6, 5, 1, 3].map(threadId));

--- a/tests/queries-comments-realdb.test.ts
+++ b/tests/queries-comments-realdb.test.ts
@@ -19,6 +19,7 @@ import {
 	insertComment,
 	getComment,
 	listThreadRefsForPost,
+	getThreadCreatedAt,
 	softDeleteComment,
 	updateCommentStatus,
 } from "../src/db/queries";
@@ -160,10 +161,11 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 	let db: any;
 	let sqlite: DatabaseSync;
 
-	// ULIDs are time-prefixed, so id order tracks created_at order — the
-	// invariant every cursor here leans on. Seeded ids agree with their
-	// timestamps for exactly that reason; a test that let them disagree would
-	// be testing a row shape the writer cannot produce.
+	// Ids and created_at are independent. Live writes mint time-prefixed ULIDs
+	// so the two usually agree, but imports keep the source's historical
+	// created_at under a fresh ULID, so id order says nothing about time order
+	// there. Chronological paging therefore cursors on (created_at, id), and the
+	// tests below seed both aligned and deliberately misaligned rows.
 	const threadId = (i: number) => `01J${String(i).padStart(23, "0")}`;
 
 	beforeEach(() => {
@@ -180,7 +182,12 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 
 	const seedThread = (
 		i: number,
-		opts: { status?: string; score?: number; parent_id?: string | null } = {},
+		opts: {
+			status?: string;
+			score?: number;
+			parent_id?: string | null;
+			created_at?: number;
+		} = {},
 	) => {
 		sqlite
 			.prepare(
@@ -195,7 +202,7 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 				opts.status ?? "approved",
 				opts.score ?? 0,
 				opts.parent_id ? 2 : 1,
-				1_700_000_000_000 + i,
+				opts.created_at ?? 1_700_000_000_000 + i,
 			);
 	};
 
@@ -205,7 +212,7 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 	 */
 	const walk = async (sort: "new" | "top" | "old", pageSize: number) => {
 		const seen: string[] = [];
-		let cursor: { score?: number; id: string } | null = null;
+		let cursor: { score?: number; created_at?: number; id: string } | null = null;
 		for (let guard = 0; guard < 20; guard++) {
 			const refs = await listThreadRefsForPost(db, "hello", {
 				sort,
@@ -216,7 +223,10 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 			seen.push(...page.map((r) => r.id));
 			const last = page[page.length - 1];
 			if (refs.length <= pageSize || !last) break;
-			cursor = sort === "top" ? { score: last.score, id: last.id } : { id: last.id };
+			cursor =
+				sort === "top"
+					? { score: last.score, id: last.id }
+					: { created_at: last.created_at, id: last.id };
 		}
 		return seen;
 	};
@@ -233,6 +243,45 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 		const seen = await walk("new", 3);
 		expect(seen).toEqual([7, 6, 5, 4, 3, 2, 1].map(threadId));
 		expect(new Set(seen).size).toBe(7);
+	});
+
+	it("pages 'new' by created_at when ids disagree with timestamps (imported rows)", async () => {
+		// Fresh ULIDs ascend 1..6 but the timestamps are shuffled, the shape an
+		// import produces. Expected order is by created_at DESC, not id DESC.
+		const stamps = [5, 1, 6, 2, 4, 3];
+		stamps.forEach((t, idx) => seedThread(idx + 1, { created_at: 1_700_000_000_000 + t }));
+		const seen = await walk("new", 2);
+		// created_at 6,5,4,3,2,1 → ids 3,1,5,6,4,2
+		expect(seen).toEqual([3, 1, 5, 6, 4, 2].map(threadId));
+	});
+
+	it("pages 'old' by created_at when ids disagree with timestamps", async () => {
+		const stamps = [5, 1, 6, 2, 4, 3];
+		stamps.forEach((t, idx) => seedThread(idx + 1, { created_at: 1_700_000_000_000 + t }));
+		const seen = await walk("old", 2);
+		// created_at 1,2,3,4,5,6 → ids 2,4,6,5,1,3
+		expect(seen).toEqual([2, 4, 6, 5, 1, 3].map(threadId));
+	});
+
+	it("breaks created_at ties on id without skipping or repeating", async () => {
+		for (let i = 1; i <= 6; i++) seedThread(i, { created_at: 1_700_000_000_000 });
+		expect(await walk("new", 2)).toEqual([6, 5, 4, 3, 2, 1].map(threadId));
+		expect(await walk("old", 4)).toEqual([1, 2, 3, 4, 5, 6].map(threadId));
+	});
+
+	it("returns created_at on every ref", async () => {
+		seedThread(1, { created_at: 1_700_000_000_123 });
+		const refs = await listThreadRefsForPost(db, "hello", { sort: "new", limit: 5 });
+		expect(refs).toEqual([{ id: threadId(1), score: 0, created_at: 1_700_000_000_123 }]);
+	});
+
+	it("getThreadCreatedAt resolves a top-level thread on the slug and nothing else", async () => {
+		seedThread(1, { created_at: 1_700_000_000_001 });
+		seedThread(2, { parent_id: threadId(1), created_at: 1_700_000_000_002 });
+		expect(await getThreadCreatedAt(db, "hello", threadId(1))).toBe(1_700_000_000_001);
+		expect(await getThreadCreatedAt(db, "hello", threadId(2))).toBeNull(); // a reply
+		expect(await getThreadCreatedAt(db, "other", threadId(1))).toBeNull(); // wrong slug
+		expect(await getThreadCreatedAt(db, "hello", threadId(9))).toBeNull(); // missing
 	});
 
 	it("'old' excludes replies, spam and pending just as 'new' does", async () => {

--- a/tests/queries-comments-realdb.test.ts
+++ b/tests/queries-comments-realdb.test.ts
@@ -297,6 +297,17 @@ describe("listThreadRefsForPost paging (real SQLite)", () => {
 		const seen = await walk("old", 10);
 		expect(seen).toEqual([threadId(1), threadId(4)]);
 	});
+
+	it("pages 'old' through negative (pre-1970) created_at without skipping or repeating", async () => {
+		// Imports can carry a pre-1970 source created_at. Paging one row at a
+		// time forces every intermediate cursor to round-trip a negative value.
+		seedThread(1, { created_at: -7200000 });
+		seedThread(2, { created_at: -3600000 });
+		seedThread(3, { created_at: 0 });
+		const seen = await walk("old", 1);
+		expect(seen).toEqual([threadId(1), threadId(2), threadId(3)]);
+		expect(new Set(seen).size).toBe(3);
+	});
 });
 
 /**


### PR DESCRIPTION
## Summary
- `listThreadRefsForPost` orders and cursors `new`/`old` on `(created_at, id)` and returns `created_at` per ref. Imported threads (fresh ULID, historical created_at) no longer get skipped or repeated.
- Chronological `next_cursor` is now `<created_at_ms>.<ulid>`. A legacy bare-ULID cursor is resolved with one PK lookup before the cache key is built, so the cache key stays canonical; an unresolvable legacy id pages from the start under the single first-page key.
- `top` cursor unchanged. Importer unchanged (user decision).

## Test plan
- [x] real-SQLite query tests with misaligned ids/timestamps, ties, legacy lookup
- [x] route-level tests: format, misaligned paging, legacy equivalence and cache key, unknown legacy id, malformed cursor, top unchanged
- [x] lint, typecheck, test, manifest:check, build, size
