### PR TITLE
feat: widget sends data-published; docs match the anchor's set-once rule (#58 doc half)

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -323,13 +323,15 @@ ignores them behaves exactly as before.
   **lazily** at read/write time — there is no cron and nothing is persisted, so a
   thread "becomes" closed the moment a request observes the rule. The age anchor
   is the host page's real publish time when the embed supplies `data-published`
-  (stored as `posts.published_at`); without it Garrul falls back to first-comment
-  time, which is later than real publish, so set `data-published` if you rely on
-  `AUTO_CLOSE_DAYS`. The anchor is **set once, by whichever request first creates
+  (the widget sends it as `post_published` on every comment create since
+  v2.27.0; stored as `posts.published_at`); without it Garrul falls back to
+  first-engagement time, which is later than real publish, so set
+  `data-published` if you rely on `AUTO_CLOSE_DAYS`. The anchor is **set once, by whichever request first creates
   the post row, and never changes** — `data-published` arrives on an
   unauthenticated comment POST, and an old enough value closes the thread
-  permanently with no repair path short of direct D1 SQL, so a later request is
-  not allowed to supply or move it. The practical consequence: if a reaction, a
+  permanently, so a later request is not allowed to supply or move it. The only
+  repair path today is direct D1 SQL on `posts.published_at`; an admin edit
+  surface for the anchor is a separate backlog item. The practical consequence: if a reaction, a
   page vote or an admin pre-close created the row before the first comment, that
   slug keeps the first-engagement anchor even once `data-published` starts
   arriving. It closes later than you asked, never earlier. A closed thread hides

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,8 +283,8 @@ Every attribute the widget reads from the `#garrul` host element
 | ------------ | -------- | ------------------------------------------------------------------------------------------- |
 | `data-slug`  | yes      | Stable thread identifier. Missing slug renders an error in the host element.                |
 | `data-api`   | no       | Worker origin override. Defaults to the origin of the script tag (`<script src>`). Set this explicitly when loading `embed.js` via a bundler or async import (anywhere `document.currentScript` may be null at execution time). |
-| `data-title` | no       | Post title; sent on first comment create, surfaces in admin and notification emails.        |
-| `data-url`   | no       | Canonical permalink; sent on first comment create, used in RSS and notification emails.     |
+| `data-title` | no       | Post title; sent on every comment create (top-level and reply). The first non-null value wins and later values are ignored. Surfaces in admin and notification emails. |
+| `data-url`   | no       | Canonical permalink; sent on every comment create (top-level and reply). The first non-null value wins and later values are ignored. Used in RSS and notification emails. |
 | `data-published` | no   | Article publish time (epoch ms or ISO 8601). The widget sends it as `post_published` on every comment create (top-level and reply); the server records it only on the request that creates the post row and never changes it after that — it arrives on an unauthenticated POST, and an old enough value closes the thread for good, so a later request cannot supply or move it. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit it and Garrul anchors on first-engagement time, which closes a bit later than intended. If a reaction, page vote or admin action created the row before the first comment, the slug keeps that first-engagement anchor. Repair today is direct D1 SQL on `posts.published_at`; an admin edit surface is a separate backlog item. |
 | `data-lang`  | no       | BCP-47 tag pinning the widget's interface language (see "Language" below). Unrecognized tags fall back to English rather than erroring. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,17 +49,19 @@ appear:
   data-api="{{INSTANCE_URL}}"
   data-title="Post title"
   data-url="https://your-site.example/post-url"
