### PR TITLE
fix: draft autosave keys include the Worker origin (N4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1194,6 +1194,10 @@ both `data-api` and the `<script src>`.
 - Don't set `data-api` to a value without `https://`. The widget passes
   it through `new URL(...)` and uses the origin verbatim for CORS-cred
   requests; mixed-content or scheme-relative values will fail.
+- Don't assume comment drafts survive a `data-api` change. Draft
+  autosave keys are `garrul:draft:<api origin>:<slug>[:<parent>]` (since
+  v2.27.0), so a draft belongs to one Worker origin. Pre-v2.27.0 drafts
+  (`garrul:draft:<slug>`) are adopted once on the next mount.
 - Don't render two `#garrul` elements on one page; only the first is
   picked up. Multi-thread is not a supported mode in v1.
 - Don't try to style internals via host CSS. Shadow DOM blocks it on

--- a/src/widget/drafts.ts
+++ b/src/widget/drafts.ts
@@ -1,0 +1,53 @@
+/**
+ * Draft autosave keys and the one-time legacy adoption.
+ *
+ * DOM-free on purpose (tsconfig.widget.json, plain node tests). embed.ts owns
+ * the textarea wiring; this module owns what the key looks like and how a
+ * pre-2.27.0 draft (no origin in the key) is carried over.
+ *
+ * Why the origin: localStorage is per host-page origin, so two Garrul
+ * instances embedded on one page (different `data-api`) shared a key for the
+ * same slug and restored each other's text. The API origin is the identity of
+ * the instance the draft belongs to.
+ */
+
+const DRAFT_PREFIX = "garrul:draft:";
+
+/** Cap on stored bytes; the server rejects oversized bodies anyway. */
+export const DRAFT_MAX = 10_000;
+
+/** The subset of Storage this module touches; lets tests pass a plain object. */
+export type DraftStorage = {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+	removeItem(key: string): void;
+};
+
+export const draftKey = (origin: string, slug: string, parentId: string | null): string =>
+	`${DRAFT_PREFIX}${origin}:${slug}${parentId ? `:${parentId}` : ""}`;
+
+/** The pre-2.27.0 key, kept only so adoptLegacyDraft can find old drafts. */
+export const legacyDraftKey = (slug: string, parentId: string | null): string =>
+	`${DRAFT_PREFIX}${slug}${parentId ? `:${parentId}` : ""}`;
+
+/**
+ * Copy a draft saved under the legacy key into the new key, then remove the
+ * legacy entry — only when the new key is empty and the legacy key has text.
+ * Any storage error (Safari private mode, quota, disabled) is swallowed:
+ * losing an old draft is acceptable, breaking the composer is not.
+ */
+export const adoptLegacyDraft = (
+	storage: DraftStorage,
+	newKey: string,
+	legacyKey: string,
+): void => {
+	try {
+		if (storage.getItem(newKey)) return;
+		const old = storage.getItem(legacyKey);
+		if (!old) return;
+		storage.setItem(newKey, old.slice(0, DRAFT_MAX));
+		storage.removeItem(legacyKey);
+	} catch {
+		// Storage unavailable — nothing to adopt.
+	}
+};

--- a/src/widget/drafts.ts
+++ b/src/widget/drafts.ts
@@ -5,10 +5,12 @@
  * the textarea wiring; this module owns what the key looks like and how a
  * pre-2.27.0 draft (no origin in the key) is carried over.
  *
- * Why the origin: localStorage is per host-page origin, so two Garrul
- * instances embedded on one page (different `data-api`) shared a key for the
- * same slug and restored each other's text. The API origin is the identity of
- * the instance the draft belongs to.
+ * Why the origin: localStorage is scoped to the host page's origin, not to
+ * the Worker a page talks to. Two pages on the same host origin that point at
+ * different Workers (a staging site and production during a migration, say)
+ * share that storage, so a key without the Worker's origin let one Worker's
+ * draft appear under the other. The API origin is the identity of the Worker
+ * the draft belongs to.
  */
 
 const DRAFT_PREFIX = "garrul:draft:";

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -277,10 +277,12 @@ const autoSize = (ta: HTMLTextAreaElement): void =>
 
 // ── Draft autosave ──────────────────────────────────────────────────────────
 // A long comment shouldn't vanish on an accidental reload or a failed submit.
-// Drafts live ONLY in the visitor's own browser (localStorage), keyed by slug
-// (and parent id for replies). No server state, no PII leaves the device; the
-// value is re-inserted via textarea.value (never as HTML), so no XSS surface.
-// Key shape and legacy adoption live in ./drafts (DOM-free, unit-tested).
+// Drafts live ONLY in the visitor's own browser (localStorage), keyed by the
+// Worker origin, the slug, and the parent id for replies, so two Garrul
+// installs embedded on the same host origin never read each other's drafts.
+// No server state, no PII leaves the device; the value is re-inserted via
+// textarea.value (never as HTML), so no XSS surface. Key shape and legacy
+// (slug-only) adoption live in ./drafts (DOM-free, unit-tested).
 
 const clearDraft = (key: string): void => {
 	try {
@@ -298,8 +300,11 @@ const clearDraft = (key: string): void => {
  * the composer.
  */
 const attachDraft = (ta: HTMLTextAreaElement, key: string, legacyKey: string): string => {
-	adoptLegacyDraft(localStorage, key, legacyKey);
 	try {
+		// Inside the try on purpose: the `localStorage` getter itself throws
+		// where storage is blocked, and that has to degrade like every other
+		// storage failure here rather than abort the mount.
+		adoptLegacyDraft(localStorage, key, legacyKey);
 		const saved = localStorage.getItem(key);
 		// Only restore into an empty field so we never clobber a server-provided
 		// or already-typed value.

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -39,6 +39,7 @@
 import { loadErrorMessage } from "./load-error";
 import { watchForSignIn } from "./auth-recovery";
 import { autoSizeTextarea } from "./autosize";
+import { DRAFT_MAX, adoptLegacyDraft, draftKey, legacyDraftKey } from "./drafts";
 import { createTurnstileGate, type TurnstileGate } from "./turnstile-gate";
 import { makeS, type StringTable, type WidgetKey } from "./strings";
 import {
@@ -279,13 +280,7 @@ const autoSize = (ta: HTMLTextAreaElement): void =>
 // Drafts live ONLY in the visitor's own browser (localStorage), keyed by slug
 // (and parent id for replies). No server state, no PII leaves the device; the
 // value is re-inserted via textarea.value (never as HTML), so no XSS surface.
-const DRAFT_PREFIX = "garrul:draft:";
-// Cap the stored size — localStorage is small and shared across the origin, and
-// the server rejects oversized bodies anyway. Generous vs. the comment limit.
-const DRAFT_MAX = 10_000;
-
-const draftKey = (slug: string, parentId: string | null): string =>
-	`${DRAFT_PREFIX}${slug}${parentId ? `:${parentId}` : ""}`;
+// Key shape and legacy adoption live in ./drafts (DOM-free, unit-tested).
 
 const clearDraft = (key: string): void => {
 	try {
@@ -302,7 +297,8 @@ const clearDraft = (key: string): void => {
  * (Safari private mode, quota, disabled) degrades to no autosave, never breaks
  * the composer.
  */
-const attachDraft = (ta: HTMLTextAreaElement, key: string): string => {
+const attachDraft = (ta: HTMLTextAreaElement, key: string, legacyKey: string): string => {
+	adoptLegacyDraft(localStorage, key, legacyKey);
 	try {
 		const saved = localStorage.getItem(key);
 		// Only restore into an empty field so we never clobber a server-provided
@@ -662,6 +658,7 @@ const buildAvatar = (a: TreeAuthor): HTMLElement => {
 
 type WidgetCtx = {
 	apiBase: string;
+	apiOrigin: string;
 	slug: string;
 	host: HTMLElement;
 	root: ShadowRoot;
@@ -2103,7 +2100,11 @@ const buildReplyForm = (parent: TreeNode, ctx: WidgetCtx): HTMLElement => {
 	ta.placeholder = s("w.reply_ph", { name: parent.author.name });
 	ta.setAttribute("aria-label", s("w.reply_ph", { name: parent.author.name }));
 	ta.required = true;
-	const dkey = attachDraft(ta, draftKey(ctx.slug, parent.id));
+	const dkey = attachDraft(
+		ta,
+		draftKey(ctx.apiOrigin, ctx.slug, parent.id),
+		legacyDraftKey(ctx.slug, parent.id),
+	);
 
 	let nameInput: HTMLInputElement | null = null;
 	if (!ctx.me) {
@@ -3494,6 +3495,8 @@ const loadOnce = async (
 	host: HTMLElement,
 	sort: SortKey | null,
 ) => {
+	// The instance's identity for draft keys — see WidgetCtx.apiOrigin.
+	const apiOrigin = new URL(apiBase).origin;
 	let siteKey: string | null = null;
 	let turnstileAlways = false;
 	// Only used when /api/v1/config never answers — the server always sends a
@@ -3663,6 +3666,7 @@ const loadOnce = async (
 		});
 	const ctx: WidgetCtx = {
 		apiBase,
+		apiOrigin,
 		slug,
 		host,
 		root,
@@ -3717,7 +3721,8 @@ const loadOnce = async (
 	const composer = form.querySelector(
 		".gr-body-input",
 	) as HTMLTextAreaElement | null;
-	if (composer) attachDraft(composer, draftKey(slug, null));
+	if (composer)
+		attachDraft(composer, draftKey(apiOrigin, slug, null), legacyDraftKey(slug, null));
 	const list = el("div", "gr-list");
 	if (data.threads.length === 0) {
 		// Don't invite a comment the reader can't leave: when comments are
@@ -4123,7 +4128,7 @@ const submit = async (
 
 		// Comment landed — drop the saved composer draft so the reload starts
 		// from a clean field.
-		clearDraft(draftKey(slug, null));
+		clearDraft(draftKey(new URL(apiBase).origin, slug, null));
 
 		// Fire-and-forget subscription — failure here doesn't roll back
 		// the comment. The widget already has both inputs handy.

--- a/src/widget/embed.ts
+++ b/src/widget/embed.ts
@@ -4004,7 +4004,7 @@ const loadOnce = async (
 
 	form.addEventListener("submit", (e) => {
 		e.preventDefault();
-		void submit(form, root, slug, apiBase, host);
+		void submit(form, root, slug, apiBase, apiOrigin, host);
 	});
 
 	// No cancel handler: the top-level composer is the page's resting state, so
@@ -4017,6 +4017,7 @@ const submit = async (
 	root: ShadowRoot,
 	slug: string,
 	apiBase: string,
+	apiOrigin: string,
 	host: HTMLElement,
 ) => {
 	// Two things write to this box: submit failures, and Turnstile. Precedence:
@@ -4128,7 +4129,7 @@ const submit = async (
 
 		// Comment landed — drop the saved composer draft so the reload starts
 		// from a clean field.
-		clearDraft(draftKey(new URL(apiBase).origin, slug, null));
+		clearDraft(draftKey(apiOrigin, slug, null));
 
 		// Fire-and-forget subscription — failure here doesn't roll back
 		// the comment. The widget already has both inputs handy.

--- a/tests/widget-drafts.test.ts
+++ b/tests/widget-drafts.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Draft keys carry the Worker origin so two Garrul instances embedded on one
+ * host page (e.g. staging and production during a migration) cannot restore
+ * each other's text. Legacy keys (no origin) are adopted once so an upgrade
+ * does not lose a half-typed comment.
+ */
+import { describe, it, expect } from "vitest";
+import { draftKey, legacyDraftKey, adoptLegacyDraft } from "../src/widget/drafts";
+
+const fakeStorage = (init: Record<string, string> = {}) => {
+	const m = new Map(Object.entries(init));
+	return {
+		getItem: (k: string) => m.get(k) ?? null,
+		setItem: (k: string, v: string) => void m.set(k, v),
+		removeItem: (k: string) => void m.delete(k),
+		dump: () => Object.fromEntries(m),
+	};
+};
+
+describe("draftKey", () => {
+	it("includes origin, slug and optional parent", () => {
+		expect(draftKey("https://c.example", "post", null)).toBe("garrul:draft:https://c.example:post");
+		expect(draftKey("https://c.example", "post", "01H")).toBe(
+			"garrul:draft:https://c.example:post:01H",
+		);
+	});
+
+	it("differs across origins for the same slug", () => {
+		expect(draftKey("https://a.example", "post", null)).not.toBe(
+			draftKey("https://b.example", "post", null),
+		);
+	});
+
+	it("legacyDraftKey reproduces the pre-2.27.0 key", () => {
+		expect(legacyDraftKey("post", null)).toBe("garrul:draft:post");
+		expect(legacyDraftKey("post", "01H")).toBe("garrul:draft:post:01H");
+	});
+});
+
+describe("adoptLegacyDraft", () => {
+	it("moves a legacy draft into the new key when the new key is empty", () => {
+		const s = fakeStorage({ "garrul:draft:post": "hello" });
+		adoptLegacyDraft(s, "garrul:draft:https://c.example:post", "garrul:draft:post");
+		expect(s.dump()).toEqual({ "garrul:draft:https://c.example:post": "hello" });
+	});
+
+	it("leaves an existing new-key draft alone", () => {
+		const s = fakeStorage({
+			"garrul:draft:post": "old",
+			"garrul:draft:https://c.example:post": "new",
+		});
+		adoptLegacyDraft(s, "garrul:draft:https://c.example:post", "garrul:draft:post");
+		expect(s.dump()).toEqual({
+			"garrul:draft:post": "old",
+			"garrul:draft:https://c.example:post": "new",
+		});
+	});
+
+	it("does nothing when there is no legacy draft", () => {
+		const s = fakeStorage();
+		adoptLegacyDraft(s, "garrul:draft:https://c.example:post", "garrul:draft:post");
+		expect(s.dump()).toEqual({});
+	});
+
+	it("swallows storage errors", () => {
+		const throwing = {
+			getItem: () => {
+				throw new Error("disabled");
+			},
+			setItem: () => {},
+			removeItem: () => {},
+		};
+		expect(() => adoptLegacyDraft(throwing, "a", "b")).not.toThrow();
+	});
+});

--- a/tests/widget-drafts.test.ts
+++ b/tests/widget-drafts.test.ts
@@ -1,8 +1,8 @@
 /**
- * Draft keys carry the Worker origin so two Garrul instances embedded on one
- * host page (e.g. staging and production during a migration) cannot restore
- * each other's text. Legacy keys (no origin) are adopted once so an upgrade
- * does not lose a half-typed comment.
+ * Draft keys carry the Worker origin so two pages on the same host origin
+ * that point at different Workers (staging and production during a
+ * migration, say) cannot restore each other's text. Legacy keys (no origin)
+ * are adopted once so an upgrade does not lose a half-typed comment.
  */
 import { describe, it, expect } from "vitest";
 import { draftKey, legacyDraftKey, adoptLegacyDraft } from "../src/widget/drafts";


### PR DESCRIPTION
## Summary
- New pure module `src/widget/drafts.ts`: `draftKey(origin, slug, parent)`, `legacyDraftKey`, `adoptLegacyDraft`.
- Two Garrul instances on one host page no longer share a draft for the same slug. A pre-upgrade draft is moved into the new key on first mount.

## Test plan
- [x] `tests/widget-drafts.test.ts` (keys, cross-origin distinctness, adoption rules, storage errors)
- [x] lint, typecheck, test, manifest:check, build, size
