### PR TITLE
perf: scope engagement queries to the comments on the page (O1)

### DIFF
--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1610,7 +1610,9 @@ rendered:
   state when those surfaces are on.
   Reactions, the viewer's reactions and the viewer's votes are loaded for
   the comments on the returned page only (batched `IN` lists of 90), not
-  for the whole post, so page cost does not grow with thread size.
+  for the whole post, so page cost does not grow with thread size. Every
+  chunk goes out in one `db.batch` call per query, so the round-trip count
+  stays constant per query regardless of how many chunks a page needs.
 - `GET /api/v1/comments/form-token` — the signed form-render timestamp
   behind the anti-spam timing heuristic, prefetched when the composer
   renders. It stays a separate call on purpose: a shared timestamp would

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1610,9 +1610,13 @@ rendered:
   state when those surfaces are on.
   Reactions, the viewer's reactions and the viewer's votes are loaded for
   the comments on the returned page only (batched `IN` lists of 90), not
-  for the whole post, so page cost does not grow with thread size. Every
-  chunk goes out in one `db.batch` call per query, so the round-trip count
-  stays constant per query regardless of how many chunks a page needs.
+  for the whole post. Page cost is bounded by the rows the page returns
+  (at most `TREE_ROW_LIMIT`), not by the post's total comment count; a
+  page that selects one very large thread still pays for that thread's
+  full subtree, because `listCommentsForThreads` returns whole subtrees.
+  Every chunk goes out in one `db.batch` call per query, so the
+  round-trip count stays constant per query regardless of how many
+  chunks a page needs.
 - `GET /api/v1/comments/form-token` — the signed form-render timestamp
   behind the anti-spam timing heuristic, prefetched when the composer
   renders. It stays a separate call on purpose: a shared timestamp would

--- a/AGENTS-OPERATE.md
+++ b/AGENTS-OPERATE.md
@@ -1608,6 +1608,9 @@ rendered:
 - `GET /api/v1/bootstrap?slug=…` — the config, the session user, the
   first page of comments, and page-level engagement and subscription
   state when those surfaces are on.
+  Reactions, the viewer's reactions and the viewer's votes are loaded for
+  the comments on the returned page only (batched `IN` lists of 90), not
+  for the whole post, so page cost does not grow with thread size.
 - `GET /api/v1/comments/form-token` — the signed form-render timestamp
   behind the anti-spam timing heuristic, prefetched when the composer
   renders. It stays a separate call on purpose: a shared timestamp would

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -12,6 +12,19 @@
 import { ulid } from "../lib/ulid";
 import { hostExpr } from "./host-expr";
 
+/**
+ * Max ids per `IN (...)` list. D1 caps bound parameters at 100; 90 leaves room
+ * for the other binds a statement carries (user_id etc.). Same figure as
+ * AUTHOR_BATCH in api.comments.ts.
+ */
+const IN_BATCH = 90;
+
+const chunk = <T>(xs: readonly T[], size: number): T[][] => {
+	const out: T[][] = [];
+	for (let i = 0; i < xs.length; i += size) out.push(xs.slice(i, i + size));
+	return out;
+};
+
 // Escape SQL LIKE wildcards so admin search inputs are matched as literals.
 // SQLite treats `%` and `_` as wildcards inside the pattern; without escaping
 // them, searching for "50%" matches "501" too, and a string of `_` chars can
@@ -975,24 +988,30 @@ export type ReactionSummary = {
 };
 
 /**
- * Aggregate reactions for every comment on a post: (comment_id, kind, count).
- * Caller pivots to per-comment buckets.
+ * Aggregate reactions for a set of comments: (comment_id, kind, count).
+ * Caller pivots to per-comment buckets. Scoped to the ids on the page rather
+ * than the whole post so a 5,000-comment thread does not pay for every
+ * reaction on every page request.
  */