+  data-published="2026-09-11T12:00:00Z"
 ></div>
 <script src="{{INSTANCE_URL}}/embed.js" defer></script>
 ```
 
 Fill these in per page:
 
-| Attribute    | Fill with                                                   |
-| ------------ | ----------------------------------------------------------- |
-| `data-slug`  | A stable identifier for THIS post (see §4).                 |
-| `data-title` | The post's human title — used in email digests and admin.   |
-| `data-url`   | The canonical permalink — reflected in RSS and email.       |
+| Attribute        | Fill with                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `data-slug`      | A stable identifier for THIS post (see §4).                                                 |
+| `data-title`     | The post's human title — used in email digests and admin.                                   |
+| `data-url`       | The canonical permalink — reflected in RSS and email.                                       |
+| `data-published` | Optional. The post's publish time (ISO 8601 or epoch ms); anchors auto-close (see §4 table). |
 
 `data-api` is the same on every page; the host element and the
 `<script src>` must agree on the Worker origin. Omitting it falls back to
@@ -99,23 +101,24 @@ releases its own reservation once real comments render.
 
 The host snippet above is the same on every stack — only the templating
 varies. One-line summary of where to put it and how to fill `data-slug`
-/ `data-title` / `data-url`:
+/ `data-title` / `data-url` / `data-published`:
 
-- **Astro** — render a `<Comments slug={entry.slug} title={entry.data.title} />`
-  component that emits the snippet; set `site:` in `astro.config.mjs`
-  so `Astro.url.href` is the prod URL.
+- **Astro** — render a `<Comments slug={entry.slug} title={entry.data.title} published={entry.data.pubDate} />`
+  component that emits the snippet (`data-published={published?.toISOString()}`);
+  set `site:` in `astro.config.mjs` so `Astro.url.href` is the prod URL.
 - **Hugo** — drop the snippet in `layouts/partials/comments.html` using
-  `{{ .File.ContentBaseName }}`, `{{ .Title }}`, `{{ .Permalink }}`;
-  invoke it from `single.html`. Front-matter `disableComments: true`
-  opts a post out.
+  `{{ .File.ContentBaseName }}`, `{{ .Title }}`, `{{ .Permalink }}`,
+  `{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}`; invoke it from
+  `single.html`. Front-matter `disableComments: true` opts a post out.
 - **Jekyll** — `_includes/comments.html` using `{{ page.slug }}`,
-  `{{ page.title | xml_escape }}`, `{{ page.url | absolute_url }}`;
-  include from `_layouts/post.html`. Front-matter `comments: false`
-  opts a post out.
+  `{{ page.title | xml_escape }}`, `{{ page.url | absolute_url }}`,
+  `{{ page.date | date_to_xmlschema }}`; include from
+  `_layouts/post.html`. Front-matter `comments: false` opts a post out.
 - **WordPress** — `wp_enqueue_script` `{{INSTANCE_URL}}/embed.js` in
   `functions.php`; render the `#garrul` div in a child-theme
   `comments.php` using `get_post_field('post_name', get_the_ID())`,
-  `get_the_title()`, `get_permalink()`. Disable native WP comments
+  `get_the_title()`, `get_permalink()`, `get_post_time('c', true)`.
+  Disable native WP comments
   in Settings → Discussion so two forms don't render together.
 - **Plain HTML** — paste the snippet verbatim, replacing the slug and
   URL.
@@ -285,7 +288,7 @@ Every attribute the widget reads from the `#garrul` host element
 | `data-api`   | no       | Worker origin override. Defaults to the origin of the script tag (`<script src>`). Set this explicitly when loading `embed.js` via a bundler or async import (anywhere `document.currentScript` may be null at execution time). |
 | `data-title` | no       | Post title; sent on every comment create (top-level and reply). The first non-null value wins and later values are ignored. Surfaces in admin and notification emails. |
 | `data-url`   | no       | Canonical permalink; sent on every comment create (top-level and reply). The first non-null value wins and later values are ignored. Used in RSS and notification emails. |
-| `data-published` | no   | Article publish time (epoch ms or ISO 8601). The widget sends it as `post_published` on every comment create (top-level and reply); the server records it only on the request that creates the post row and never changes it after that — it arrives on an unauthenticated POST, and an old enough value closes the thread for good, so a later request cannot supply or move it. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit it and Garrul anchors on first-engagement time, which closes a bit later than intended. If a reaction, page vote or admin action created the row before the first comment, the slug keeps that first-engagement anchor. Repair today is direct D1 SQL on `posts.published_at`; an admin edit surface is a separate backlog item. |
+| `data-published` | no   | Article publish time (epoch ms or ISO 8601). On the iframe variant pass it as `?published=` (§6). The widget sends it as `post_published` on every comment create (top-level and reply); the server records it only on the request that creates the post row and never changes it after that — it arrives on an unauthenticated POST, and an old enough value closes the thread for good, so a later request cannot supply or move it. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit it and Garrul anchors on first-engagement time, which closes a bit later than intended. If a reaction, page vote or admin action created the row before the first comment, the slug keeps that first-engagement anchor. Repair today is direct D1 SQL on `posts.published_at`; an admin edit surface is a separate backlog item. |
 | `data-lang`  | no       | BCP-47 tag pinning the widget's interface language (see "Language" below). Unrecognized tags fall back to English rather than erroring. |
 
 The host element MUST have `id="garrul"`; the widget looks it up by ID
