### PR TITLE
chore(release): 2.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garrul",
-  "version": "2.26.1",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garrul",
-      "version": "2.26.1",
+      "version": "2.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "hono": "^4.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garrul",
-  "version": "2.26.1",
+  "version": "2.27.0",
   "private": true,
   "description": "Self-hosted comment system on Cloudflare Workers + D1 + KV",
   "license": "Apache-2.0",

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.26.1",
+  "version": "2.27.0",
   "minPreviousVersion": "1.0.0",
   "renderer": {
     "version": 3,


### PR DESCRIPTION
Version bump and manifest for 2.27.0. Notes are in the tag and GitHub release.