-export const listReactionsForPost = async (
+export const listReactionsForComments = async (
 	db: D1Database,
-	post_slug: string,
+	comment_ids: readonly string[],
 ): Promise<ReactionSummary[]> => {
-	const result = await db
-		.prepare(
-			`SELECT r.comment_id, r.kind, COUNT(*) AS count
-			 FROM reactions r
-			 JOIN comments c ON c.id = r.comment_id
-			 WHERE c.post_slug = ?
-			 GROUP BY r.comment_id, r.kind`,
-		)
-		.bind(post_slug)
-		.all<{ comment_id: string; kind: string; count: number }>();
-	return result.results ?? [];
+	const out: ReactionSummary[] = [];
+	for (const batch of chunk(comment_ids, IN_BATCH)) {
+		const placeholders = batch.map(() => "?").join(",");
+		const result = await db
+			.prepare(
+				`SELECT r.comment_id, r.kind, COUNT(*) AS count
+				 FROM reactions r
+				 WHERE r.comment_id IN (${placeholders})
+				 GROUP BY r.comment_id, r.kind`,
+			)
+			.bind(...batch)
+			.all<ReactionSummary>();
+		out.push(...(result.results ?? []));
+	}
+	return out;
 };
 
 /**
@@ -1018,28 +1037,24 @@ export const listReactionsForComment = async (
 	return result.results ?? [];
 };
 
-/**
- * Returns the set of (comment_id, kind) pairs the given user has reacted
- * with on the given post. Returned as `comment_id|kind` strings so the
- * caller can do an O(1) presence check.
- */
-export const listUserReactionsOnPost = async (
+/** `comment_id|kind` pairs the viewer has reacted with, over a set of comments. */
+export const listUserReactionsOnComments = async (
 	db: D1Database,
-	post_slug: string,
+	comment_ids: readonly string[],
 	user_id: string,
 ): Promise<Set<string>> => {
-	const result = await db
-		.prepare(
-			`SELECT r.comment_id, r.kind
-			 FROM reactions r
-			 JOIN comments c ON c.id = r.comment_id
-			 WHERE c.post_slug = ? AND r.user_id = ?`,
-		)
-		.bind(post_slug, user_id)
-		.all<{ comment_id: string; kind: string }>();
 	const out = new Set<string>();
-	for (const row of result.results ?? []) {
-		out.add(`${row.comment_id}|${row.kind}`);
+	for (const batch of chunk(comment_ids, IN_BATCH)) {
+		const placeholders = batch.map(() => "?").join(",");
+		const result = await db
+			.prepare(
+				`SELECT r.comment_id, r.kind
+				 FROM reactions r
+				 WHERE r.comment_id IN (${placeholders}) AND r.user_id = ?`,
+			)
+			.bind(...batch, user_id)
+			.all<{ comment_id: string; kind: string }>();
+		for (const row of result.results ?? []) out.add(`${row.comment_id}|${row.kind}`);
 	}
 	return out;
 };
@@ -3795,29 +3810,26 @@ export const castVote = async (
 	return reselectScores(db, comment_id, user_id);
 };
 
-/**
- * Returns the calling user's vote on each (comment_id) for one post, as
- * a Map keyed by comment_id. Used to populate `my_vote` on the public
- * list endpoint for authenticated viewers; anonymous viewers bypass this
- * (the cached payload has no my_vote field).
- */
-export const getUserVotesOnPost = async (
+/** The viewer's vote per comment, over a set of comments. */
+export const getUserVotesOnComments = async (
 	db: D1Database,
-	post_slug: string,
+	comment_ids: readonly string[],
 	user_id: string,
 ): Promise<Map<string, -1 | 1>> => {
-	const result = await db
-		.prepare(
-			`SELECT v.comment_id, v.value
-			   FROM votes v
-			   JOIN comments c ON c.id = v.comment_id
-			  WHERE c.post_slug = ? AND v.user_id = ?`,
-		)
-		.bind(post_slug, user_id)
-		.all<{ comment_id: string; value: number }>();
 	const out = new Map<string, -1 | 1>();
-	for (const r of result.results ?? []) {
-		if (r.value === 1 || r.value === -1) out.set(r.comment_id, r.value);
+	for (const batch of chunk(comment_ids, IN_BATCH)) {
+		const placeholders = batch.map(() => "?").join(",");
+		const result = await db
+			.prepare(
+				`SELECT v.comment_id, v.value
+				   FROM votes v
+				  WHERE v.comment_id IN (${placeholders}) AND v.user_id = ?`,
+			)
+			.bind(...batch, user_id)
+			.all<{ comment_id: string; value: number }>();
+		for (const r of result.results ?? []) {
+			if (r.value === 1 || r.value === -1) out.set(r.comment_id, r.value);
+		}
 	}
 	return out;
 };

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -997,20 +997,22 @@ export const listReactionsForComments = async (
 	db: D1Database,
 	comment_ids: readonly string[],
 ): Promise<ReactionSummary[]> => {
-	const out: ReactionSummary[] = [];
-	for (const batch of chunk(comment_ids, IN_BATCH)) {
+	const chunks = chunk(comment_ids, IN_BATCH);
+	if (chunks.length === 0) return [];
+	const stmts = chunks.map((batch) => {
 		const placeholders = batch.map(() => "?").join(",");
-		const result = await db
+		return db
 			.prepare(
 				`SELECT r.comment_id, r.kind, COUNT(*) AS count
 				 FROM reactions r
 				 WHERE r.comment_id IN (${placeholders})
 				 GROUP BY r.comment_id, r.kind`,
 			)
-			.bind(...batch)
-			.all<ReactionSummary>();
-		out.push(...(result.results ?? []));
-	}
+			.bind(...batch);
+	});
+	const results = await db.batch<ReactionSummary>(stmts);
+	const out: ReactionSummary[] = [];
+	for (const result of results) out.push(...(result.results ?? []));
 	return out;
 };
 
@@ -1043,17 +1045,21 @@ export const listUserReactionsOnComments = async (
 	comment_ids: readonly string[],
 	user_id: string,
 ): Promise<Set<string>> => {
-	const out = new Set<string>();
-	for (const batch of chunk(comment_ids, IN_BATCH)) {
+	const chunks = chunk(comment_ids, IN_BATCH);
+	if (chunks.length === 0) return new Set<string>();
+	const stmts = chunks.map((batch) => {
 		const placeholders = batch.map(() => "?").join(",");
-		const result = await db
+		return db
 			.prepare(
 				`SELECT r.comment_id, r.kind
 				 FROM reactions r
 				 WHERE r.comment_id IN (${placeholders}) AND r.user_id = ?`,
 			)
-			.bind(...batch, user_id)
-			.all<{ comment_id: string; kind: string }>();
+			.bind(...batch, user_id);
+	});
+	const results = await db.batch<{ comment_id: string; kind: string }>(stmts);
+	const out = new Set<string>();
+	for (const result of results) {
 		for (const row of result.results ?? []) out.add(`${row.comment_id}|${row.kind}`);
 	}
 	return out;
@@ -3816,17 +3822,21 @@ export const getUserVotesOnComments = async (
 	comment_ids: readonly string[],
 	user_id: string,
 ): Promise<Map<string, -1 | 1>> => {
-	const out = new Map<string, -1 | 1>();
-	for (const batch of chunk(comment_ids, IN_BATCH)) {
+	const chunks = chunk(comment_ids, IN_BATCH);
+	if (chunks.length === 0) return new Map<string, -1 | 1>();
+	const stmts = chunks.map((batch) => {
 		const placeholders = batch.map(() => "?").join(",");
-		const result = await db
+		return db
 			.prepare(
 				`SELECT v.comment_id, v.value
 				   FROM votes v
 				  WHERE v.comment_id IN (${placeholders}) AND v.user_id = ?`,
 			)
-			.bind(...batch, user_id)
-			.all<{ comment_id: string; value: number }>();
+			.bind(...batch, user_id);
+	});
+	const results = await db.batch<{ comment_id: string; value: number }>(stmts);
+	const out = new Map<string, -1 | 1>();
+	for (const result of results) {
 		for (const r of result.results ?? []) {
 			if (r.value === 1 || r.value === -1) out.set(r.comment_id, r.value);
 		}

--- a/src/routes/api.comments.ts
+++ b/src/routes/api.comments.ts
@@ -29,14 +29,14 @@ import {
 	getComment,
 	getPost,
 	getUser,
-	getUserVotesOnPost,
+	getUserVotesOnComments,
 	insertComment,
 	isUserRole,
 	listActiveSubscriptionsForPost,
 	listCommentsForThreads,
-	listReactionsForPost,
+	listReactionsForComments,
 	listThreadRefsForPost,
-	listUserReactionsOnPost,
+	listUserReactionsOnComments,
 	softDeleteComment,
 	TREE_ROW_LIMIT,
 	updateCommentBody,
@@ -1075,9 +1075,13 @@ export const buildTreePage = async (
 	}
 	const authors = await loadAuthors(env.DB, rows);
 
-	const reactionRows = await listReactionsForPost(env.DB, slug);
+	// Engagement is loaded for the comments on this page only. `rows` is every
+	// comment listCommentsForThreads returned for the page's threads (top-level
+	// and replies), so ids here are exactly what buildTree will render.
+	const pageIds = rows.map((r) => r.id);
+	const reactionRows = await listReactionsForComments(env.DB, pageIds);
 	const mineSet = session
-		? await listUserReactionsOnPost(env.DB, slug, session.user_id)
+		? await listUserReactionsOnComments(env.DB, pageIds, session.user_id)
 		: new Set<string>();
 	const reactionsById = new Map<string, ReactionCount[]>();
 	for (const r of reactionRows) {
@@ -1091,7 +1095,7 @@ export const buildTreePage = async (
 	}
 
 	const myVotes = session
-		? await getUserVotesOnPost(env.DB, slug, session.user_id)
+		? await getUserVotesOnComments(env.DB, pageIds, session.user_id)
 		: new Map<string, -1 | 1>();
 
 	// When the operator opts in, keep every deleted comment as a placeholder

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -61,6 +61,9 @@ const makeD1 = (db: DatabaseSync): any => ({
 			},
 		};
 	},
+	async batch(stmts: { all: () => Promise<{ results: unknown[] }> }[]) {
+		return Promise.all(stmts.map((s) => s.all()));
+	},
 });
 
 const SID = "a".repeat(64);

--- a/tests/comments-pagination.test.ts
+++ b/tests/comments-pagination.test.ts
@@ -33,6 +33,11 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { comments } from "../src/routes/api.comments";
+import {
+	getUserVotesOnComments,
+	listReactionsForComments,
+	listUserReactionsOnComments,
+} from "../src/db/queries";
 import { treeCacheKey } from "../src/lib/tree-cache";
 import {
 	installMockCaches,
@@ -189,6 +194,12 @@ const seedReplies = (threadCount: number, perThread: number) => {
 	}
 };
 
+const seedReaction = (commentId: string, userId: string, kind = "heart") => {
+	sqlite
+		.prepare("INSERT INTO reactions (comment_id, user_id, kind, created_at) VALUES (?, ?, ?, 1)")
+		.run(commentId, userId, kind);
+};
+
 const setSetting = (key: string, value: string) => {
 	sqlite
 		.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)")
@@ -208,6 +219,8 @@ type ListResp = {
 		id: string;
 		score_up: number;
 		score_down: number;
+		reactions: { kind: string; count: number; mine: boolean }[];
+		my_vote: -1 | 0 | 1;
 		replies: unknown[];
 	}[];
 	next_cursor: string | null;
@@ -652,5 +665,82 @@ describe("GET /comments — edge-cache hit/bypass", () => {
 				treeCacheKey(REQ_URL, SLUG, "top", 2, `8:${mkUlid(9)}`).url,
 			),
 		).toBe(true);
+	});
+});
+
+describe("engagement queries are scoped to the page", () => {
+	const reactionsQueries = () =>
+		queries.filter((q) => /FROM reactions r/.test(q.sql) && /IN \(/.test(q.sql));
+
+	it("loads reactions only for the comments on the page", async () => {
+		// Page size comes from the `comments_per_page` setting (there is no
+		// query param). With 2 per page, new-sort page 1 = threads 4,3; page 2 = 2,1.
+		seedThreads(4);
+		seedReaction(mkUlid(4), USER, "heart");
+		seedReaction(mkUlid(1), USER, "heart");
+		seedReaction(mkUlid(2), USER, "laugh");
+		setSetting("comments_per_page", "2");
+		const env = mkEnv();
+		queries.length = 0;
+		const page = await get(env, `slug=${SLUG}&sort=new`);
+
+		expect(page.threads.map((t) => t.id)).toEqual([mkUlid(4), mkUlid(3)]);
+		expect(page.threads[0]?.reactions).toEqual([{ kind: "heart", count: 1, mine: false }]);
+		expect(page.threads[1]?.reactions).toEqual([]);
+
+		const rq = reactionsQueries();
+		expect(rq.length).toBe(1);
+		// Binds are exactly the page's comment ids; nothing from page 2.
+		expect([...rq[0]!.binds].sort()).toEqual([mkUlid(3), mkUlid(4)].sort());
+		// `Recorded.rows` is the row COUNT the stub saw. Only thread 4's heart
+		// matches the page ids, so exactly one row comes back.
+		expect(rq[0]!.rows).toBe(1);
+	});
+
+	it("includes replies on the page in the id set", async () => {
+		seedThreads(1);
+		seedReplies(1, 1); // one reply under thread 1, id mkUlid(100_000)
+		const replyId = mkUlid(100_000);
+		seedReaction(replyId, USER, "heart");
+		const env = mkEnv();
+		queries.length = 0;
+		await get(env, `slug=${SLUG}&sort=new`);
+		const rq = reactionsQueries();
+		expect(rq.length).toBe(1);
+		expect(rq[0]!.binds).toContain(replyId);
+	});
+
+	it("issues no engagement query for an empty page", async () => {
+		const env = mkEnv();
+		queries.length = 0;
+		const page = await get(env, `slug=${SLUG}&sort=new`);
+		expect(page.threads).toEqual([]);
+		expect(reactionsQueries().length).toBe(0);
+	});
+});
+
+describe("engagement query batching", () => {
+	const ids = Array.from({ length: 200 }, (_, i) => mkUlid(i + 1));
+
+	it("splits 200 ids into batches of 90, 90, 20 for all three queries", async () => {
+		seedThreads(0);
+		const env = mkEnv();
+		queries.length = 0;
+		const db = env.DB;
+		await listReactionsForComments(db, ids);
+		await listUserReactionsOnComments(db, ids, USER);
+		await getUserVotesOnComments(db, ids, USER);
+		const sizes = queries.map((q) => q.binds.length);
+		// reactions: ids only; user reactions and votes: ids + user_id
+		expect(sizes).toEqual([90, 90, 20, 91, 91, 21, 91, 91, 21]);
+	});
+
+	it("returns empty results and runs no query for an empty id list", async () => {
+		const env = mkEnv();
+		queries.length = 0;
+		expect(await listReactionsForComments(env.DB, [])).toEqual([]);
+		expect(await listUserReactionsOnComments(env.DB, [], USER)).toEqual(new Set());
+		expect(await getUserVotesOnComments(env.DB, [], USER)).toEqual(new Map());
+		expect(queries.length).toBe(0);
 	});
 });

--- a/tests/comments-pagination.test.ts
+++ b/tests/comments-pagination.test.ts
@@ -98,6 +98,12 @@ const makeD1 = (db: DatabaseSync): any => ({
 			},
 		};
 	},
+	// D1's real `batch` issues every statement over one round trip; this stub
+	// only needs to preserve per-statement recording so the pagination/batching
+	// assertions above still see one `queries` entry per chunk.
+	async batch(stmts: { all: () => Promise<{ results: unknown[] }> }[]) {
+		return Promise.all(stmts.map((s) => s.all()));
+	},
 });
 
 const makeKv = () => {

--- a/tests/comments-pending.test.ts
+++ b/tests/comments-pending.test.ts
@@ -123,7 +123,12 @@ const makeDb = (approved: Row[], pending: Row[]) => {
 			},
 		};
 	};
-	return { prepare: (sql: string) => chain(sql) };
+	return {
+		prepare: (sql: string) => chain(sql),
+		async batch(stmts: { all: () => Promise<{ results: unknown[] }> }[]) {
+			return Promise.all(stmts.map((s) => s.all()));
+		},
+	};
 };
 
 const makeKv = () => {

--- a/tests/comments-tree-cache-session.test.ts
+++ b/tests/comments-tree-cache-session.test.ts
@@ -51,6 +51,9 @@ const makeD1 = (db: DatabaseSync): any => ({
 			},
 		};
 	},
+	async batch(stmts: { all: () => Promise<{ results: unknown[] }> }[]) {
+		return Promise.all(stmts.map((s) => s.all()));
+	},
 });
 
 const SID = "a".repeat(64);