@@ -882,6 +885,7 @@ route and listen for height messages:
     var src = new URL("{{INSTANCE_URL}}/embed/post-slug-here");
     src.searchParams.set("title", document.title);
     src.searchParams.set("url", window.location.href);
+    src.searchParams.set("published", "2026-09-11T12:00:00Z"); // optional
     src.searchParams.set("parent_origin", window.location.origin);
     f.src = src.toString();
 
@@ -905,6 +909,13 @@ Worker `postMessage`s height updates to a known target instead of `"*"`.
 `frame-ancestors` permits, so an unlisted host can't frame `/embed/*`
 either. The iframe variant gives up host-page CSS-variable theming (the
 iframe is a separate document) but inherits everything else.
+
+The frame has no `data-*` attributes of its own, so post metadata
+travels as query parameters: `?title=`, `?url=` and `?published=` land
+on `data-title`, `data-url` and `data-published` inside the frame.
+`?published=` is optional and is left off the frame entirely when empty,
+so the widget sees "absent" rather than an empty string. Build the `src`
+with `URLSearchParams` (as above) so the values are encoded.
 
 `?lang=` is the iframe's equivalent of `data-lang` — it lands on both
 the frame's `<html lang>` and the widget inside it. There is no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ Every attribute the widget reads from the `#garrul` host element
 | `data-api`   | no       | Worker origin override. Defaults to the origin of the script tag (`<script src>`). Set this explicitly when loading `embed.js` via a bundler or async import (anywhere `document.currentScript` may be null at execution time). |
 | `data-title` | no       | Post title; sent on first comment create, surfaces in admin and notification emails.        |
 | `data-url`   | no       | Canonical permalink; sent on first comment create, used in RSS and notification emails.     |
-| `data-published` | no   | Article publish time (epoch ms or ISO 8601); sent on first comment create. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit and Garrul falls back to the first-comment time, which closes the thread a bit later than intended. Only relevant if the operator enabled `AUTO_CLOSE_DAYS`. Recorded only by the request that creates the post row and immutable after that — it comes in on an unauthenticated POST and an old value closes the thread for good, so it is never accepted from a later request. If a reaction or page vote created the row first, the slug keeps the first-engagement anchor. |
+| `data-published` | no   | Article publish time (epoch ms or ISO 8601). The widget sends it as `post_published` on every comment create (top-level and reply); the server records it only on the request that creates the post row and never changes it after that — it arrives on an unauthenticated POST, and an old enough value closes the thread for good, so a later request cannot supply or move it. Anchors age-based auto-close (`AUTO_CLOSE_DAYS`). Omit it and Garrul anchors on first-engagement time, which closes a bit later than intended. If a reaction, page vote or admin action created the row before the first comment, the slug keeps that first-engagement anchor. Repair today is direct D1 SQL on `posts.published_at`; an admin edit surface is a separate backlog item. |
 | `data-lang`  | no       | BCP-47 tag pinning the widget's interface language (see "Language" below). Unrecognized tags fall back to English rather than erroring. |
 
 The host element MUST have `id="garrul"`; the widget looks it up by ID
@@ -1191,6 +1191,10 @@ both `data-api` and the `<script src>`.
   widget reads `data-slug`, `data-api`, `data-title`, `data-url`,
   `data-published`, `data-theme`, and `data-lang` off the host element
   at runtime.
+- Don't expect `data-published` to fix an existing thread's auto-close
+  anchor. It is recorded once, by whichever request first created the
+  post row. Set it before the first engagement on a page, or repair
+  `posts.published_at` with D1 SQL.
 - Don't set `data-api` to a value without `https://`. The widget passes
   it through `new URL(...)` and uses the origin verbatim for CORS-cred
   requests; mixed-content or scheme-relative values will fail.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Drop the widget into any page:
   data-api="https://comments.example.com"
   data-title="My post title"
   data-url="https://example.com/my-post/"
+  data-published="2026-09-11T12:00:00Z"
 ></div>
 <script src="https://comments.example.com/embed.js" defer></script>
 ```

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -19,9 +19,12 @@ AI assistant.
   data-api="https://comments.example.com"
   data-title="My post title"
   data-url="https://example.com/my-post/"
+  data-published="2026-09-11T12:00:00Z"
 ></div>
 <script src="https://comments.example.com/embed.js" defer></script>
 ```
+
+`data-published` is optional. It anchors age-based auto-close (`AUTO_CLOSE_DAYS`) to the article's real publish time; without it the anchor is the first engagement on the thread. It is recorded once, by the request that creates the post row.
 
 ## Content-Security-Policy
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -57,6 +57,13 @@ entirely.
 ></iframe>
 ```
 
+The iframe has no `data-*` attributes of its own, so the post metadata
+travels as query parameters instead: `?title=`, `?url=` and
+`?published=` land on `data-title`, `data-url` and `data-published`
+inside the frame (`?published=` is omitted from the frame when empty).
+`?theme=`, `?preset=` and `?lang=` cover the presentation side. Build
+the `src` with `URLSearchParams` so the values are encoded.
+
 The iframe page posts content height to the parent via
 `postMessage({type:"garrul:height", height})`. See
 [`../examples/iframe/index.html`](../examples/iframe/index.html) for a

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ configured in `wrangler.toml` (`[[routes]]` for a custom domain, or the
 | [`lazy-load/`](./lazy-load/)       | Scroll-into-view and click-to-load deferred loaders            | You want to cut the two mount requests bouncers cost you, at high traffic |
 
 The framework recipes are deliberately near-identical at the HTML level —
-the only thing that varies is how each platform renders the four `data-*`
+the only thing that varies is how each platform renders the five `data-*`
 attributes from its post metadata.
 
 ## The embed contract
@@ -36,16 +36,18 @@ Every recipe boils down to a mount element plus the `embed.js` script:
   data-api="https://comments.yourdomain.com"
   data-title="My post title"
   data-url="https://example.com/my-post/"
+  data-published="2026-09-11T12:00:00Z"
 ></div>
 <script src="https://comments.yourdomain.com/embed.js" defer></script>
 ```
 
-| Attribute    | What it does                                                                                                                         |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `data-slug`  | Stable identifier for the comment thread. Changing it orphans existing comments — pick something tied to the post's identity, not its URL. |
-| `data-api`   | Origin of your Worker. Must match an entry in `ALLOWED_ORIGINS`.                                                                     |
-| `data-title` | Human-readable title shown in email digests and the per-post RSS feed.                                                                |
-| `data-url`   | Canonical permalink for the post. Reflected back in email digests and used to build per-comment permalinks (`/c/:id`).               |
+| Attribute        | What it does                                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `data-slug`      | Stable identifier for the comment thread. Changing it orphans existing comments — pick something tied to the post's identity, not its URL. |
+| `data-api`       | Origin of your Worker. Must match an entry in `ALLOWED_ORIGINS`.                                                                     |
+| `data-title`     | Human-readable title shown in email digests and the per-post RSS feed.                                                                |
+| `data-url`       | Canonical permalink for the post. Reflected back in email digests and used to build per-comment permalinks (`/c/:id`).               |
+| `data-published` | Optional. The post's publish time (ISO 8601 or epoch ms). Anchors age-based auto-close (`AUTO_CLOSE_DAYS`); recorded once, on the request that creates the post row. Omit it and the anchor is first-engagement time. |
 
 The widget mounts inside a Shadow DOM, so host CSS does not leak in. The
 `plain-html/` example includes a "host-bleed-check" block you can use to

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -26,6 +26,7 @@ const { entry } = Astro.props;
     data-api="https://comments.yourdomain.com"
     data-title={entry.data.title}
     data-url={Astro.url.href}