--- a/tests/thread-closure-api.test.ts
+++ b/tests/thread-closure-api.test.ts
@@ -48,6 +48,9 @@ const makeD1 = (db: DatabaseSync): any => ({
 			},
 		};
 	},
+	async batch(stmts: { all: () => Promise<{ results: unknown[] }> }[]) {
+		return Promise.all(stmts.map((s) => s.all()));
+	},
 });
 
 const SID = "a".repeat(64);

--- a/tests/widget-boot.test.ts
+++ b/tests/widget-boot.test.ts
@@ -355,6 +355,9 @@ const makeD1 = (db: DatabaseSync): any => ({
 			},
 		};
 	},
+	async batch(stmts: { all: () => Promise<{ results: unknown[] }> }[]) {
+		return Promise.all(stmts.map((s) => s.all()));
+	},
 });
 
 describe("fetchBootstrap — against the real handler", () => {


### PR DESCRIPTION
## Summary
- `listReactionsForComments`, `listUserReactionsOnComments`, `getUserVotesOnComments` replace the three whole-slug queries; each batches `IN (...)` lists of 90 ids.
- `buildTreePage` passes the ids of the comments it will render. Response shape unchanged.

## Test plan
- [x] route-level real-SQLite test: page 1 carries only page-1 reactions, the recorded query binds only page-1 ids, replies included, empty page issues no query
- [x] batching unit test (200 ids → 90/90/20)
- [x] lint, typecheck, test, manifest:check, build, size