+    data-published={entry.data.pubDate.toISOString()}
   ></div>
   <script src="https://comments.yourdomain.com/embed.js" defer></script>
 </section>
@@ -37,8 +38,8 @@ const { entry } = Astro.props;
 
 ```astro
 ---
-interface Props { slug: string; title: string; }
-const { slug, title } = Astro.props;
+interface Props { slug: string; title: string; published?: Date; }
+const { slug, title, published } = Astro.props;
 const url = Astro.url.href;
 const apiOrigin = "https://comments.yourdomain.com";
 ---
@@ -50,6 +51,7 @@ const apiOrigin = "https://comments.yourdomain.com";
     data-api={apiOrigin}
     data-title={title}
     data-url={url}
+    data-published={published?.toISOString()}
   ></div>
   <script src={`${apiOrigin}/embed.js`} defer></script>
 </section>
@@ -62,7 +64,7 @@ Use it from any post layout:
 import Comments from "../components/Comments.astro";
 const { entry } = Astro.props;
 ---
-<Comments slug={entry.slug} title={entry.data.title} />
+<Comments slug={entry.slug} title={entry.data.title} published={entry.data.pubDate} />
 ```
 
 ## Notes
@@ -75,6 +77,12 @@ const { entry } = Astro.props;
   `Astro.url.href` does the right thing on prod, but in `astro dev`
   it'll be `localhost:4321/...` — set a `site:` in `astro.config.mjs`
   so prod builds use the real URL).
+- `data-published` is optional. It anchors age-based auto-close
+  (`AUTO_CLOSE_DAYS`) on the post's real publish date instead of the
+  first comment's. `pubDate` here is whatever your content collection
+  schema calls the date field (`z.coerce.date()` gives you a `Date`);
+  Astro drops the attribute when the value is `undefined`, so a
+  collection without a date needs no special casing.
 - For Cloudflare Pages hosting, add your Pages domain (e.g.
   `https://yoursite.pages.dev` and your custom domain) to
   `ALLOWED_ORIGINS` in `wrangler.toml`. The Worker's CORS middleware

--- a/examples/hugo/README.md
+++ b/examples/hugo/README.md
@@ -29,6 +29,7 @@ override per-deployment via `HUGO_PARAMS_GARRULAPI`:
     data-api="{{ $api }}"
     data-title="{{ .Title }}"
     data-url="{{ .Permalink }}"
+    data-published="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}"
   ></div>
   <script src="{{ $api }}/embed.js" defer></script>
 </section>
@@ -51,6 +52,10 @@ override per-deployment via `HUGO_PARAMS_GARRULAPI`:
   strings.TrimPrefix "/"` so the slug is the URL path. Whichever you
   pick, **be consistent** — changing slug strings orphans the existing
   thread.
+- `data-published` is optional. It anchors age-based auto-close
+  (`AUTO_CLOSE_DAYS`) on the post's front-matter `date` instead of the
+  first comment's time. The format string is RFC 3339, which is what the
+  widget expects; `.Date.UnixMilli` works too if you prefer epoch ms.
 - To disable comments on a single page, add `disableComments: true` to
   its front-matter.
 - Add your published origin (e.g. `https://yourblog.com`) to

--- a/examples/iframe/index.html
+++ b/examples/iframe/index.html
@@ -48,6 +48,7 @@
 			var src = new URL("http://localhost:8787/embed/welcome");
 			src.searchParams.set("title", "Iframe demo");
 			src.searchParams.set("url", window.location.href);
+			src.searchParams.set("published", "2026-09-11T12:00:00Z");
 			src.searchParams.set("parent_origin", window.location.origin);
 			f.src = src.toString();
 

--- a/examples/jekyll/README.md
+++ b/examples/jekyll/README.md
@@ -28,6 +28,7 @@ garrul:
     data-api="{{ site.garrul.api }}"
     data-title="{{ page.title | xml_escape }}"
     data-url="{{ page.url | absolute_url }}"
+    data-published="{{ page.date | date_to_xmlschema }}"
   ></div>
   <script src="{{ site.garrul.api }}/embed.js" defer></script>
 </section>
@@ -50,6 +51,11 @@ In `_layouts/post.html`, at the bottom of `<article>`:
 - `page.slug` is auto-generated from the post filename (the part after
   the date, sans extension). Stable across rebuilds — but if you rename
   a post file, the slug changes and the existing thread is orphaned.
+- `data-published` is optional. It anchors age-based auto-close
+  (`AUTO_CLOSE_DAYS`) on the post's date instead of the first comment's
+  time. `date_to_xmlschema` emits ISO 8601, which is what the widget
+  expects; `page.date` comes from the filename date or the `date:`
+  front-matter key.
 - To disable comments on one post, add `comments: false` to its
   front-matter.
 - Add your published origin (e.g. `https://yourblog.github.io` or your

--- a/examples/lazy-load/README.md
+++ b/examples/lazy-load/README.md
@@ -37,6 +37,7 @@ get a seamless experience. Bouncers cost you nothing.
     data-api="https://comments.example.com"
     data-title="My post title"
     data-url="https://example.com/my-post/"
+    data-published="2026-09-11T12:00:00Z"
   ></div>
 </section>
 
@@ -97,6 +98,7 @@ Render a button; mount the widget only after a click.
     data-api="https://comments.example.com"
     data-title="My post title"
     data-url="https://example.com/my-post/"
+    data-published="2026-09-11T12:00:00Z"
     hidden
   ></div>
 </section>

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -39,6 +39,7 @@
 		data-api="http://localhost:8787"
 		data-title="Garrul demo post"
 		data-url="http://localhost:5173/examples/plain-html/"
+		data-published="2026-09-11T12:00:00Z"
 	></div>
 
 	<script src="http://localhost:8787/embed.js" defer></script>

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -82,9 +82,10 @@ useful for a single demo page.
   WordPress nonce wiring needed.
 - `data-published` is optional. It anchors age-based auto-close
   (`AUTO_CLOSE_DAYS`) on the post's publish date instead of the first
-  comment's time. `get_post_time('c', true)` returns the GMT publish
-  time in ISO 8601; the second argument matters, because the local-time
-  variant carries the site's offset instead of `Z`.
+  comment's time. `get_post_time('c', true)` returns the publish time
+  in ISO 8601 as UTC (`2026-09-11T12:00:00+00:00`). The server parses
+  either time zone, so the `true` is for consistency with the other
+  recipes rather than correctness.
 - WordPress core's comment count helpers (`comments_number`,
   `get_comments_number`) won't reflect Garrul comments. If you want the
   count badge in your post list, fetch `GET /api/v1/counts?slugs=a,b,c`

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -29,9 +29,10 @@ Replace your theme's `comments.php` with:
 ```php
 <?php
 if (post_password_required()) return;
-$slug  = get_post_field('post_name', get_the_ID());
-$title = get_the_title();
-$url   = get_permalink();
+$slug      = get_post_field('post_name', get_the_ID());
+$title     = get_the_title();
+$url       = get_permalink();
+$published = get_post_time('c', true); // ISO 8601, UTC
 ?>
 <section id="comments" class="garrul-wrap">
     <h2>Comments</h2>
@@ -41,6 +42,7 @@ $url   = get_permalink();
         data-api="https://comments.yourdomain.com"
         data-title="<?php echo esc_attr($title); ?>"
         data-url="<?php echo esc_url($url); ?>"
+        data-published="<?php echo esc_attr($published); ?>"
     ></div>
 </section>
 ```
@@ -60,6 +62,7 @@ of a post (works for one-off pages or testing):
     data-api="https://comments.yourdomain.com"
     data-title="Hello world"
     data-url="https://yourblog.com/hello-world/"
+    data-published="2026-09-11T12:00:00Z"
 ></div>
 <script src="https://comments.yourdomain.com/embed.js" defer></script>
 ```
@@ -77,6 +80,11 @@ useful for a single demo page.
   `wrangler.toml` (e.g. `https://yourblog.com`).
 - The Cloudflare Worker handles all CSRF / spam protection — no
   WordPress nonce wiring needed.
+- `data-published` is optional. It anchors age-based auto-close
+  (`AUTO_CLOSE_DAYS`) on the post's publish date instead of the first
+  comment's time. `get_post_time('c', true)` returns the GMT publish
+  time in ISO 8601; the second argument matters, because the local-time
+  variant carries the site's offset instead of `Z`.
 - WordPress core's comment count helpers (`comments_number`,
   `get_comments_number`) won't reflect Garrul comments. If you want the
   count badge in your post list, fetch `GET /api/v1/counts?slugs=a,b,c`

--- a/src/routes/embed-iframe.ts
+++ b/src/routes/embed-iframe.ts
@@ -19,6 +19,9 @@
  *     same origin as this route, which is the common case)
  *   ?title=...                        — passed through to data-title
  *   ?url=...                          — passed through to data-url
+ *   ?published=...                    — passed through to data-published
+ *     (epoch ms or ISO 8601); omitted when empty so the widget's
+ *     dataset check sees "absent", not ""
  *   ?theme=light|dark|auto            — host-page theme hint
  *   ?preset=minimal|soft|contrast     — named palette (docs/THEMING.md). The
  *     iframe path can't set CSS variables on the widget — the host page is a
@@ -373,6 +376,10 @@ iframe.get("/:slug", (c) => {
 
 	const title = c.req.query("title") ?? "";
 	const pageUrl = c.req.query("url") ?? "";
+	// Passed through, not validated: the widget forwards it as post_published
+	// and the server parses it there, so the same unparseable value fails the
+	// same way on both embed paths.
+	const published = c.req.query("published") ?? "";
 	// Validated against the vocabulary, not merely escaped: it reaches a CSS
 	// declaration below, where escapeAttr buys nothing. Same three values the
 	// Turnstile route accepts; anything else is "auto" (follow the OS).
@@ -439,7 +446,7 @@ iframe.get("/:slug", (c) => {
   data-slug="${escapeAttr(slug)}"
   data-api="${escapeAttr(apiBase)}"
   data-title="${escapeAttr(title)}"
-  data-url="${escapeAttr(pageUrl)}"
+  data-url="${escapeAttr(pageUrl)}"${published ? `\n  data-published="${escapeAttr(published)}"` : ""}
   data-theme="${escapeAttr(theme)}"${preset ? `\n  data-preset="${escapeAttr(preset)}"` : ""}
   data-lang="${escapeAttr(lang)}"
 ></div>

--- a/src/widget/boot.ts
+++ b/src/widget/boot.ts
@@ -272,3 +272,23 @@ export const fetchBootstrap = async (
 		return null;
 	}
 };
+
+/** Post metadata attached to every comment create, from the host's data-*. */
+export type PostMeta = {
+	post_title: string | null;
+	post_url: string | null;
+	/** Raw `data-published` (epoch ms or ISO 8601); the server parses it. */
+	post_published: string | null;
+};
+
+/**
+ * Read `data-title`, `data-url` and `data-published` off a host element's
+ * dataset. Takes the plain record rather than the element so it stays DOM-free
+ * and testable. Missing attributes become null: the server's body type is
+ * `string | null` and `upsertPost` treats null as "nothing to record".
+ */
+export const postMetaFromDataset = (ds: Record<string, string | undefined>): PostMeta => ({
+	post_title: ds.title ?? null,
+	post_url: ds.url ?? null,
+	post_published: ds.published ?? null,
+});

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -78,6 +78,7 @@ import {
 	type SubscriptionSection,
 	fetchBootstrap,
 	fetchConfig,
+	postMetaFromDataset,
 } from "./boot";
 // Generated from styles.css by scripts/build-styles.ts (gitignored, rebuilt by
 // build:assets). Edit styles.css, never the .gen file.
@@ -2288,8 +2289,7 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 					turnstile_token: turnstileToken,
 					website: honey.value,
 					form_ts: formTs,
-					post_title: ctx.host.dataset.title ?? null,
-					post_url: ctx.host.dataset.url ?? null,
+					...postMetaFromDataset(ctx.host.dataset),
 				}),
 			});
 			const json = (await res.json()) as {
@@ -4101,8 +4101,7 @@ const submit = async (
 				turnstile_token: turnstileToken,
 				website: honeypot,
 				form_ts: formTs,
-				post_title: host.dataset.title ?? null,
-				post_url: host.dataset.url ?? null,
+				...postMetaFromDataset(host.dataset),
 			}),
 		});
 		const json = (await res.json()) as {

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -7,8 +7,12 @@
  *
  * Optional data-* attributes:
  *   data-api="https://comments.example.com"  // origin of the Garrul Worker
- *   data-title="Post title"                  // sent on first comment create
+ *   data-title="Post title"                  // sent on every comment create;
+ *                                            // server keeps the first non-null
  *   data-url="https://blog/.../post-url"     // ditto
+ *   data-published="2026-09-11T12:00:00Z"    // ditto (ISO 8601 or epoch ms);
+ *                                            // anchors age-based auto-close,
+ *                                            // recorded once on post creation
  *
  * Behavior:
  *   1. Mount a Shadow DOM on DOMContentLoaded.

--- a/tests/embed-iframe.test.ts
+++ b/tests/embed-iframe.test.ts
@@ -236,6 +236,31 @@ describe("GET /embed/:slug", () => {
 		});
 	});
 
+	describe("?published=", () => {
+		it("forwards the value to data-published", async () => {
+			const res = await fetchPage(
+				`/embed/hello?published=${encodeURIComponent("2026-09-11T12:00:00Z")}`,
+			);
+			expect(await res.text()).toContain('data-published="2026-09-11T12:00:00Z"');
+		});
+
+		it("emits no attribute when the param is absent", async () => {
+			// The widget reads `ds.published ?? null`, so an empty attribute would
+			// send post_published: "" instead of omitting the field.
+			const res = await fetchPage("/embed/hello");
+			expect(await res.text()).not.toContain("data-published");
+		});
+
+		it("cannot break out of the attribute", async () => {
+			const res = await fetchPage(
+				`/embed/hello?published=${encodeURIComponent('x" onload="alert(1)')}`,
+			);
+			const body = await res.text();
+			expect(body).not.toContain('" onload="');
+			expect(body).toContain("data-published=\"x&quot; onload=&quot;alert(1)\"");
+		});
+	});
+
 	it("keeps the ?api= override gated on the allowlist", async () => {
 		// Regression guard on the pattern parent_origin was modelled after: an
 		// unlisted override would load attacker-controlled JS into the frame,

--- a/tests/widget-post-meta.test.ts
+++ b/tests/widget-post-meta.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The post metadata the widget attaches to every comment create, read off the
+ * host element's data-* attributes. `post_published` anchors age-based
+ * auto-close on the server; the server records it only on the request that
+ * creates the post row, so the widget must send it on every create (it cannot
+ * know which one is first).
+ */
+import { describe, it, expect } from "vitest";
+import { postMetaFromDataset } from "../src/widget/boot";
+
+describe("postMetaFromDataset", () => {
+	it("passes title, url and published through", () => {
+		expect(
+			postMetaFromDataset({
+				title: "Hello",
+				url: "https://example.com/hello/",
+				published: "2026-09-11T12:00:00Z",
+			}),
+		).toEqual({
+			post_title: "Hello",
+			post_url: "https://example.com/hello/",
+			post_published: "2026-09-11T12:00:00Z",
+		});
+	});
+
+	it("maps missing attributes to null", () => {
+		expect(postMetaFromDataset({})).toEqual({
+			post_title: null,
+			post_url: null,
+			post_published: null,
+		});
+	});
+
+	it("ignores unrelated data-* attributes", () => {
+		expect(postMetaFromDataset({ slug: "x", api: "https://c.example", title: "T" })).toEqual({
+			post_title: "T",
+			post_url: null,
+			post_published: null,
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- The widget reads `data-published` and sends `post_published` on both comment-create paths via a DOM-free helper (`postMetaFromDataset`). No server change: `upsertPost` already records it on the row-creating request only.
- Docs (AGENTS.md, AGENTS-OPERATE.md, docs/embedding.md, README.md) now state the anchor is sent by the widget on every create, recorded once, immutable, and repairable only by D1 SQL until the admin edit surface (separate backlog item) ships.

## Test plan
- [x] `tests/widget-post-meta.test.ts`
- [x] existing post-title / thread-closure tests unchanged
- [x] lint, typecheck, test, manifest:check, build, size
